### PR TITLE
feat: viser alle deployments for tenant

### DIFF
--- a/src/lib/domain/list-items/DeploymentListItem.svelte
+++ b/src/lib/domain/list-items/DeploymentListItem.svelte
@@ -7,10 +7,13 @@
 	import { BodyLong, Tag } from '@nais/ds-svelte-community';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import ListItem from '$lib/ui/ListItem.svelte';
+	import { PersonGroupIcon } from '@nais/ds-svelte-community/icons';
+	import IconLabel from '$lib/ui/IconLabel.svelte';
 
 	const {
 		deployment,
-		showEnv
+		showEnv,
+		showTeam
 	}: {
 		deployment: {
 			id: string;
@@ -37,11 +40,21 @@
 			triggerUrl: string | null;
 		};
 		showEnv?: boolean;
+		showTeam?: boolean;
 	} = $props();
 </script>
 
 <ListItem>
-	<div>
+	<div class="grid">
+		{#if showTeam}
+			<IconLabel
+				label={deployment.teamSlug}
+				icon={PersonGroupIcon}
+				size="large"
+				level="3"
+				href="/team/{deployment.teamSlug}/deployments"
+			/>
+		{/if}
 		<BodyLong size="small" as="div">
 			{#if deployment.commitSha && isValidSha(deployment.commitSha) && deployment.deployerUsername}
 				Commit
@@ -133,5 +146,10 @@
 		justify-content: center;
 		gap: var(--ax-space-4);
 		font-size: 16px;
+	}
+
+	.grid {
+		display: grid;
+		grid-template-columns: 50ch auto;
 	}
 </style>

--- a/src/routes/deployments/+page.svelte
+++ b/src/routes/deployments/+page.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import GraphErrors from '$lib/ui/GraphErrors.svelte';
+	import { Heading } from '@nais/ds-svelte-community';
+	import type { PageProps } from './$types';
+	import Pagination from '$lib/ui/Pagination.svelte';
+	import { changeParams } from '$lib/utils/searchparams';
+	import { format } from 'date-fns';
+	import DeploymentListItem from '$lib/domain/list-items/DeploymentListItem.svelte';
+	import List from '$lib/ui/List.svelte';
+
+	const changeQuery = (
+		params: {
+			after?: string;
+			before?: string;
+		} = {}
+	) => {
+		changeParams({
+			before: params.before ?? before,
+			after: params.after ?? after
+		});
+	};
+
+	let { data }: PageProps = $props();
+	let { TenantDeployments } = $derived(data);
+	let after: string = $derived($TenantDeployments.variables?.after ?? '');
+	let before: string = $derived($TenantDeployments.variables?.before ?? '');
+</script>
+
+<div class="page">
+	<div class="container">
+		<GraphErrors errors={$TenantDeployments.errors} />
+		{#if $TenantDeployments.data}
+			<div>
+				<Heading level="2" spacing>Deployments</Heading>
+
+				{#if $TenantDeployments.data?.deployments.pageInfo.totalCount > 0}
+					<List
+						title="{$TenantDeployments.data.deployments.pageInfo
+							.totalCount} deployment{$TenantDeployments.data.deployments.pageInfo.totalCount !== 1
+							? 's'
+							: ''} - showing {$TenantDeployments.data.deployments.pageInfo.pageEnd -
+							$TenantDeployments.data.deployments.pageInfo.pageStart +
+							1} from {format(
+							$TenantDeployments.data.deployments.nodes.at(0)?.createdAt ?? '',
+							'dd/MM/yyyy'
+						)} to {format(
+							$TenantDeployments.data.deployments.nodes.at(-1)?.createdAt ?? '',
+							'dd/MM/yyyy'
+						)}"
+					>
+						{#each $TenantDeployments.data.deployments.nodes as deployment (deployment.id)}
+							<div><DeploymentListItem {deployment} showEnv showTeam /></div>
+						{/each}
+					</List>
+				{/if}
+
+				<Pagination
+					page={$TenantDeployments.data.deployments.pageInfo}
+					loaders={{
+						loadPreviousPage: () => {
+							changeQuery({
+								after: '',
+								before: $TenantDeployments.data?.deployments.pageInfo.startCursor ?? ''
+							});
+						},
+						loadNextPage: () => {
+							changeQuery({
+								before: '',
+								after: $TenantDeployments.data?.deployments.pageInfo.endCursor ?? ''
+							});
+						}
+					}}
+				/>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.container {
+		margin-top: var(--spacing-layout);
+		display: flex;
+		flex-direction: column;
+		gap: var(--spacing-layout);
+	}
+</style>

--- a/src/routes/deployments/+page.ts
+++ b/src/routes/deployments/+page.ts
@@ -1,0 +1,20 @@
+import { load_TenantDeployments } from '$houdini';
+import { addPageMeta } from '$lib/utils/pageMeta';
+
+const rows = 25;
+
+export async function load(event) {
+	const after = event.url.searchParams.get('after') || '';
+	const before = event.url.searchParams.get('before') || '';
+	return {
+		...(await addPageMeta(event, {
+			title: 'Tenant Deployments'
+		})),
+		...(await load_TenantDeployments({
+			event,
+			variables: {
+				...(before ? { before, last: rows } : { after, first: rows })
+			}
+		}))
+	};
+}

--- a/src/routes/deployments/query.gql
+++ b/src/routes/deployments/query.gql
@@ -1,0 +1,38 @@
+query TenantDeployments($first: Int, $last: Int, $before: Cursor, $after: Cursor) {
+	deployments(first: $first, last: $last, before: $before, after: $after)
+		@paginate(mode: SinglePage) {
+		pageInfo {
+			hasNextPage
+			endCursor
+			hasPreviousPage
+			pageEnd
+			pageStart
+			startCursor
+			totalCount
+		}
+		nodes {
+			id
+			statuses {
+				nodes {
+					state
+					message
+					createdAt
+				}
+			}
+			resources {
+				nodes {
+					id
+					kind
+					name
+				}
+			}
+			environmentName
+			createdAt
+			teamSlug
+			repository
+			commitSha
+			deployerUsername
+			triggerUrl
+		}
+	}
+}


### PR DESCRIPTION
This pull request implements a new paginated deployments list page at `/deployments`, including backend data loading, query, and UI improvements. The main changes introduce a paginated query for deployments, a new page to display them, and updates to the `DeploymentListItem` component to optionally show the team associated with each deployment.

**Deployments Page Implementation:**

- Added a new paginated deployments list page at `/deployments`, including a Svelte page (`+page.svelte`), a page loader (`+page.ts`), and a GraphQL query (`query.gql`). The page displays deployment information with pagination controls and error handling. [[1]](diffhunk://#diff-00419a89c2506cba3a9afab07b01c61ebd7e9c6ace9538651f3b008dea865d81R1-R86) [[2]](diffhunk://#diff-55cb9be05383097c0b26db5a7348e45dc1c0adab17d700f3c4a3231e89b43de8R1-R20) [[3]](diffhunk://#diff-cc45fd80440cbe0e4c31827ede4383d98c0efc7866406323e4fd1fc61dc81a46R1-R38)

**Deployment List Item Enhancements:**

- Updated `DeploymentListItem.svelte` to support an optional `showTeam` prop, displaying the team slug with an icon and link when enabled. Also added grid layout styles to accommodate the new team label. [[1]](diffhunk://#diff-70150cafd686d89c654078c6f56618cd28662e7654f502f97a1aa4955d70a3f9R10-R16) [[2]](diffhunk://#diff-70150cafd686d89c654078c6f56618cd28662e7654f502f97a1aa4955d70a3f9R43-R57) [[3]](diffhunk://#diff-70150cafd686d89c654078c6f56618cd28662e7654f502f97a1aa4955d70a3f9R150-R154)