### PR TITLE
fix: matcher Github sin policy for navn

### DIFF
--- a/src/routes/team/[team]/(teamPages)/repositories/+page.svelte
+++ b/src/routes/team/[team]/(teamPages)/repositories/+page.svelte
@@ -64,7 +64,7 @@
 						size="small"
 						variant="secondary"
 						on:click={() => {
-							if (!repoName.match(/^[a-z0-9-]+\/[a-z0-9-]+$/i)) {
+							if (!repoName.match(/^[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+$/i)) {
 								inputError = true;
 								return;
 							}


### PR DESCRIPTION
 The repository name can only contain ASCII letters, digits, and the characters ., -, and _.