### PR TITLE
feat(instancegroup): use NAIS source kind, drop YAML heuristic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,7 @@
 			"integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -208,7 +209,7 @@
 		},
 		"node_modules/@clack/prompts/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
-			"dev": true,
+			"extraneous": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -236,7 +237,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
 			"integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
@@ -263,7 +263,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
 			"integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
 			}
@@ -285,7 +284,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.40.0.tgz",
 			"integrity": "sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.6.0",
 				"crelt": "^1.0.6",
@@ -1428,15 +1426,13 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.0.tgz",
 			"integrity": "sha512-PNGcolp9hr4PJdXR4ix7XtixDrClScvtSCYW3rQG106oVMOOI+jFb+0+J3mbeL/53g1Zd6s0kJzaw6Ri68GmAA==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@lezer/highlight": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
 			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@lezer/common": "^1.3.0"
 			}
@@ -1446,7 +1442,6 @@
 			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.6.tgz",
 			"integrity": "sha512-u42yGuGBsHgodm86lwi0HAtUTNSs23yl9RoaI5em90B+OGm9/XuWkNiJ46sKkCgp8Tp4zgoBQbepcshfKLhFdw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@lezer/common": "^1.0.0"
 			}
@@ -2698,7 +2693,6 @@
 			"integrity": "sha512-dtdb26HMwKu+ToxQ2+KscbB0ytdoYcF1ziQOmkxryJyQ10Qe5/0D5xJAhuU4sIu8hShUfhRl1ONqGe5rBfk6Jw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ts-dedent": "^2.0.0",
 				"type-fest": "~2.19"
@@ -2801,7 +2795,6 @@
 			"integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -2844,7 +2837,6 @@
 			"integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"deepmerge": "^4.3.1",
@@ -3592,7 +3584,8 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/braces": {
 			"version": "3.0.5",
@@ -3785,7 +3778,6 @@
 			"integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.57.2",
 				"@typescript-eslint/types": "8.57.2",
@@ -4342,7 +4334,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4593,7 +4584,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -5189,7 +5179,8 @@
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/d3-array": {
 			"version": "3.2.4",
@@ -5693,7 +5684,8 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/dset": {
 			"version": "3.1.4",
@@ -5885,7 +5877,6 @@
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -5950,7 +5941,6 @@
 			"integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
@@ -6866,7 +6856,6 @@
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
 			"integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
 			}
