### PR TITLE
refactor: replace viewerCanElevate with viewerIsMember

### DIFF
--- a/src/routes/team/[team]/[env]/secret/[secret]/+page.svelte
+++ b/src/routes/team/[team]/[env]/secret/[secret]/+page.svelte
@@ -43,10 +43,10 @@
 	let secret = $derived($Secret.data?.team.environment.secret);
 	let viewerIsMember = $derived($Secret.data?.team.viewerIsMember ?? false);
 	let isAdmin = $derived($Secret.data?.me?.__typename === 'User' ? $Secret.data.me.isAdmin : false);
-	let viewerCanElevate = $derived($Secret.data?.team.viewerCanElevate ?? false);
 
-	// Admin can mutate (create/update/delete) but cannot elevate unless they are team members
+	// Admin can mutate (create/update/delete) but only team members can view secret values
 	let canMutate = $derived(viewerIsMember || isAdmin);
+	let canViewValues = $derived(viewerIsMember);
 
 	let secretName = $derived(page.params.secret ?? '');
 	let env = $derived(page.params.env ?? '');
@@ -309,7 +309,7 @@
 					</HelpText>
 				</div>
 				<div class="header-buttons">
-					{#if viewerCanElevate}
+					{#if canViewValues}
 						{#if secretsRevealed}
 							<Button
 								variant="secondary"
@@ -381,7 +381,7 @@
 											size="small"
 											copyText={revealedValues.get(keyName) ?? ''}
 										/>
-										{#if viewerCanElevate}
+										{#if canViewValues}
 											<Button
 												size="small"
 												variant="tertiary"

--- a/src/routes/team/[team]/[env]/secret/[secret]/AddKeyValue.svelte
+++ b/src/routes/team/[team]/[env]/secret/[secret]/AddKeyValue.svelte
@@ -83,7 +83,7 @@
 		key = '';
 		value = '';
 
-		// Reload secret values if user has active elevation
+		// Reload secret after adding new key
 		if (onSuccess) {
 			await onSuccess();
 		}

--- a/src/routes/team/[team]/[env]/secret/[secret]/query.gql
+++ b/src/routes/team/[team]/[env]/secret/[secret]/query.gql
@@ -6,7 +6,6 @@ query Secret($secret: String!, $team: Slug!, $env: String!) @cache(policy: Netwo
 	}
 	team(slug: $team) {
 		viewerIsMember
-		viewerCanElevate
 		environment(name: $env) {
 			secret(name: $secret) {
 				name


### PR DESCRIPTION
Only team members can view secret values - removes elevation concept from authorization check.