### PR TITLE
Try adding probe to the ingress

### DIFF
--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -7,6 +7,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: 8k
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
+    prometheus.io/path: /isAlive
+    prometheus.io/scrape: "true"
 spec:
   ingressClassName: 'nais-ingress-external'
   rules:


### PR DESCRIPTION
This pull request makes a minor update to the `charts/templates/ingress.yaml` file, adding Prometheus-related annotations to enable scraping of the `/isAlive` endpoint.

* Added `prometheus.io/path` and `prometheus.io/scrape` annotations to the ingress metadata to facilitate Prometheus monitoring of the `/isAlive` endpoint.