### PR TITLE
Refactor team settings load function to remove user access check

### DIFF
--- a/src/routes/team/[team]/settings/+page.ts
+++ b/src/routes/team/[team]/settings/+page.ts
@@ -2,12 +2,14 @@ import { load_TeamSettings } from '$houdini';
 import { addPageMeta } from '$lib/utils/pageMeta';
 
 export async function load(event) {
+	const parent = await event.parent();
 	return {
 		...(await addPageMeta(event, { title: 'Settings' })),
 		...(await load_TeamSettings({
 			event,
 			variables: {
-				team: event.params.team
+				team: event.params.team,
+				viewerIsMember: parent.viewerIsMember
 			}
 		}))
 	};

--- a/src/routes/team/[team]/settings/+page.ts
+++ b/src/routes/team/[team]/settings/+page.ts
@@ -9,7 +9,7 @@ export async function load(event) {
 			event,
 			variables: {
 				team: event.params.team,
-				viewerIsMember: parent.viewerIsMember
+				viewerIsMember: parent.viewerIsMember ?? false
 			}
 		}))
 	};

--- a/src/routes/team/[team]/settings/+page.ts
+++ b/src/routes/team/[team]/settings/+page.ts
@@ -1,19 +1,7 @@
 import { load_TeamSettings } from '$houdini';
 import { addPageMeta } from '$lib/utils/pageMeta';
-import { error } from '@sveltejs/kit';
-import { get } from 'svelte/store';
 
 export async function load(event) {
-	const pd = await event.parent();
-	const userInfoData = get(pd.UserInfo);
-
-	if (
-		!pd.viewerIsMember &&
-		!(userInfoData.data?.me.__typename === 'User' && userInfoData.data?.me.isAdmin)
-	) {
-		error(403, 'You are not allowed to view this page');
-	}
-
 	return {
 		...(await addPageMeta(event, { title: 'Settings' })),
 		...(await load_TeamSettings({

--- a/src/routes/team/[team]/settings/query.gql
+++ b/src/routes/team/[team]/settings/query.gql
@@ -1,10 +1,10 @@
-query TeamSettings($team: Slug!) {
+query TeamSettings($team: Slug!, $viewerIsMember: Boolean!) {
 	team(slug: $team) {
 		slug
 		lastSuccessfulSync
 		purpose
 		slackChannel
-		deploymentKey {
+		deploymentKey @include(if: $viewerIsMember) {
 			created
 			expires
 			key


### PR DESCRIPTION
This pull request simplifies the `load` function in `src/routes/team/[team]/settings/+page.ts` by removing the access control logic that restricted non-members and non-admins from viewing the page.

Removed access control:

* Eliminated the logic that checked if the user was a team member or admin and returned a 403 error if not, allowing all users to access the team settings page. ([src/routes/team/[team]/settings/+page.tsL3-L16](diffhunk://#diff-650bafe3b3a48e7f6bd14af28d811557d179697a2b7515fd3f434fa6f2a84c69L3-L16))