### PR TITLE
Prevent light theme flash during server rendering

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { afterNavigate, beforeNavigate } from '$app/navigation';
 	import { page } from '$app/state';
 	import { graphql } from '$houdini';
@@ -83,7 +84,7 @@
 	</title>
 </svelte:head>
 
-<Theme theme={themeSwitch.theme}>
+<Theme theme={browser ? themeSwitch.theme : data.theme}>
 	<Page contentBlockPadding="none">
 		<div class="full-wrapper">
 			{#if loading}


### PR DESCRIPTION
Because we're using $effect to set the correct value for the theme switcher, we get a flash of light theme if the user has chosen the dark theme, when the page is rendered on the server.

Now, when server rendered, we're using the value provided by the cookie (with fallback to "light"), instead of the default light theme.