### PR TITLE
fix: correct feature check from OpenSearch to Valkey

### DIFF
--- a/src/routes/team/[team]/valkey/+page.ts
+++ b/src/routes/team/[team]/valkey/+page.ts
@@ -13,15 +13,15 @@ export async function load(event) {
 	const userInfoData = get(parent.UserInfo) as {
 		data?: {
 			features?: {
-				openSearch?: {
+				valkey?: {
 					enabled?: boolean;
 				};
 			};
 		};
 	};
 
-	if (userInfoData.data?.features?.openSearch?.enabled === false) {
-		error(404, 'OpenSearch not enabled');
+	if (userInfoData.data?.features?.valkey?.enabled === false) {
+		error(404, 'Valkey not enabled');
 	}
 
 	const after = event.url.searchParams.get('after') || '';


### PR DESCRIPTION
This pull request updates the feature flag check in the `load` function to use `valkey` instead of `openSearch`. This ensures that the page correctly checks for the Valkey feature and displays an appropriate error if it is not enabled.

Feature flag update:

* Updated the feature flag check in the `load` function of `+page.ts` to use `valkey` instead of `openSearch`, and changed the error message to "Valkey not enabled" for consistency. ([src/routes/team/[team]/valkey/+page.tsL16-R24](diffhunk://#diff-0494e4deddf7deae2b190063f7c6081aa1d06e33b2c6f3040b1b00c6c32e6d94L16-R24))