### PR TITLE
feat: add LogDestinationGeneric type to schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2892,6 +2892,14 @@ interface LogDestination {
   id: ID!
 }
 
+type LogDestinationGeneric implements LogDestination & Node {
+  """The globally unique ID of the log destination."""
+  id: ID!
+
+  """Name defined in the manifest"""
+  name: String!
+}
+
 type LogDestinationLoki implements LogDestination & Node {
   """Grafana URL to view the logs."""
   grafanaURL: String!


### PR DESCRIPTION
This pull request introduces a new GraphQL type, `LogDestinationGeneric`, to the schema. This type implements the existing `LogDestination` interface and provides a generic log destination option with an ID and a manifest-defined name.

Schema enhancements:

* Added a new `LogDestinationGeneric` type to the GraphQL schema, implementing the `LogDestination` interface and including fields for `id` and `name`.