@@ -9073,7 +9062,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -9207,7 +9195,6 @@
 			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -9224,7 +9211,6 @@
 			"integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -9327,6 +9313,7 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -9342,6 +9329,7 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -9462,7 +9450,6 @@
 			"integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9473,7 +9460,6 @@
 			"integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -9486,7 +9472,8 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/read-cmd-shim": {
 			"version": "4.0.0",
@@ -9724,7 +9711,6 @@
 			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -10182,7 +10168,6 @@
 			"integrity": "sha512-tMoRAts9EVqf+mEMPLC6z1DPyHbcPe+CV1MhLN55IKsl0HxNjvVGK44rVPSePbltPE6vIsn4bdRj6CCUt8SJwQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@storybook/global": "^5.0.0",
 				"@storybook/icons": "^2.0.1",
@@ -10381,7 +10366,6 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.0.tgz",
 			"integrity": "sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -11001,7 +10985,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -11194,7 +11177,6 @@
 			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelte
@@ -22,7 +22,6 @@
 	import type { PageProps } from './$types';
 	import type { ValueEncoding$options } from '$houdini';
 	import { ValueEncoding } from '$houdini';
-	import { parse as parseYaml } from 'yaml';
 	import EnvironmentVariables from './EnvironmentVariables.svelte';
 	import MountedFiles from './MountedFiles.svelte';
 
@@ -41,24 +40,6 @@
 	const application = $derived($InstanceGroupDetail.data?.team.environment.application);
 	const allGroups = $derived(application?.instanceGroups ?? []);
 	const viewerIsMember = $derived($InstanceGroupDetail.data?.team.viewerIsMember ?? false);
-
-	// Parse manifest to extract user-defined env var names from spec.env
-	const specEnvNames = $derived.by(() => {
-		const content = application?.manifest?.content;
-		if (!content) return new Set<string>();
-		try {
-			const doc = parseYaml(content);
-			const envList = doc?.spec?.env;
-			if (!Array.isArray(envList)) return new Set<string>();
-			return new Set<string>(
-				envList
-					.map((e: { name?: string }) => e.name)
-					.filter((n): n is string => typeof n === 'string')
-			);
-		} catch {
-			return new Set<string>();
-		}
-	});
 
 	// Determine if this group is "current" or "incoming"
 	const incoming = $derived(
@@ -468,7 +449,6 @@
 
 		<EnvironmentVariables
 			envVars={visibleEnvVars}
-			{specEnvNames}
 			{viewerIsMember}
 			{revealedValues}
 			onReveal={(secretName) => {

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/EnvironmentVariables.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/EnvironmentVariables.svelte
@@ -19,15 +19,13 @@
 
 	interface Props {
 		envVars: EnvironmentVariable[];
-		specEnvNames: Set<string>;
 		viewerIsMember: boolean;
 		revealedValues: SvelteMap<string, string>;
 		onReveal: (secretName: string) => void;
 		onHideAll: () => void;
 	}
 
-	let { envVars, specEnvNames, viewerIsMember, revealedValues, onReveal, onHideAll }: Props =
-		$props();
+	let { envVars, viewerIsMember, revealedValues, onReveal, onHideAll }: Props = $props();
 
 	const hasSecrets = $derived(envVars.some((e) => e.source.kind === 'SECRET'));
 </script>
@@ -83,14 +81,15 @@
 						</Td>
 						<Td>
 							<span class="source">
-								{env.source.kind === 'SPEC'
-									? specEnvNames.has(env.name)
-										? 'Application manifest'
-										: 'Nais'
+								{env.source.kind === 'SECRET'
+									? 'Secret'
 									: env.source.kind === 'CONFIG'
-										? 'ConfigMap'
-										: 'Secret'}
-								{#if env.source.kind !== 'SPEC' && env.source.name}/ {env.source.name}{/if}
+										? 'Config'
+										: env.source.kind === 'SPEC'
+											? 'Application manifest'
+											: 'Nais'}
+								{#if (env.source.kind === 'SECRET' || env.source.kind === 'CONFIG') && env.source.name}/
+									{env.source.name}{/if}
 							</span>
 						</Td>
 					</Tr>

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/MountedFiles.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/MountedFiles.svelte
@@ -38,10 +38,12 @@
 						<Td>
 							<span class="source">
 								{file.source.kind === 'CONFIG'
-									? 'ConfigMap'
+									? 'Config'
 									: file.source.kind === 'SECRET'
 										? 'Secret'
-										: 'Spec'}
+										: file.source.kind === 'SPEC'
+											? 'Application manifest'
+											: 'Nais'}
 								{#if file.source.name}/ {file.source.name}{/if}
 							</span>
 						</Td>

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/query.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/query.gql
@@ -12,9 +12,6 @@ query InstanceGroupDetail($app: String!, $team: Slug!, $env: String!) @cache(pol
 						name
 					}
 				}
-				manifest {
-					content
-				}
 				resources {
 					scaling {
 						maxInstances


### PR DESCRIPTION
## Summary

Adopts the new `NAIS` value in `InstanceGroupValueSourceKind` (nais/api #402) and removes the YAML-parsing heuristic previously used to guess whether env vars came from the application manifest.

## Changes

- `query.gql`: drop `manifest { content }` — no longer needed
- `+page.svelte`: drop yaml import, `specEnvNames` computation, and prop threading
- `EnvironmentVariables.svelte`: switch on `kind` directly; render SPEC as "Application manifest", NAIS as "Nais"; "ConfigMap" → "Config" in labels
- `MountedFiles.svelte`: same treatment for mounted files
- `package-lock.json`: fresh install

## Verification

All pre-commit checks pass:
- `npm run lockfile-lint` ✅
- `npx svelte-kit sync` ✅
- `npm run check` (0 errors, 0 warnings) ✅
- `npm run lint` ✅
- `npm run test -- --run` (196/196) ✅
- `helm lint --strict ./charts` ✅