### PR TITLE
Add delete functionality for Unleash instances with confirmation dialog

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,9 @@
 			"source.organizeImports": "explicit"
 		}
 	},
-	"editor.insertSpaces": false
+	"editor.insertSpaces": false,
+	"chat.tools.terminal.autoApprove": {
+		"npm run generate": true,
+		"npx houdini": true
+	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,9 +33,5 @@
 			"source.organizeImports": "explicit"
 		}
 	},
-	"editor.insertSpaces": false,
-	"chat.tools.terminal.autoApprove": {
-		"npm run generate": true,
-		"npx houdini": true
-	}
+	"editor.insertSpaces": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,6 +209,7 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -2020,7 +2020,7 @@ input CreateServiceAccountTokenInput {
 
   """
   Optional expiry date of the token.
-  
+
   If not specified, the token will never expire.
   """
   expiresAt: Date
@@ -2035,11 +2035,11 @@ input CreateServiceAccountTokenInput {
 type CreateServiceAccountTokenPayload {
   """
   The secret of the service account token.
-  
+
   This value is only returned once, and can not be retrieved at a later stage. If the secret is lost, a new token must be created.
-  
+
   Once obtained, the secret can be used to authenticate as the service account using the HTTP `Authorization` request header:
-  
+
   ```
   Authorization: Bearer <secret>
   ```
@@ -2056,7 +2056,7 @@ type CreateServiceAccountTokenPayload {
 input CreateTeamInput {
   """
   The purpose / description of the team.
-  
+
   What is the team for? What is the team working on? This value is meant for human consumption, and should be enough
   to give a newcomer an idea of what the team is about.
   """
@@ -2064,14 +2064,14 @@ input CreateTeamInput {
 
   """
   The main Slack channel for the team.
-  
+
   Where does the team communicate? This value is used to link to the team's main Slack channel.
   """
   slackChannel: String!
 
   """
   Unique team slug.
-  
+
   After creation, this value can not be changed. Also, after a potential deletion of the team, the slug can not be
   reused, so please choose wisely.
   """
@@ -2388,6 +2388,16 @@ input DeleteValkeyInput {
 type DeleteValkeyPayload {
   """Whether or not the job was deleted."""
   valkeyDeleted: Boolean
+}
+
+input DeleteUnleashInstanceInput {
+  """The team that owns the Unleash instance to delete."""
+  teamSlug: Slug!
+}
+
+type DeleteUnleashInstancePayload {
+  """Whether or not the Unleash instance was deleted."""
+  unleashDeleted: Boolean
 }
 
 """Description of a deployment."""
@@ -4258,7 +4268,7 @@ input MetricsQueryInput {
   """
   Optional range query parameters.
   If provided, executes a range query instead of an instant query.
-  
+
   Limits to prevent excessive memory usage:
   - Minimum step: 10 seconds
   - Maximum time range: 30 days
@@ -4335,7 +4345,7 @@ type Mutation {
 
   """
   Add a team member
-  
+
   If the user is already a member or an owner of the team, the mutation will result in an error.
   """
   addTeamMember(input: AddTeamMemberInput!): AddTeamMemberPayload!
@@ -4360,12 +4370,12 @@ type Mutation {
 
   """
   Confirm a team deletion
-  
+
   This will start the actual team deletion process, which will be done in an asynchronous manner. All external
   entities controlled by Nais will also be deleted.
-  
+
   WARNING: There is no going back after starting this process.
-  
+
   Note: Service accounts are not allowed to confirm a team deletion.
   """
   confirmTeamDeletion(input: ConfirmTeamDeletionInput!): ConfirmTeamDeletionPayload!
@@ -4390,23 +4400,23 @@ type Mutation {
 
   """
   Create a service account token.
-  
+
   The secret is automatically generated, and is returned as a part of the payload for this mutation. The secret can
   not be retrieved at a later stage.
-  
+
   A service account can have multiple active tokens at the same time.
   """
   createServiceAccountToken(input: CreateServiceAccountTokenInput!): CreateServiceAccountTokenPayload!
 
   """
   Create a new Nais team
-  
+
   The user creating the team will be granted team ownership, unless the user is a service account, in which case the
   team will not get an initial owner. To add one or more owners to the team, refer to the `addTeamOwners` mutation.
-  
+
   Creation of a team will also create external resources for the team, which will be managed by the Nais API
   reconcilers. This will be done asynchronously.
-  
+
   Refer to the [official Nais documentation](https://docs.nais.io/explanations/team/) for more information regarding
   Nais teams.
   """
@@ -4414,10 +4424,10 @@ type Mutation {
 
   """
   Create a new Unleash instance.
-  
+
   This mutation will create a new Unleash instance for the given team. The team
   will be set as owner of the Unleash instance and will be able to manage it.
-  
+
   By default, instances are created with the default version.
   Optionally specify a releaseChannel to subscribe to automatic version updates.
   """
@@ -4471,15 +4481,23 @@ type Mutation {
   deleteValkey(input: DeleteValkeyInput!): DeleteValkeyPayload!
 
   """
+  Delete an Unleash instance.
+
+  The Unleash instance can only be deleted if no other teams have access to it.
+  Revoke access for all other teams before deleting the instance.
+  """
+  deleteUnleashInstance(input: DeleteUnleashInstanceInput!): DeleteUnleashInstancePayload!
+
+  """
   Disable a reconciler
-  
+
   The reconciler configuration will be left intact.
   """
   disableReconciler(input: DisableReconcilerInput!): Reconciler!
 
   """
   Enable a reconciler
-  
+
   A reconciler must be fully configured before it can be enabled.
   """
   enableReconciler(input: EnableReconcilerInput!): Reconciler!
@@ -4498,7 +4516,7 @@ type Mutation {
 
   """
   Remove a team member
-  
+
   If the user is not already a member or an owner of the team, the mutation will result in an error.
   """
   removeTeamMember(input: RemoveTeamMemberInput!): RemoveTeamMemberPayload!
@@ -4508,12 +4526,12 @@ type Mutation {
 
   """
   Request a key that can be used to trigger a team deletion process
-  
+
   Deleting a team is a two step process. First an owner of the team (or an admin) must request a team deletion key,
   and then a second owner of the team (or an admin) must confirm the deletion using the confirmTeamDeletion mutation.
-  
+
   The returned delete key is valid for an hour, and can only be used once.
-  
+
   Note: Service accounts are not allowed to request team delete keys.
   """
   requestTeamDeletion(input: RequestTeamDeletionInput!): RequestTeamDeletionPayload!
@@ -4534,7 +4552,7 @@ type Mutation {
 
   """
   Assign a role to a team member
-  
+
   The user must already be a member of the team for this mutation to succeed.
   """
   setTeamMemberRole(input: SetTeamMemberRoleInput!): SetTeamMemberRolePayload!
@@ -4586,14 +4604,14 @@ type Mutation {
 
   """
   Update a service account token.
-  
+
   Note that the secret itself can not be updated, only the metadata.
   """
   updateServiceAccountToken(input: UpdateServiceAccountTokenInput!): UpdateServiceAccountTokenPayload!
 
   """
   Update an existing Nais team
-  
+
   This mutation can be used to update the team purpose and the main Slack channel. It is not possible to update the
   team slug.
   """
@@ -4604,7 +4622,7 @@ type Mutation {
 
   """
   Update an Unleash instance's release channel.
-  
+
   Use this mutation to change to a different release channel.
   """
   updateUnleashInstance(input: UpdateUnleashInstanceInput!): UpdateUnleashInstancePayload!
@@ -7512,14 +7530,14 @@ type StartValkeyMaintenancePayload {
 type Subscription {
   """
   Subscribe to log lines
-  
+
   This subscription is used to stream log lines.
   """
   log(filter: LogSubscriptionFilter!): LogLine!
 
   """
   Subscribe to workload logs
-  
+
   This subscription is used to stream logs from a specific workload. When filtering logs you must either specify an
   application or a job owned by a team that is running in a specific environment. You can also filter logs on instance
   name(s).
@@ -9363,7 +9381,7 @@ type UpdateSecretValuePayload {
 input UpdateServiceAccountInput {
   """
   The new description of the service account.
-  
+
   If not specified, the description will remain unchanged.
   """
   description: String
@@ -9380,14 +9398,14 @@ type UpdateServiceAccountPayload {
 input UpdateServiceAccountTokenInput {
   """
   The new description of the service account token.
-  
+
   If not specified, the description will remain unchanged.
   """
   description: String
 
   """
   The new name of the service account token.
-  
+
   If not specified, the name will remain unchanged.
   """
   name: String
@@ -9428,14 +9446,14 @@ type UpdateTeamEnvironmentPayload {
 input UpdateTeamInput {
   """
   An optional new purpose / description of the team.
-  
+
   When omitted the existing value will not be updated.
   """
   purpose: String
 
   """
   An optional new Slack channel for the team.
-  
+
   When omitted the existing value will not be updated.
   """
   slackChannel: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -2390,16 +2390,6 @@ type DeleteValkeyPayload {
   valkeyDeleted: Boolean
 }
 
-input DeleteUnleashInstanceInput {
-  """The team that owns the Unleash instance to delete."""
-  teamSlug: Slug!
-}
-
-type DeleteUnleashInstancePayload {
-  """Whether or not the Unleash instance was deleted."""
-  unleashDeleted: Boolean
-}
-
 """Description of a deployment."""
 type Deployment implements Node {
   """The git commit SHA that was deployed."""
@@ -4471,7 +4461,7 @@ type Mutation {
 
   """
   Delete an Unleash instance.
-  
+
   The Unleash instance can only be deleted if no other teams have access to it.
   Revoke access for all other teams before deleting the instance.
   """
@@ -4479,14 +4469,6 @@ type Mutation {
 
   """Delete an existing Valkey instance."""
   deleteValkey(input: DeleteValkeyInput!): DeleteValkeyPayload!
-
-  """
-  Delete an Unleash instance.
-
-  The Unleash instance can only be deleted if no other teams have access to it.
-  Revoke access for all other teams before deleting the instance.
-  """
-  deleteUnleashInstance(input: DeleteUnleashInstanceInput!): DeleteUnleashInstancePayload!
 
   """
   Disable a reconciler

--- a/src/lib/ui/Confirm.svelte
+++ b/src/lib/ui/Confirm.svelte
@@ -5,6 +5,7 @@
 	interface Props {
 		confirmText?: string;
 		open?: boolean;
+		disabled?: boolean;
 		variant?:
 			| 'primary'
 			| 'primary-neutral'
@@ -23,6 +24,7 @@
 	let {
 		confirmText = 'Confirm',
 		open = $bindable(false),
+		disabled = false,
 		variant = 'primary',
 		header,
 		children,
@@ -48,7 +50,7 @@
 	</div>
 
 	{#snippet footer()}
-		<Button {variant} type="submit" onclick={confirm}>{confirmText}</Button>
+		<Button {variant} type="submit" onclick={confirm} {disabled}>{confirmText}</Button>
 		<Button variant="tertiary" type="reset" onclick={cancel}>Cancel</Button>
 	{/snippet}
 </Modal>

--- a/src/routes/team/[team]/unleash/+page.svelte
+++ b/src/routes/team/[team]/unleash/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { graphql } from '$houdini';
 	import { docURL } from '$lib/doc';
 	import CpuIcon from '$lib/icons/CpuIcon.svelte';
@@ -21,6 +23,7 @@
 		Table,
 		Tbody,
 		Td,
+		TextField,
 		Th,
 		Thead,
 		Tooltip,
@@ -246,6 +249,42 @@
 				allowedTeamSlug: teamName
 			})
 			.then(() => Unleash.fetch({ policy: 'CacheAndNetwork' }));
+
+	// Delete Unleash instance
+	const deleteUnleashInstance = graphql(`
+		mutation DeleteUnleashInstance($team: Slug!) {
+			deleteUnleashInstance(input: { teamSlug: $team }) {
+				unleashDeleted
+			}
+		}
+	`);
+
+	let deleteConfirmOpen = $state(false);
+	let deleteConfirmation = $state('');
+	let deleting = $state(false);
+	let deleteError = $state('');
+	const allowedTeamsCount = $derived(unleash?.allowedTeams.nodes.length ?? 0);
+	const canDelete = $derived(allowedTeamsCount === 1 && unleash?.ready);
+	const deleteConfirmed = $derived(deleteConfirmation === unleash?.name);
+
+	const deleteUnleash = async () => {
+		deleting = true;
+		deleteError = '';
+		try {
+			const result = await deleteUnleashInstance.mutate({ team: teamSlug });
+			if (result.errors && result.errors.length > 0) {
+				deleteError = extractErrorMessages(result.errors).join(', ');
+			} else if (result.data?.deleteUnleashInstance.unleashDeleted) {
+				goto(`/team/${page.params.team}?deleted=unleash`);
+			} else {
+				deleteError = 'Failed to delete the Unleash instance. Please try again.';
+			}
+		} catch (e) {
+			deleteError = e instanceof Error ? e.message : 'An unexpected error occurred.';
+		} finally {
+			deleting = false;
+		}
+	};
 </script>
 
 {#if $Unleash.errors}
@@ -308,6 +347,24 @@
 	</Alert>
 {/if}
 
+{#if $deleteUnleashInstance.errors}
+	<Alert variant="error" size="small" style="margin-bottom: 1rem;">
+		{#each new Set(extractErrorMessages($deleteUnleashInstance.errors)) as error (error)}
+			{error}<br />
+		{/each}
+		<Button variant="tertiary" size="small" onclick={() => ($deleteUnleashInstance.errors = [])}>
+			Dismiss
+		</Button>
+	</Alert>
+{/if}
+
+{#if deleteError}
+	<Alert variant="error" size="small" style="margin-bottom: 1rem;">
+		{deleteError}
+		<Button variant="tertiary" size="small" onclick={() => (deleteError = '')}>Dismiss</Button>
+	</Alert>
+{/if}
+
 {#if !enabled}
 	<Alert style="margin-bottom: 1rem;" variant="info">
 		Unleash is not enabled for this tenant. Contact your administrator.
@@ -342,6 +399,48 @@
 		<BodyShort>Are you sure you want to remove this team?</BodyShort>
 	</Confirm>
 
+	{#if viewerIsMember}
+		<Confirm
+			confirmText="Delete"
+			variant="danger"
+			bind:open={deleteConfirmOpen}
+			onconfirm={deleteUnleash}
+			disabled={!canDelete || !deleteConfirmed}
+		>
+			{#snippet header()}
+				<Heading>Delete Unleash Instance</Heading>
+			{/snippet}
+			{#if !canDelete}
+				<Alert variant="warning" size="small" style="margin-bottom: var(--ax-space-8);">
+					{#if !unleash.ready}
+						The Unleash instance must be ready before it can be deleted.
+					{:else if allowedTeamsCount > 1}
+						Revoke access for all other teams before deleting. Currently {allowedTeamsCount - 1} other
+						team{allowedTeamsCount > 2 ? 's have' : ' has'} access.
+					{/if}
+				</Alert>
+			{:else}
+				<BodyShort spacing>
+					This will permanently delete the Unleash instance <b>{unleash.name}</b> and all its data.
+				</BodyShort>
+				<BodyShort spacing>
+					This action cannot be undone. To confirm, type <b>{unleash.name}</b> below:
+				</BodyShort>
+				<TextField
+					label="Confirm instance name"
+					hideLabel
+					bind:value={deleteConfirmation}
+					placeholder={unleash.name}
+				/>
+				{#if !deleteConfirmed && deleteConfirmation.length > 0}
+					<Alert variant="error" size="small" style="margin-top: var(--ax-space-4);">
+						The instance name does not match.
+					</Alert>
+				{/if}
+			{/if}
+		</Confirm>
+	{/if}
+
 	{#if addTeamModalOpen}
 		<TeamSearchModal
 			bind:open={addTeamModalOpen}
@@ -354,6 +453,24 @@
 
 	<div class="layout-two-column">
 		<div class="content">
+			{#if viewerIsMember}
+				<div class="detail-actions">
+					<Button
+						variant="danger"
+						size="small"
+						loading={deleting}
+						onclick={() => {
+							deleteConfirmation = '';
+							deleteError = '';
+							deleteConfirmOpen = true;
+						}}
+						icon={TrashIcon}
+					>
+						Delete
+					</Button>
+				</div>
+			{/if}
+
 			<section aria-labelledby="info-heading">
 				<Heading as="h2" id="info-heading" size="medium" spacing>Instance details</Heading>
 				<dl class="settings-list">


### PR DESCRIPTION
Implement a confirmation dialog for deleting Unleash instances, ensuring users confirm the action before proceeding. This change enhances user experience by preventing accidental deletions.