### PR TITLE
Add activity log for Kubernetes resource changes and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,7 +207,6 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -4484,14 +4483,14 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-			"integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.11",
 				"form-data": "^4.0.5",
-				"proxy-from-env": "^1.1.0"
+				"proxy-from-env": "^2.1.0"
 			}
 		},
 		"node_modules/axobject-query": {
@@ -9399,10 +9398,13 @@
 			}
 		},
 		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-			"license": "MIT"
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/pump": {
 			"version": "3.0.3",

--- a/schema.graphql
+++ b/schema.graphql
@@ -37,6 +37,12 @@ enum ActivityLogActivityType {
   """Activity log entry for deployment activity."""
   DEPLOYMENT
 
+  """A generic kubernetes resource was created via apply."""
+  GENERIC_KUBERNETES_RESOURCE_CREATED
+
+  """A generic kubernetes resource was updated via apply."""
+  GENERIC_KUBERNETES_RESOURCE_UPDATED
+
   """Activity log entries related to job deletion."""
   JOB_DELETED
 
@@ -730,6 +736,37 @@ type ApplicationConnection {
   pageInfo: PageInfo!
 }
 
+type ApplicationCreatedActivityLogEntry implements ActivityLogEntry & Node {
+  """
+  The identity of the actor who performed the action. The value is either the name of a service account, or the email address of a user.
+  """
+  actor: String!
+
+  """Creation time of the entry."""
+  createdAt: Time!
+
+  """Data associated with the creation."""
+  data: GenericKubernetesResourceActivityLogEntryData!
+
+  """The environment name that the entry belongs to."""
+  environmentName: String
+
+  """ID of the entry."""
+  id: ID!
+
+  """Message that summarizes the entry."""
+  message: String!
+
+  """Name of the resource that was affected by the action."""
+  resourceName: String!
+
+  """Type of the resource that was affected by the action."""
+  resourceType: ActivityLogEntryResourceType!
+
+  """The team slug that the entry belongs to."""
+  teamSlug: Slug!
+}
+
 type ApplicationDeletedActivityLogEntry implements ActivityLogEntry & Node {
   """
   The identity of the actor who performed the action. The value is either the name of a service account, or the email address of a user.
@@ -942,6 +979,37 @@ enum ApplicationState {
 
   """The application state is unknown."""
   UNKNOWN
+}
+
+type ApplicationUpdatedActivityLogEntry implements ActivityLogEntry & Node {
+  """
+  The identity of the actor who performed the action. The value is either the name of a service account, or the email address of a user.
+  """
+  actor: String!
+
+  """Creation time of the entry."""
+  createdAt: Time!
+
+  """Data associated with the update."""
+  data: GenericKubernetesResourceActivityLogEntryData!
+
+  """The environment name that the entry belongs to."""
+  environmentName: String
+
+  """ID of the entry."""
+  id: ID!
+
+  """Message that summarizes the entry."""
+  message: String!
+
+  """Name of the resource that was affected by the action."""
+  resourceName: String!
+
+  """Type of the resource that was affected by the action."""
+  resourceType: ActivityLogEntryResourceType!
+
+  """The team slug that the entry belongs to."""
+  teamSlug: Slug!
 }
 
 input AssignRoleToServiceAccountInput {
@@ -1652,7 +1720,7 @@ input CreateKafkaCredentialsInput {
   """The team that owns the Kafka topic."""
   teamSlug: Slug!
 
-  """Time-to-live for the credentials (e.g. '1d', '7d'). Maximum 30 days."""
+  """Time-to-live for the credentials (e.g. '1d', '7d'). Maximum 365 days."""
   ttl: String!
 }
 
@@ -2559,6 +2627,101 @@ type Features implements Node {
   valkey: FeatureValkey!
 }
 
+"""
+Activity log entry for a resource kind that is not modelled in the GraphQL API.
+The resource type will be the uppercase Kubernetes kind, e.g. 'NAISJOB'.
+"""
+type GenericKubernetesResourceActivityLogEntry implements ActivityLogEntry & Node {
+  """
+  The identity of the actor who performed the action. The value is either the name of a service account, or the email address of a user.
+  """
+  actor: String!
+
+  """Creation time of the entry."""
+  createdAt: Time!
+
+  """Data associated with the apply operation."""
+  data: GenericKubernetesResourceActivityLogEntryData!
+
+  """The environment name that the entry belongs to."""
+  environmentName: String
+
+  """ID of the entry."""
+  id: ID!
+
+  """Message that summarizes the entry."""
+  message: String!
+
+  """Name of the resource that was affected by the action."""
+  resourceName: String!
+
+  """Type of the resource that was affected by the action."""
+  resourceType: ActivityLogEntryResourceType!
+
+  """The team slug that the entry belongs to."""
+  teamSlug: Slug
+}
+
+"""
+Additional data associated with a resource created or updated via apply.
+"""
+type GenericKubernetesResourceActivityLogEntryData {
+  """The apiVersion of the applied resource."""
+  apiVersion: String!
+
+  """The fields that changed during the apply. Only populated for updates."""
+  changedFields: [ResourceChangedField!]!
+
+  """
+  GitHub Actions OIDC token claims at the time of the apply. Only present when the request was authenticated via a GitHub token.
+  """
+  gitHubActorClaims: GitHubActorClaims
+
+  """The kind of the applied resource."""
+  kind: String!
+}
+
+"""
+GitHub Actions OIDC token claims captured at the time of an apply operation.
+"""
+type GitHubActorClaims {
+  """The GitHub username that triggered the workflow."""
+  actor: String!
+
+  """The GitHub deployment environment name, if the job targets one."""
+  environment: String!
+
+  """
+  The event that triggered the workflow, e.g. 'push' or 'workflow_dispatch'.
+  """
+  eventName: String!
+
+  """
+  The ref of the reusable workflow called by this job, if any. E.g. 'org/repo/.github/workflows/deploy.yaml@refs/heads/main'.
+  """
+  jobWorkflowRef: String!
+
+  """The git ref that triggered the workflow, e.g. 'refs/heads/main'."""
+  ref: String!
+
+  """The repository name that triggered the workflow, e.g. 'org/repo'."""
+  repository: String!
+
+  """The immutable numeric GitHub repository ID."""
+  repositoryID: String!
+
+  """The attempt number of the workflow run (1-indexed)."""
+  runAttempt: String!
+
+  """
+  The unique identifier of the Actions workflow run. Links to https://github.com/<repo>/actions/runs/<runId>.
+  """
+  runID: String!
+
+  """The path to the workflow file, e.g. '.github/workflows/deploy.yaml'."""
+  workflow: String!
+}
+
 input GrantPostgresAccessInput {
   clusterName: String!
 
@@ -3121,6 +3284,37 @@ type JobConnection {
   pageInfo: PageInfo!
 }
 
+type JobCreatedActivityLogEntry implements ActivityLogEntry & Node {
+  """
+  The identity of the actor who performed the action. The value is either the name of a service account, or the email address of a user.
+  """
+  actor: String!
+
+  """Creation time of the entry."""
+  createdAt: Time!
+
+  """Data associated with the creation."""
+  data: GenericKubernetesResourceActivityLogEntryData!
+
+  """The environment name that the entry belongs to."""
+  environmentName: String
+
+  """ID of the entry."""
+  id: ID!
+
+  """Message that summarizes the entry."""
+  message: String!
+
+  """Name of the resource that was affected by the action."""
+  resourceName: String!
+
+  """Type of the resource that was affected by the action."""
+  resourceType: ActivityLogEntryResourceType!
+
+  """The team slug that the entry belongs to."""
+  teamSlug: Slug!
+}
+
 type JobDeletedActivityLogEntry implements ActivityLogEntry & Node {
   """
   The identity of the actor who performed the action. The value is either the name of a service account, or the email address of a user.
@@ -3378,6 +3572,37 @@ type JobTriggeredActivityLogEntry implements ActivityLogEntry & Node {
 
   """Creation time of the entry."""
   createdAt: Time!
+
+  """The environment name that the entry belongs to."""
+  environmentName: String
+
+  """ID of the entry."""
+  id: ID!
+
+  """Message that summarizes the entry."""
+  message: String!
+
+  """Name of the resource that was affected by the action."""
+  resourceName: String!
+
+  """Type of the resource that was affected by the action."""
+  resourceType: ActivityLogEntryResourceType!
+
+  """The team slug that the entry belongs to."""
+  teamSlug: Slug!
+}
+
+type JobUpdatedActivityLogEntry implements ActivityLogEntry & Node {
+  """
+  The identity of the actor who performed the action. The value is either the name of a service account, or the email address of a user.
+  """
+  actor: String!
+
+  """Creation time of the entry."""
+  createdAt: Time!
+
+  """Data associated with the update."""
+  data: GenericKubernetesResourceActivityLogEntryData!
 
   """The environment name that the entry belongs to."""
   environmentName: String
@@ -5299,6 +5524,18 @@ type RequestTeamDeletionPayload {
   The delete key for the team. This can be used to confirm the deletion of the team.
   """
   key: TeamDeleteKey
+}
+
+"""A single field that changed."""
+type ResourceChangedField {
+  """The dot-separated path to the changed field, e.g. 'spec.replicas'."""
+  field: String!
+
+  """The value after the change. Null if the field was removed."""
+  newValue: String
+
+  """The value before the change. Null if the field was added."""
+  oldValue: String
 }
 
 input ResourceIssueFilter {


### PR DESCRIPTION
This pull request extends the GraphQL schema to support comprehensive activity logging for generic Kubernetes resources created or updated via apply operations. It introduces new activity log entry types for both applications and jobs, adds supporting types for capturing detailed change data, and increases the allowed TTL for Kafka credentials.

**Activity log enhancements for generic Kubernetes resources:**

- Added new activity types to the `ActivityLogActivityType` enum for generic Kubernetes resource creation and update events.
- Introduced `GenericKubernetesResourceActivityLogEntry` type to represent activity log entries for resource kinds not explicitly modeled in the API, along with supporting types for detailed change tracking (`GenericKubernetesResourceActivityLogEntryData`, `GitHubActorClaims`, and `ResourceChangedField`). [[1]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R2630-R2724) [[2]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R5529-R5540)

**New activity log entry types for applications and jobs:**

- Added `ApplicationCreatedActivityLogEntry` and `ApplicationUpdatedActivityLogEntry` types to log creation and update actions on applications, including detailed resource and actor information. [[1]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R739-R769) [[2]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R984-R1014)
- Added `JobCreatedActivityLogEntry` and `JobUpdatedActivityLogEntry` types to log creation and update actions on jobs, with similar detailed fields. [[1]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R3287-R3317) [[2]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R3595-R3625)

**Kafka credentials policy update:**

- Increased the maximum allowed TTL for Kafka credentials from 30 days to 365 days in the `CreateKafkaCredentialsInput` input type.