### PR TITLE
Show restart info and timestamp in instance group detail

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -853,6 +853,12 @@ type ApplicationInstanceStatus {
   """
   lastExitReason: String
 
+  """
+  The timestamp of the last container termination, if applicable.
+  This is populated even when the instance is currently running, to help debug restart loops.
+  """
+  lastExitTimestamp: Time
+
   """A user-friendly description of the current state."""
   message: String!
 
@@ -3147,6 +3153,9 @@ enum IssueType {
   MISSING_SBOM
   NO_RUNNING_INSTANCES
   OPENSEARCH
+
+  """Raised when an application is stuck in a restart loop."""
+  APPLICATION_RESTART_LOOP
   SQLINSTANCE_STATE
   SQLINSTANCE_VERSION
   UNLEASH_RELEASE_CHANNEL
@@ -5682,6 +5691,33 @@ input RestartApplicationInput {
 type RestartApplicationPayload {
   """The application that was restarted."""
   application: Application
+}
+
+"""An issue raised when an application keeps restarting repeatedly."""
+type RestartLoopIssue implements Issue & Node {
+  """Unique identifier for this issue."""
+  id: ID!
+
+  """The reason for the last container exit."""
+  lastExitReason: String!
+
+  """The timestamp of the last container exit."""
+  lastExitTimestamp: Time!
+
+  """A human-readable description of the issue."""
+  message: String!
+
+  """The number of container restarts."""
+  restartCount: Int!
+
+  """The severity of the issue."""
+  severity: Severity!
+
+  """The team environment where the issue was detected."""
+  teamEnvironment: TeamEnvironment!
+
+  """The workload that is stuck in a restart loop."""
+  workload: Workload!
 }
 
 input RevokeRoleFromServiceAccountInput {

--- a/schema.graphql
+++ b/schema.graphql
@@ -918,6 +918,33 @@ type ApplicationResources implements WorkloadResources {
   scaling: ApplicationScaling!
 }
 
+"""An issue raised when an application keeps restarting repeatedly."""
+type ApplicationRestartLoopIssue implements Issue & Node {
+  """Unique identifier for this issue."""
+  id: ID!
+
+  """The reason for the last container exit."""
+  lastExitReason: String!
+
+  """The timestamp of the last container exit."""
+  lastExitTimestamp: Time!
+
+  """A human-readable description of the issue."""
+  message: String!
+
+  """The number of container restarts."""
+  restartCount: Int!
+
+  """The severity of the issue."""
+  severity: Severity!
+
+  """The team environment where the issue was detected."""
+  teamEnvironment: TeamEnvironment!
+
+  """The workload that is stuck in a restart loop."""
+  workload: Workload!
+}
+
 type ApplicationRestartedActivityLogEntry implements ActivityLogEntry & Node {
   """
   The identity of the actor who performed the action. The value is either the name of a service account, or the email address of a user.
@@ -3144,6 +3171,8 @@ enum IssueOrderField {
 }
 
 enum IssueType {
+  """Raised when an application is stuck in a restart loop."""
+  APPLICATION_RESTART_LOOP
   DEPRECATED_INGRESS
   DEPRECATED_REGISTRY
   EXTERNAL_INGRESS_CRITICAL_VULNERABILITY
@@ -3153,9 +3182,6 @@ enum IssueType {
   MISSING_SBOM
   NO_RUNNING_INSTANCES
   OPENSEARCH
-
-  """Raised when an application is stuck in a restart loop."""
-  APPLICATION_RESTART_LOOP
   SQLINSTANCE_STATE
   SQLINSTANCE_VERSION
   UNLEASH_RELEASE_CHANNEL
@@ -5691,33 +5717,6 @@ input RestartApplicationInput {
 type RestartApplicationPayload {
   """The application that was restarted."""
   application: Application
-}
-
-"""An issue raised when an application keeps restarting repeatedly."""
-type ApplicationRestartLoopIssue implements Issue & Node {
-  """Unique identifier for this issue."""
-  id: ID!
-
-  """The reason for the last container exit."""
-  lastExitReason: String!
-
-  """The timestamp of the last container exit."""
-  lastExitTimestamp: Time!
-
-  """A human-readable description of the issue."""
-  message: String!
-
-  """The number of container restarts."""
-  restartCount: Int!
-
-  """The severity of the issue."""
-  severity: Severity!
-
-  """The team environment where the issue was detected."""
-  teamEnvironment: TeamEnvironment!
-
-  """The workload that is stuck in a restart loop."""
-  workload: Workload!
 }
 
 input RevokeRoleFromServiceAccountInput {

--- a/schema.graphql
+++ b/schema.graphql
@@ -5694,7 +5694,7 @@ type RestartApplicationPayload {
 }
 
 """An issue raised when an application keeps restarting repeatedly."""
-type RestartLoopIssue implements Issue & Node {
+type ApplicationRestartLoopIssue implements Issue & Node {
   """Unique identifier for this issue."""
   id: ID!
 

--- a/src/lib/domain/issues/ApplicationRestartLoopIssue.svelte
+++ b/src/lib/domain/issues/ApplicationRestartLoopIssue.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import type { IssueFragment$data } from '$houdini';
+	import { Detail, Heading } from '@nais/ds-svelte-community';
+	import IssueLabel from './IssueLabel.svelte';
+
+	let {
+		data
+	}: {
+		data: Extract<IssueFragment$data, { __typename: 'ApplicationRestartLoopIssue' }>;
+	} = $props();
+
+	let workloadType: 'app' | 'job' = $derived.by(() => {
+		return data.workload.__typename === 'Application' ? 'app' : 'job';
+	});
+</script>
+
+<div class="item">
+	<div class="label">
+		<IssueLabel
+			environmentName={data.teamEnvironment.environment.name}
+			teamSlug={data.teamEnvironment.team.slug}
+			severity={data.severity}
+			resourceName={data.workload.name}
+			resourceType={workloadType}
+		/>
+	</div>
+
+	<div>
+		<Heading as="h4" size="xsmall">Restart Loop for {data.workload.name}</Heading>
+		<Detail>{data.message}</Detail>
+	</div>
+</div>
+
+<style>
+	.item {
+		display: grid;
+		grid-template-columns: 25ch auto;
+		gap: 1rem;
+	}
+	.label {
+		display: flex;
+		align-items: center;
+	}
+</style>

--- a/src/lib/domain/list-items/IssueListItem.svelte
+++ b/src/lib/domain/list-items/IssueListItem.svelte
@@ -7,6 +7,7 @@
 	import FailedSynchronizationIssue from '$lib/domain/issues/FailedSynchronizationIssue.svelte';
 	import InvalidSpecIssue from '$lib/domain/issues/InvalidSpecIssue.svelte';
 	import LastRunFailedIssue from '$lib/domain/issues/LastRunFailedIssue.svelte';
+	import ApplicationRestartLoopIssue from '$lib/domain/issues/ApplicationRestartLoopIssue.svelte';
 	import NoRunningInstancesIssue from '$lib/domain/issues/NoRunningInstancesIssue.svelte';
 	import OpenSearchIssue from '$lib/domain/issues/OpenSearchIssue.svelte';
 	import SqlInstanceStateIssue from '$lib/domain/issues/SqlInstanceStateIssue.svelte';
@@ -96,6 +97,12 @@
 							name
 						}
 					}
+					... on ApplicationRestartLoopIssue {
+						workload {
+							__typename
+							name
+						}
+					}
 					... on OpenSearchIssue {
 						event
 						openSearch {
@@ -151,6 +158,8 @@
 				return VulnerableImageIssue as Component<{ data: unknown }>;
 			case 'NoRunningInstancesIssue':
 				return NoRunningInstancesIssue as Component<{ data: unknown }>;
+			case 'ApplicationRestartLoopIssue':
+				return ApplicationRestartLoopIssue as Component<{ data: unknown }>;
 			case 'OpenSearchIssue':
 				return OpenSearchIssue as Component<{ data: unknown }>;
 			case 'SqlInstanceStateIssue':

--- a/src/routes/dataproduct/issues/query.gql
+++ b/src/routes/dataproduct/issues/query.gql
@@ -67,6 +67,11 @@ query AllIssues($issueType: IssueType) {
 							name
 						}
 					}
+					... on ApplicationRestartLoopIssue {
+						workload {
+							name
+						}
+					}
 					... on OpenSearchIssue {
 						event
 						openSearch {

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelte
@@ -291,14 +291,18 @@
 									</Tag>
 								</Td>
 								<Td>
-									{#if instance.status.message && instance.status.message.toLowerCase() !== instance.status.state.toLowerCase()}
-										{instance.status.message}
-									{:else if instance.status.lastExitReason && instance.restarts > 0 && instance.status.state === 'RUNNING'}
+									{#if instance.status.lastExitReason && instance.restarts > 0}
 										<span class="exit-info">
 											Last exit: {instance.status
 												.lastExitReason}{#if instance.status.lastExitCode !== null && instance.status.lastExitCode !== undefined}
-												(code {instance.status.lastExitCode}){/if}
+												(code {instance.status
+													.lastExitCode}){/if}{#if instance.status.lastExitTimestamp}, <Time
+													time={instance.status.lastExitTimestamp}
+													distance
+												/>{/if}
 										</span>
+									{:else if instance.status.message && instance.status.message.toLowerCase() !== instance.status.state.toLowerCase()}
+										{instance.status.message}
 									{:else}
 										<span class="muted">-</span>
 									{/if}

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/query.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/query.gql
@@ -91,6 +91,7 @@ query InstanceGroupDetail($app: String!, $team: Slug!, $env: String!) @cache(pol
 							ready
 							lastExitReason
 							lastExitCode
+							lastExitTimestamp
 						}
 						created
 						memory: instanceUtilization(resourceType: MEMORY) {


### PR DESCRIPTION
## Summary

- Fix bug where Message column always showed "Running and ready." for instances with restarts, hiding the exit reason
- Show exit info (reason, code, timestamp) first when an instance has restarts
- Add `lastExitTimestamp` to the instance status query to show how recently the last restart occurred
- Update schema from API to include `lastExitTimestamp` field and `APPLICATION_RESTART_LOOP` issue type

Depends on nais/api#399