### PR TITLE
introduce typed eslint with deprecation warning

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url));
 export default ts.config(
 	includeIgnoreFile(gitignorePath),
 	js.configs.recommended,
-	...ts.configs.recommended,
+	...ts.configs.recommendedTypeChecked,
 	...svelte.configs['flat/recommended'],
 	prettier,
 	...svelte.configs['flat/prettier'],
@@ -19,6 +19,13 @@ export default ts.config(
 			globals: {
 				...globals.browser,
 				...globals.node
+			},
+			parserOptions: {
+				projectService: {
+					allowDefaultProject: ['.storybook/*.ts']
+				},
+				tsconfigRootDir: import.meta.dirname,
+				extraFileExtensions: ['.svelte']
 			}
 		}
 	},
@@ -32,6 +39,12 @@ export default ts.config(
 					experimentalGenerics: true
 				}
 			}
+		},
+		rules: {
+			'@typescript-eslint/no-floating-promises': 'off',
+			'@typescript-eslint/no-unsafe-assignment': 'off',
+			'@typescript-eslint/no-unsafe-call': 'off',
+			'@typescript-eslint/no-deprecated': 'error'
 		}
 	},
 	{
@@ -40,5 +53,12 @@ export default ts.config(
 			'svelte/valid-each-key': 'error'
 			/*'svelte/no-unused-class-name': 'error'*/
 		}
+	},
+	{
+		files: ['**/*.js'],
+		...ts.configs.disableTypeChecked
+	},
+	{
+		ignores: ['build/', '.svelte-kit/', 'dist/', '.yarn/', 'node_modules/']
 	}
 );


### PR DESCRIPTION
Dette er et forslag. 

Den fører til at `npm run lint` er en god del tregere, men finner visse ting som kanskje er nødvendig. 

Målet mitt var å fremheve bruk av deprecated ting fra api, som f.eks. 
![image](https://github.com/user-attachments/assets/8b6f9460-7f33-4839-a238-5f59401b4b4a)

Men den finner ganske mange flere feil også