### PR TITLE
Add SecretValuesViewed to activity logs

### DIFF
--- a/src/lib/domain/activity/activity-log-tooltip.ts
+++ b/src/lib/domain/activity/activity-log-tooltip.ts
@@ -19,6 +19,7 @@ export function activityTooltip(typename: string): string {
 		case 'SecretValueAddedActivityLogEntry':
 		case 'SecretValueRemovedActivityLogEntry':
 		case 'SecretValueUpdatedActivityLogEntry':
+		case 'SecretValuesViewedActivityLogEntry':
 			return 'Secret';
 		case 'RepositoryAddedActivityLogEntry':
 		case 'RepositoryRemovedActivityLogEntry':

--- a/src/lib/domain/activity/shared/texts/SecretValuesViewedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/SecretValuesViewedActivityLogEntryText.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import { activityLogResourceLink } from '../../utils';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'SecretValuesViewedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	<strong>{data.actor}</strong> viewed secret values for
+	<a
+		href={activityLogResourceLink(
+			data.environmentName ?? '',
+			data.resourceType,
+			data.resourceName,
+			data.teamSlug
+		)}>{data.resourceName}</a
+	>
+	{#if data.secretValuesViewed?.reason}
+		<BodyShort size="small"><em>Reason: {data.secretValuesViewed.reason}</em></BodyShort>
+	{/if}
+
+	<BodyShort textColor="subtle" size="small">
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/team-overview/TeamOverviewActivityLog.svelte
+++ b/src/lib/domain/activity/team-overview/TeamOverviewActivityLog.svelte
@@ -23,6 +23,7 @@
 	import SecretValueAddedActivityLogEntryText from '../shared/texts/SecretValueAddedActivityLogEntryText.svelte';
 	import SecretValueRemovedActivityLogEntryText from '../shared/texts/SecretValueRemovedActivityLogEntryText.svelte';
 	import SecretValueUpdatedActivityLogEntryText from '../shared/texts/SecretValueUpdatedActivityLogEntryText.svelte';
+	import SecretValuesViewedActivityLogEntryText from '../shared/texts/SecretValuesViewedActivityLogEntryText.svelte';
 	import TeamMemberAddedActivityLogEntryText from '../shared/texts/TeamMemberAddedActivityLogEntryText.svelte';
 	import TeamMemberRemovedActivityLogEntryText from '../shared/texts/TeamMemberRemovedActivityLogEntryText.svelte';
 	import TeamMemberSetRoleActivityLogEntryText from '../shared/texts/TeamMemberSetRoleActivityLogEntryText.svelte';
@@ -58,6 +59,7 @@
 			ActivityLogActivityType.SECRET_VALUE_ADDED,
 			ActivityLogActivityType.SECRET_VALUE_REMOVED,
 			ActivityLogActivityType.SECRET_VALUE_UPDATED,
+			ActivityLogActivityType.SECRET_VALUES_VIEWED,
 			ActivityLogActivityType.TEAM_CONFIRM_DELETE_KEY,
 			ActivityLogActivityType.TEAM_CREATED,
 			ActivityLogActivityType.TEAM_CREATE_DELETE_KEY,
@@ -170,6 +172,13 @@
 									valueName
 								}
 							}
+							... on SecretValuesViewedActivityLogEntry {
+								__typename
+
+								secretValuesViewed: data {
+									reason
+								}
+							}
 							... on TeamMemberAddedActivityLogEntry {
 								__typename
 
@@ -256,6 +265,8 @@
 				return SecretCreatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'SecretDeletedActivityLogEntry':
 				return SecretDeletedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'SecretValuesViewedActivityLogEntry':
+				return SecretValuesViewedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'TeamMemberAddedActivityLogEntry':
 				return TeamMemberAddedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'TeamMemberRemovedActivityLogEntry':

--- a/src/lib/domain/list-items/ActivityLogListItem.svelte
+++ b/src/lib/domain/list-items/ActivityLogListItem.svelte
@@ -26,6 +26,7 @@
 	import SecretValueAddedActivityLogEntryText from '../activity/shared/texts/SecretValueAddedActivityLogEntryText.svelte';
 	import SecretValueRemovedActivityLogEntryText from '../activity/shared/texts/SecretValueRemovedActivityLogEntryText.svelte';
 	import SecretValueUpdatedActivityLogEntryText from '../activity/shared/texts/SecretValueUpdatedActivityLogEntryText.svelte';
+	import SecretValuesViewedActivityLogEntryText from '../activity/shared/texts/SecretValuesViewedActivityLogEntryText.svelte';
 	import ServiceMaintenanceActivityLogEntryText from '../activity/shared/texts/ServiceMaintenanceActivityLogEntryText.svelte';
 	import TeamEnvironmentUpdatedActivityLogEntryText from '../activity/shared/texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte';
 	import TeamMemberAddedActivityLogEntryText from '../activity/shared/texts/TeamMemberAddedActivityLogEntryText.svelte';
@@ -129,6 +130,11 @@
 					... on SecretValueUpdatedActivityLogEntry {
 						secretValueUpdated: data {
 							valueName
+						}
+					}
+					... on SecretValuesViewedActivityLogEntry {
+						secretValuesViewed: data {
+							reason
 						}
 					}
 					... on ServiceMaintenanceActivityLogEntry {
@@ -250,6 +256,8 @@
 				return SecretValueRemovedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'SecretValueUpdatedActivityLogEntry':
 				return SecretValueUpdatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'SecretValuesViewedActivityLogEntry':
+				return SecretValuesViewedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ServiceMaintenanceActivityLogEntry':
 				return ServiceMaintenanceActivityLogEntryText as Component<{ data: unknown }>;
 			case 'TeamEnvironmentUpdatedActivityLogEntry':

--- a/src/routes/team/[team]/activity-log/+page.svelte
+++ b/src/routes/team/[team]/activity-log/+page.svelte
@@ -59,7 +59,8 @@
 			ActivityLogActivityType.SECRET_DELETED,
 			ActivityLogActivityType.SECRET_VALUE_ADDED,
 			ActivityLogActivityType.SECRET_VALUE_REMOVED,
-			ActivityLogActivityType.SECRET_VALUE_UPDATED
+			ActivityLogActivityType.SECRET_VALUE_UPDATED,
+			ActivityLogActivityType.SECRET_VALUES_VIEWED
 		],
 		Team: [
 			ActivityLogActivityType.TEAM_CONFIRM_DELETE_KEY,


### PR DESCRIPTION
Show when someone viewed secret values across all activity log views:
- team/activity-log
- team/overview  
- team/secrets (sidebar)
- team/secrets/secret (sidebar)

Displays the secret name and justification reason consistently across all views.