### PR TITLE
Make pagination default in secrets

### DIFF
--- a/src/routes/team/[team]/secrets/+page.ts
+++ b/src/routes/team/[team]/secrets/+page.ts
@@ -1,7 +1,6 @@
 import { load_Secrets, OrderDirection, SecretOrderField, type SecretFilter } from '$houdini';
 import { urlToOrderDirection, urlToOrderField } from '$lib/components/OrderByMenu.svelte';
 
-const rows = 25;
 export async function load(event) {
 	const filter = event.url.searchParams.get('filter') || '';
 
@@ -12,7 +11,6 @@ export async function load(event) {
 	}
 
 	const after = event.url.searchParams.get('after') || '';
-	const before = event.url.searchParams.get('before') || '';
 
 	return {
 		...(await load_Secrets({
@@ -23,7 +21,7 @@ export async function load(event) {
 					field: urlToOrderField(SecretOrderField, SecretOrderField.NAME, event.url),
 					direction: urlToOrderDirection(event.url, OrderDirection.ASC)
 				},
-				...(before ? { before, last: rows } : { after, first: rows }),
+				after,
 				filter: filterVar
 			}
 		}))

--- a/src/routes/team/[team]/secrets/query.gql
+++ b/src/routes/team/[team]/secrets/query.gql
@@ -1,21 +1,8 @@
-query Secrets(
-	$team: Slug!
-	$orderBy: SecretOrder
-	$filter: SecretFilter
-	$first: Int
-	$last: Int
-	$before: Cursor
-	$after: Cursor
-) @cache(policy: CacheAndNetwork) {
+query Secrets($team: Slug!, $orderBy: SecretOrder, $filter: SecretFilter, $after: Cursor)
+@cache(policy: CacheAndNetwork) {
 	team(slug: $team) {
-		secrets(
-			first: $first
-			last: $last
-			before: $before
-			after: $after
-			orderBy: $orderBy
-			filter: $filter
-		) @paginate(mode: SinglePage) {
+		secrets(first: 25, after: $after, orderBy: $orderBy, filter: $filter)
+			@paginate(mode: SinglePage) {
 			pageInfo {
 				totalCount
 				hasPreviousPage


### PR DESCRIPTION
When not having a default `first`, we have to pass some arguments to load next. Since it doesn't seem to ever use `before`, I removed it.