### PR TITLE
Do a case insentivite match when looking for the user

### DIFF
--- a/src/routes/team/[team]/members/AddMember.svelte
+++ b/src/routes/team/[team]/members/AddMember.svelte
@@ -82,7 +82,12 @@
 	let errors: string[] = $state([]);
 	const submit = async () => {
 		errors = [];
-		const userID = $store.data?.users.nodes.find((u) => u.email === email)?.email;
+		const userID = $store.data?.users.nodes.find(
+			(u) =>
+				email.localeCompare(u.email, undefined, {
+					sensitivity: 'base'
+				}) === 0
+		)?.email;
 		if (!userID) {
 			errors = ['User not found'];
 			return;


### PR DESCRIPTION
When not choosing an email from the datalist, the casing might be different from what we have stored. So do the lookup using the localeCompare with case and accent insentitive match

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare