### PR TITLE
feat: add environment filtering to deployments

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1661,6 +1661,9 @@ type DeploymentEdge {
 }
 
 input DeploymentFilter {
+  """Filter deployments by environments."""
+  environments: [String!]
+
   """Get deployments from a given date until today."""
   from: Time
 }

--- a/src/routes/deployments/metadata.gql
+++ b/src/routes/deployments/metadata.gql
@@ -1,0 +1,8 @@
+query DeploymentsMetadata @cache(policy: CacheAndNetwork) {
+	environments {
+		nodes {
+			id
+			name
+		}
+	}
+}


### PR DESCRIPTION
This pull request adds environment-based filtering to the deployments page, allowing users to filter deployments by environment through both the UI and query parameters. It also introduces new metadata fetching for environments and updates the GraphQL schema and queries to support this functionality.

**Environment Filtering and Metadata Integration:**

* Added an `environments` filter to the `DeploymentFilter` input in the GraphQL schema, enabling backend support for filtering deployments by environment.
* Created a new `DeploymentsMetadata` GraphQL query to fetch available environments, which is now loaded on the deployments page. [[1]](diffhunk://#diff-6fb318fb900b04b2352c1c0d5ddc1b719180bacae21667d72c89ba5728ef5174R1-R8) [[2]](diffhunk://#diff-55cb9be05383097c0b26db5a7348e45dc1c0adab17d700f3c4a3231e89b43de8L1-R1) [[3]](diffhunk://#diff-55cb9be05383097c0b26db5a7348e45dc1c0adab17d700f3c4a3231e89b43de8L40-R52)

**UI Enhancements for Filtering:**

* Implemented an environment filter dropdown using `ActionMenu` and checkboxes in `+page.svelte`, allowing users to select one or multiple environments to filter deployments. [[1]](diffhunk://#diff-00419a89c2506cba3a9afab07b01c61ebd7e9c6ace9538651f3b008dea865d81L8-R10) [[2]](diffhunk://#diff-00419a89c2506cba3a9afab07b01c61ebd7e9c6ace9538651f3b008dea865d81R104-R141)
* Synchronized environment filter state with URL query parameters and ensured the deployments list updates accordingly. [[1]](diffhunk://#diff-00419a89c2506cba3a9afab07b01c61ebd7e9c6ace9538651f3b008dea865d81R21-R35) [[2]](diffhunk://#diff-00419a89c2506cba3a9afab07b01c61ebd7e9c6ace9538651f3b008dea865d81R44-R61)

**Backend and Query Parameter Handling:**

* Updated the page loader to parse the `environments` parameter from the URL, build the appropriate filter object, and pass it to the deployments query. [[1]](diffhunk://#diff-55cb9be05383097c0b26db5a7348e45dc1c0adab17d700f3c4a3231e89b43de8R32-R39) [[2]](diffhunk://#diff-55cb9be05383097c0b26db5a7348e45dc1c0adab17d700f3c4a3231e89b43de8L40-R52)