### PR TITLE
fix: simplify CPU and memory usage percentage calculations

### DIFF
--- a/src/routes/team/[team]/[env]/app/[app]/Instances.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/Instances.svelte
@@ -22,13 +22,13 @@
 
 	const usage_cpu_percent = $derived(
 		app?.team.environment.application.utilization.requested_cpu
-			? (cpu_usage / app.team.environment.application.utilization.requested_cpu) * 100
+			? (cpu_usage / app?.team.environment.application.utilization.requested_cpu) * 100
 			: 0
 	);
 
 	const usage_memory_percent = $derived(
 		app?.team.environment.application.utilization.requested_memory
-			? (memory_usage / app.team.environment.application.utilization.requested_memory) * 100
+			? (memory_usage / app?.team.environment.application.utilization.requested_memory) * 100
 			: 0
 	);
 


### PR DESCRIPTION
This pull request simplifies how CPU and memory usage percentages are calculated in the `Instances.svelte` component by switching to a more direct utilization metric. Instead of multiplying per-instance resource requests, it now uses aggregate requested values, which makes the logic clearer and less error-prone.

Resource usage calculation improvements:

* Updated the CPU usage percentage calculation to use `application.utilization.requested_cpu` directly, replacing the previous logic that multiplied per-instance requests by the number of instances. ([src/routes/team/[team]/[env]/app/[app]/Instances.svelteL24-R31](diffhunk://#diff-a197e70997835d567983a74f572c9ff27a0345030517b0ca8adef96718d42058L24-R31))
* Updated the memory usage percentage calculation to use `application.utilization.requested_memory` directly, removing the need to multiply per-instance memory requests by the instance count. ([src/routes/team/[team]/[env]/app/[app]/Instances.svelteL24-R31](diffhunk://#diff-a197e70997835d567983a74f572c9ff27a0345030517b0ca8adef96718d42058L24-R31))