### PR TITLE
Reduce query complexity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -5467,6 +5467,9 @@ input TeamVulnerabilitySummaryFilter {
 input TeamWorkloadsFilter {
   """Only return workloads from the given named environments."""
   environments: [String!]
+
+  """Filter workloads with given workload states."""
+  states: [WorkloadState!]
 }
 
 """

--- a/src/lib/components/VulnerabilityOverview.svelte
+++ b/src/lib/components/VulnerabilityOverview.svelte
@@ -29,7 +29,11 @@
 						riskScoreTrend
 						unassigned
 					}
-					workloads(first: 999) {
+					workloads(
+						first: 50
+						filter: { states: [NOT_NAIS, FAILING] }
+						orderBy: { field: STATUS, direction: DESC }
+					) {
 						pageInfo {
 							totalCount
 						}

--- a/src/lib/components/list/Badge.svelte
+++ b/src/lib/components/list/Badge.svelte
@@ -17,15 +17,20 @@
 
 	export type BadgeProps = {
 		count: number;
+		max?: number;
 		level: WorkloadStatusErrorLevel$options;
 	};
 
-	const { count, level }: BadgeProps = $props();
+	const { count, level, max }: BadgeProps = $props();
 </script>
 
 {#if count}
 	<div class={['badge', `badge--${level}`, { 'badge--long': `${count}`.length > 2 }]}>
-		{count}
+		{#if max && count > max}
+			{max}+
+		{:else}
+			{count}
+		{/if}
 	</div>
 {/if}
 

--- a/src/routes/+page.gql
+++ b/src/routes/+page.gql
@@ -17,7 +17,7 @@ query UserTeams @cache(policy: CacheAndNetwork) {
 						id
 						slug
 						purpose
-						workloads(first: 999) {
+						workloads(first: 10, filter: { states: [NOT_NAIS, FAILING] }) {
 							nodes {
 								status {
 									errors {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -54,6 +54,7 @@
 								team={node.team}
 								badge={{
 									count: errors.length,
+									max: 9,
 									level: badgeLevel(errors)
 								}}
 							/>

--- a/src/routes/team/[team]/+page.gql
+++ b/src/routes/team/[team]/+page.gql
@@ -86,6 +86,5 @@ query TeamOverview($team: Slug!) @cache(policy: NetworkOnly) {
 			riskScoreTrend
 			ranking
 		}
-		...VulnerabilityOverviewFragment
 	}
 }

--- a/src/routes/team/[team]/+page.gql
+++ b/src/routes/team/[team]/+page.gql
@@ -30,7 +30,11 @@ query TeamOverview($team: Slug!) @cache(policy: NetworkOnly) {
 			}
 		}
 
-		workloads(first: 999) {
+		workloads(
+			first: 50
+			filter: { states: [NOT_NAIS, FAILING] }
+			orderBy: { field: STATUS, direction: DESC }
+		) {
 			pageInfo {
 				totalCount
 			}


### PR DESCRIPTION
When fetching Workloads, we can no filter on states. So in these cases we do not need workloads that's `NAIS`.

Also change the badge in the team list on the frontpage to show `9+` if there's 10 or more errors for the team.