### PR TITLE
feat/job overview layout and vulnerability parity

### DIFF
--- a/src/routes/team/[team]/[env]/app/[app]/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/+page.svelte
@@ -117,7 +117,7 @@
 				{/if}
 				<div style="display:flex; flex-direction: column; gap: var(--ax-space-16);">
 					<div class="instances-header">
-						<Heading as="h3" size="medium">Instances</Heading>
+						<Heading as="h3" size="medium">Instance groups</Heading>
 						{#if viewerIsMember}
 							<Button
 								variant="secondary"

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.ts
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.ts
@@ -5,7 +5,7 @@ export async function load(event) {
 	return {
 		instanceGroupName: event.params.instancegroup,
 		...(await addPageMeta(event, {
-			title: `Instance Group: ${event.params.instancegroup}`
+			title: `${event.params.instancegroup}`
 		})),
 		...(await load_InstanceGroupDetail({
 			event,

--- a/src/routes/team/[team]/[env]/job/[job]/+page.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/+page.svelte
@@ -8,7 +8,6 @@
 	import Configs from '$lib/domain/resources/Configs.svelte';
 	import NetworkPolicy from '$lib/domain/resources/NetworkPolicy.svelte';
 	import Secrets from '$lib/domain/resources/Secrets.svelte';
-	import WorkloadVulnerabilitySummary from '$lib/domain/vulnerability/WorkloadVulnerabilitySummary.svelte';
 	import WorkloadDeploy from '$lib/domain/workload/WorkloadDeploy.svelte';
 	import Confirm from '$lib/ui/Confirm.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
@@ -143,6 +142,14 @@
 						</List>
 					</div>
 				{/if}
+				<Schedule
+					schedule={job.schedule}
+					scheduleContext={{
+						team: job.team.slug,
+						environment: job.teamEnvironment.environment.name,
+						job: job.name
+					}}
+				/>
 				<div style="display:flex; flex-direction: column; gap:0.5rem;">
 					<div class="runs-header">
 						<Heading as="h2" size="medium">Runs</Heading>
@@ -176,26 +183,14 @@
 				</div>
 			</div>
 			<div class="sidebar">
-				<Schedule
-					schedule={job.schedule}
-					scheduleContext={{
-						team: job.team.slug,
-						environment: job.teamEnvironment.environment.name,
-						job: job.name
-					}}
-				/>
 				{#if jobName && environment}
 					<AggregatedCostForWorkload workload={jobName} {environment} {teamSlug} />
 				{/if}
-				<div>
-					<Heading as="h2" size="small">Vulnerabilities</Heading>
-					<WorkloadVulnerabilitySummary workload={job} />
-				</div>
 				{#if jobName && environment}
 					<Configs workload={jobName} {environment} {teamSlug} />
 					<Secrets workload={jobName} {environment} {teamSlug} />
 				{/if}
-				<SidebarActivity activityLog={job} />
+				<SidebarActivity activityLog={job} direct={job.activityLog} />
 			</div>
 		</div>
 

--- a/src/routes/team/[team]/[env]/job/[job]/Schedule.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/Schedule.svelte
@@ -21,11 +21,15 @@
 			{#if runConfig.error}
 				<p style="color: red;">Error: {runConfig.error}</p>
 			{:else}
-				<dl style="margin: 0">
-					<dt>Schedule</dt>
-					<dd style="margin: 0">{runConfig.description}</dd>
-					<dt>Next run</dt>
-					<dd style="margin: 0">{runConfig.nextRun}</dd>
+				<dl class="details-grid">
+					<div class="details-item">
+						<dt>Schedule</dt>
+						<dd>{runConfig.description}</dd>
+					</div>
+					<div class="details-item">
+						<dt>Next run</dt>
+						<dd>{runConfig.nextRun}</dd>
+					</div>
 				</dl>
 			{/if}
 		{:else}
@@ -42,6 +46,29 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--ax-space-4);
-		align-items: start;
+		width: 100%;
+	}
+
+	.details-grid {
+		margin: 0;
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 1rem;
+		width: 100%;
+	}
+
+	.details-item {
+		display: grid;
+		gap: var(--ax-space-2);
+	}
+
+	dd {
+		margin: 0;
+	}
+
+	@media (max-width: 800px) {
+		.details-grid {
+			grid-template-columns: 1fr;
+		}
 	}
 </style>

--- a/src/routes/team/[team]/[env]/job/[job]/Schedule.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/Schedule.svelte
@@ -22,14 +22,10 @@
 				<p style="color: red;">Error: {runConfig.error}</p>
 			{:else}
 				<dl class="details-grid">
-					<div class="details-item">
-						<dt>Schedule</dt>
-						<dd>{runConfig.description}</dd>
-					</div>
-					<div class="details-item">
-						<dt>Next run</dt>
-						<dd>{runConfig.nextRun}</dd>
-					</div>
+					<dt>Schedule</dt>
+					<dd>{runConfig.description}</dd>
+					<dt>Next run</dt>
+					<dd>{runConfig.nextRun}</dd>
 				</dl>
 			{/if}
 		{:else}
@@ -57,9 +53,24 @@
 		width: 100%;
 	}
 
-	.details-item {
-		display: grid;
-		gap: var(--ax-space-2);
+	.details-grid dt:nth-of-type(1) {
+		grid-column: 1;
+		grid-row: 1;
+	}
+
+	.details-grid dd:nth-of-type(1) {
+		grid-column: 1;
+		grid-row: 2;
+	}
+
+	.details-grid dt:nth-of-type(2) {
+		grid-column: 2;
+		grid-row: 1;
+	}
+
+	.details-grid dd:nth-of-type(2) {
+		grid-column: 2;
+		grid-row: 2;
 	}
 
 	dd {
@@ -69,6 +80,12 @@
 	@media (max-width: 800px) {
 		.details-grid {
 			grid-template-columns: 1fr;
+		}
+
+		.details-grid dt,
+		.details-grid dd {
+			grid-column: auto;
+			grid-row: auto;
 		}
 	}
 </style>

--- a/src/routes/team/[team]/[env]/job/[job]/Schedule.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/Schedule.svelte
@@ -48,29 +48,10 @@
 	.details-grid {
 		margin: 0;
 		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: 1rem;
+		grid-template-rows: repeat(2, auto);
+		grid-auto-flow: column;
+		grid-auto-columns: 1fr;
 		width: 100%;
-	}
-
-	.details-grid dt:nth-of-type(1) {
-		grid-column: 1;
-		grid-row: 1;
-	}
-
-	.details-grid dd:nth-of-type(1) {
-		grid-column: 1;
-		grid-row: 2;
-	}
-
-	.details-grid dt:nth-of-type(2) {
-		grid-column: 2;
-		grid-row: 1;
-	}
-
-	.details-grid dd:nth-of-type(2) {
-		grid-column: 2;
-		grid-row: 2;
 	}
 
 	dd {
@@ -79,13 +60,9 @@
 
 	@media (max-width: 800px) {
 		.details-grid {
-			grid-template-columns: 1fr;
-		}
-
-		.details-grid dt,
-		.details-grid dd {
-			grid-column: auto;
-			grid-row: auto;
+			grid-template-rows: none;
+			grid-auto-flow: row;
+			grid-auto-columns: auto;
 		}
 	}
 </style>

--- a/src/routes/team/[team]/[env]/job/[job]/query.gql
+++ b/src/routes/team/[team]/[env]/job/[job]/query.gql
@@ -9,18 +9,6 @@ query Job($job: String!, $team: Slug!, $env: String!) @cache(policy: NetworkOnly
 				team {
 					slug
 				}
-				image {
-					hasSBOM
-					vulnerabilitySummary {
-						critical
-						high
-						medium
-						low
-						unassigned
-						riskScore
-						lastUpdated
-					}
-				}
 				issues {
 					edges {
 						node {
@@ -51,7 +39,7 @@ query Job($job: String!, $team: Slug!, $env: String!) @cache(policy: NetworkOnly
 					}
 				}
 
-				...SidebarActivityLogFragment
+				...SidebarActivityLogFragment @with(limit: 20) @mask_disable
 				...JobRuns
 				...Persistence
 				...WorkloadDeploy


### PR DESCRIPTION
## Summary
This PR aligns App and Job overview pages around a signal-first layout and removes now-unused vulnerability summary data from the Job overview query.

## What changed
- App overview:
  - Renamed section heading from "Instances" to "Instance groups".
  - Simplified instance group page title to use only the instance group name.
- Job overview:
  - Moved Run Configuration from the sidebar into the main content area.
  - Placed Run Configuration above Runs for better flow (configure, then execute/history).
  - Updated Run Configuration layout so Schedule and Next run are shown as two aligned columns (desktop) and stacked on small screens.
  - Removed vulnerability summary panel from the overview page.
  - Kept sidebar activity parity by passing direct activity log data.
- Job query:
  - Removed `image.hasSBOM` and `image.vulnerabilitySummary` from the overview query because they are no longer rendered there.
  - Kept activity log fragment with `@with(limit: 20) @mask_disable` parity.

## Why
- Reduce visual noise on overview pages.
- Keep App and Job overview information hierarchy consistent.
- Avoid fetching data that is not used in the overview UI.

## Verification
- `npm run check` passes (Houdini generation + svelte-check).

## Notes
- Vulnerability visibility on overview pages now relies on issues surfaced there.
- Detailed vulnerability data remains available on dedicated vulnerability pages.
