### PR TITLE
refactor: update chromium detection to be specific for Mac users

### DIFF
--- a/src/routes/Login.svelte
+++ b/src/routes/Login.svelte
@@ -10,7 +10,9 @@
 
 	let { userAgent }: { userAgent: string } = $props();
 
-	let chromiumBased: boolean = $derived(userAgent.indexOf('Chrome/') > 0);
+	let chromiumBasedOnMac: boolean = $derived(
+		userAgent.indexOf('Chrome/') > 0 && userAgent.indexOf('Mac') > -1
+	);
 </script>
 
 <svelte:head>
@@ -67,7 +69,7 @@
 			Log in to Nais Console
 		</Button>
 
-		{#if isNaisdevice() && chromiumBased}
+		{#if isNaisdevice() && chromiumBasedOnMac}
 			<p class="help">
 				If anything Chrome-related tried to open a page before logging into naisdevice, your browser
 				will not notice that naisdevice is now connected until you have deleted the open sockets.


### PR DESCRIPTION
This pull request updates the browser detection logic on the login page to more accurately target Chrome users on macOS. Instead of detecting all Chromium-based browsers, the code now specifically checks for Chrome running on a Mac, ensuring that the user guidance is only shown to the relevant audience.

Browser detection improvements:

* Changed the `chromiumBased` variable to `chromiumBasedOnMac` in `Login.svelte`, so the login page now only considers Chrome on macOS when displaying certain help messages.
* Updated the conditional rendering logic to use `chromiumBasedOnMac` instead of the previous, broader check.