### PR TITLE
Better information about valkey when deleting workload

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2269,6 +2269,7 @@ type OpenSearch implements Node & Persistence {
   status: OpenSearchStatus!
   team: Team!
   teamEnvironment: TeamEnvironment!
+  terminationProtection: Boolean!
   workload: Workload
 }
 
@@ -5889,6 +5890,7 @@ type ValkeyInstance implements Node & Persistence {
   status: ValkeyInstanceStatus!
   team: Team!
   teamEnvironment: TeamEnvironment!
+  terminationProtection: Boolean!
   workload: Workload
 }
 

--- a/src/routes/team/[team]/[env]/app/[app]/delete/+page.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/delete/+page.gql
@@ -41,6 +41,7 @@ query DeleteAppPage($app: String!, $team: Slug!, $env: String!) @cache(policy: N
 						id
 						__typename
 						name
+						terminationProtection
 					}
 				}
 				sqlInstances {
@@ -50,11 +51,6 @@ query DeleteAppPage($app: String!, $team: Slug!, $env: String!) @cache(policy: N
 						name
 						cascadingDelete
 					}
-				}
-				openSearch {
-					id
-					__typename
-					name
 				}
 			}
 		}

--- a/src/routes/team/[team]/[env]/app/[app]/delete/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/delete/+page.svelte
@@ -46,7 +46,7 @@
 			app.bigQueryDatasets.nodes.filter((s) => s.cascadingDelete).length > 0 ||
 			app.buckets.nodes.filter((s) => s.cascadingDelete).length > 0 ||
 			app.redisInstances.nodes.length > 0 ||
-			app.valkeyInstances.nodes.length > 0
+			app.valkeyInstances.nodes.filter((s) => !s.terminationProtection).length > 0
 		);
 	}
 
@@ -54,7 +54,8 @@
 		return (
 			app.sqlInstances.nodes.filter((s) => !s.cascadingDelete).length > 0 ||
 			app.bigQueryDatasets.nodes.filter((s) => !s.cascadingDelete).length > 0 ||
-			app.buckets.nodes.filter((s) => !s.cascadingDelete).length > 0
+			app.buckets.nodes.filter((s) => !s.cascadingDelete).length > 0 ||
+			app.valkeyInstances.nodes.filter((s) => s.terminationProtection).length > 0
 		);
 	}
 </script>
@@ -105,7 +106,7 @@
 						by the app, it will be permanently deleted.
 					</PersistenceList>
 				{/each}
-				{#each app.valkeyInstances.nodes as node (node.id)}
+				{#each app.valkeyInstances.nodes.filter((s) => !s.terminationProtection) as node (node.id)}
 					<PersistenceList persistence={node}
 						>If this Valkey instance is defined on team level, it won't be deleted. If it's created
 						by the app, it will be permanently deleted.
@@ -132,6 +133,9 @@
 						<PersistenceList persistence={node} />
 					{/each}
 					{#each app.buckets.nodes.filter((s) => !s.cascadingDelete) as node (node.id)}
+						<PersistenceList persistence={node} />
+					{/each}
+					{#each app.valkeyInstances.nodes.filter((s) => s.terminationProtection) as node (node.id)}
 						<PersistenceList persistence={node} />
 					{/each}
 				</div>

--- a/src/routes/team/[team]/[env]/job/[job]/delete/+page.gql
+++ b/src/routes/team/[team]/[env]/job/[job]/delete/+page.gql
@@ -44,6 +44,7 @@ query DeleteJobPage($job: String!, $team: Slug!, $env: String!) @cache(policy: N
 						id
 						__typename
 						name
+						terminationProtection
 					}
 				}
 				sqlInstances {
@@ -53,11 +54,6 @@ query DeleteJobPage($job: String!, $team: Slug!, $env: String!) @cache(policy: N
 						name
 						cascadingDelete
 					}
-				}
-				openSearch {
-					id
-					__typename
-					name
 				}
 			}
 		}

--- a/src/routes/team/[team]/[env]/job/[job]/delete/+page.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/delete/+page.svelte
@@ -54,7 +54,7 @@
 			app.bigQueryDatasets.nodes.filter((s) => s.cascadingDelete).length > 0 ||
 			app.buckets.nodes.filter((s) => s.cascadingDelete).length > 0 ||
 			app.redisInstances.nodes.length > 0 ||
-			app.valkeyInstances.nodes.length > 0
+			app.valkeyInstances.nodes.filter((s) => !s.terminationProtection).length > 0
 		);
 	}
 
@@ -62,7 +62,8 @@
 		return (
 			app.sqlInstances.nodes.filter((s) => !s.cascadingDelete).length > 0 ||
 			app.bigQueryDatasets.nodes.filter((s) => !s.cascadingDelete).length > 0 ||
-			app.buckets.nodes.filter((s) => !s.cascadingDelete).length > 0
+			app.buckets.nodes.filter((s) => !s.cascadingDelete).length > 0 ||
+			app.valkeyInstances.nodes.filter((s) => s.terminationProtection).length > 0
 		);
 	}
 </script>
@@ -110,7 +111,7 @@
 						by the app, it will be permanently deleted.
 					</PersistenceList>
 				{/each}
-				{#each job.valkeyInstances.nodes as node (node.id)}
+				{#each job.valkeyInstances.nodes.filter((s) => !s.terminationProtection) as node (node.id)}
 					<PersistenceList persistence={node}
 						>If this Valkey instance is defined on team level, it won't be deleted. If it's created
 						by the app, it will be permanently deleted.
@@ -137,6 +138,9 @@
 						<PersistenceList persistence={node} />
 					{/each}
 					{#each job.buckets.nodes.filter((s) => !s.cascadingDelete) as node (node.id)}
+						<PersistenceList persistence={node} />
+					{/each}
+					{#each job.valkeyInstances.nodes.filter((s) => s.terminationProtection) as node (node.id)}
 						<PersistenceList persistence={node} />
 					{/each}
 				</div>


### PR DESCRIPTION
Also, remove opensearch from graphql query, since it's always a team resource, and wasn't used.