### PR TITLE
refactor: streamline Affected Workloads section and improve error han…

### DIFF
--- a/src/routes/vulnerabilities/[cve]/+page.svelte
+++ b/src/routes/vulnerabilities/[cve]/+page.svelte
@@ -130,7 +130,7 @@
 		{:else if hasOtherErrors($CVEDetails.errors)}
 			<GraphErrors errors={$CVEDetails.errors} />
 		{/if}
-		{#if !isNotFoundError($CVEDetails.errors)}
+		{#if !isNotFoundError($CVEWorkloads.errors)}
 			<Heading level="2" size="small">
 				Affected Workloads
 				{#if $CVEWorkloads.data?.cve.workloads.pageInfo.totalCount ?? 0 > 0}


### PR DESCRIPTION
This pull request makes a small update to the `src/routes/vulnerabilities/[cve]/+page.svelte` file, refining how the "Vulnerability not found" message is displayed. The changes remove the explicit warning alert for missing vulnerabilities and adjust the conditional logic for rendering affected workloads and errors. This results in a cleaner UI and more consistent error handling.