### PR TITLE
chore: change Dependabot update interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 14
     groups:
@@ -19,13 +19,13 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 14
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 14


### PR DESCRIPTION
This pull request updates the Dependabot configuration to reduce the frequency of automated update checks for npm, GitHub Actions, and Docker dependencies from weekly to monthly. This change will decrease the number of update PRs generated, reducing maintenance overhead.

Dependabot schedule changes:

* Changed the update interval for the `npm` package ecosystem from weekly to monthly in `.github/dependabot.yml`.
* Changed the update interval for both `github-actions` and `docker` package ecosystems from weekly to monthly in `.github/dependabot.yml`.