### PR TITLE
fix: make page header menu items clickable

### DIFF
--- a/src/lib/doc.ts
+++ b/src/lib/doc.ts
@@ -10,7 +10,7 @@ export const docURL = (path: string = '') => {
 };
 
 export const tenantURL = (host: string, path: string = '') => {
-	const tn = page.data.tenantName;
+	const tn = page.data.tenantName || 'nav';
 
 	return `https://${host}.${tn}.cloud.nais.io${path}`;
 };

--- a/src/lib/ui/HeaderActionMenuItem.svelte
+++ b/src/lib/ui/HeaderActionMenuItem.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import type { Component, Snippet } from 'svelte';
+	import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
 
-	interface Props {
+	type Props = {
 		href?: string;
 		icon?: Component;
 		active?: boolean;
@@ -10,7 +11,9 @@
 		ariaCurrent?: 'page';
 		onSelect?: (event: MouseEvent) => void;
 		children: Snippet;
-	}
+		class?: string;
+	} & HTMLAnchorAttributes &
+		HTMLButtonAttributes;
 
 	let {
 		href,
@@ -20,7 +23,9 @@
 		rel,
 		ariaCurrent,
 		onSelect,
-		children
+		children,
+		class: className,
+		...restProps
 	}: Props = $props();
 </script>
 
@@ -31,9 +36,15 @@
 		{rel}
 		role="menuitem"
 		data-marker={icon ? 'left' : undefined}
-		class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+		class={[
+			'ds-svelte-action-menu__item',
+			'aksel-action-menu__item',
+			'header-action-menu-item',
+			className
+		]}
 		aria-current={ariaCurrent}
 		onclick={onSelect}
+		{...restProps}
 	>
 		<span class="action-menu-label" style:font-weight={active ? 'bold' : 'normal'}>
 			{@render children()}
@@ -50,8 +61,14 @@
 		type="button"
 		role="menuitem"
 		data-marker={icon ? 'left' : undefined}
-		class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+		class={[
+			'ds-svelte-action-menu__item',
+			'aksel-action-menu__item',
+			'header-action-menu-item',
+			className
+		]}
 		onclick={onSelect}
+		{...restProps}
 	>
 		<span class="action-menu-label" style:font-weight={active ? 'bold' : 'normal'}>
 			{@render children()}

--- a/src/lib/ui/HeaderActionMenuItem.svelte
+++ b/src/lib/ui/HeaderActionMenuItem.svelte
@@ -23,14 +23,21 @@
 		rel,
 		ariaCurrent,
 		onSelect,
+		onclick: rawOnclick,
 		children,
 		class: className,
 		...restProps
 	}: Props = $props();
+
+	function handleClick(event: MouseEvent) {
+		onSelect?.(event);
+		(rawOnclick as ((event: MouseEvent) => void) | undefined)?.(event);
+	}
 </script>
 
 {#if href}
 	<a
+		{...restProps}
 		{href}
 		{target}
 		{rel}
@@ -43,8 +50,7 @@
 			className
 		]}
 		aria-current={ariaCurrent}
-		onclick={onSelect}
-		{...restProps}
+		onclick={handleClick}
 	>
 		<span class="action-menu-label" style:font-weight={active ? 'bold' : 'normal'}>
 			{@render children()}
@@ -58,6 +64,7 @@
 	</a>
 {:else}
 	<button
+		{...restProps}
 		type="button"
 		role="menuitem"
 		data-marker={icon ? 'left' : undefined}
@@ -67,8 +74,7 @@
 			'header-action-menu-item',
 			className
 		]}
-		onclick={onSelect}
-		{...restProps}
+		onclick={handleClick}
 	>
 		<span class="action-menu-label" style:font-weight={active ? 'bold' : 'normal'}>
 			{@render children()}

--- a/src/lib/ui/HeaderActionMenuItem.svelte
+++ b/src/lib/ui/HeaderActionMenuItem.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import type { Component, Snippet } from 'svelte';
+
+	interface Props {
+		href?: string;
+		icon?: Component;
+		active?: boolean;
+		target?: string;
+		rel?: string;
+		ariaCurrent?: 'page';
+		onSelect?: (event: MouseEvent) => void;
+		children: Snippet;
+	}
+
+	let {
+		href,
+		icon,
+		active = false,
+		target,
+		rel,
+		ariaCurrent,
+		onSelect,
+		children
+	}: Props = $props();
+</script>
+
+{#if href}
+	<a
+		{href}
+		{target}
+		{rel}
+		role="menuitem"
+		data-marker={icon ? 'left' : undefined}
+		class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+		aria-current={ariaCurrent}
+		onclick={onSelect}
+	>
+		<span class="action-menu-label" style:font-weight={active ? 'bold' : 'normal'}>
+			{@render children()}
+		</span>
+		{#if icon}
+			{@const Icon = icon}
+			<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+				<Icon />
+			</div>
+		{/if}
+	</a>
+{:else}
+	<button
+		type="button"
+		role="menuitem"
+		data-marker={icon ? 'left' : undefined}
+		class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+		onclick={onSelect}
+	>
+		<span class="action-menu-label" style:font-weight={active ? 'bold' : 'normal'}>
+			{@render children()}
+		</span>
+		{#if icon}
+			{@const Icon = icon}
+			<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+				<Icon />
+			</div>
+		{/if}
+	</button>
+{/if}
+
+<style>
+	.action-menu-label {
+		color: var(--ax-text-neutral);
+		display: inline-flex;
+		align-items: center;
+		gap: var(--ax-space-2);
+	}
+
+	.header-action-menu-item {
+		width: 100%;
+		box-sizing: border-box;
+		background: transparent;
+		border: none;
+		color: inherit;
+		text-decoration: none;
+		text-align: left;
+		font: inherit;
+		cursor: pointer;
+	}
+</style>

--- a/src/routes/PageHeader.svelte
+++ b/src/routes/PageHeader.svelte
@@ -54,6 +54,14 @@
 	function isActive(pathname: string) {
 		return page.url.pathname === pathname || page.url.pathname.startsWith(pathname + '/');
 	}
+
+	function closeMenu(event: Event) {
+		const popover = (event.currentTarget as HTMLElement | null)?.closest('[popover]') as
+			| (HTMLElement & { hidePopover?: () => void })
+			| null;
+
+		popover?.hidePopover?.();
+	}
 </script>
 
 <InternalHeader>
@@ -86,6 +94,7 @@
 					role="menuitem"
 					class={headerActionMenuItemClass}
 					aria-current={isActive(item.href) ? 'page' : undefined}
+					onclick={closeMenu}
 				>
 					<span
 						class="action-menu-label"
@@ -103,7 +112,10 @@
 				role="menuitem"
 				data-marker="left"
 				class={headerActionMenuItemClass}
-				onclick={() => (feedbackOpen = true)}
+				onclick={(event) => {
+					closeMenu(event);
+					feedbackOpen = true;
+				}}
 			>
 				<span class="action-menu-label">Feedback</span>
 				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
@@ -144,6 +156,7 @@
 				role="menuitem"
 				data-marker="left"
 				class={headerActionMenuItemClass}
+				onclick={closeMenu}
 			>
 				<span class="action-menu-label">Docs <ExternalLinkIcon /></span>
 				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
@@ -157,6 +170,7 @@
 				role="menuitem"
 				data-marker="left"
 				class={headerActionMenuItemClass}
+				onclick={closeMenu}
 			>
 				<span class="action-menu-label">Grafana <ExternalLinkIcon /></span>
 				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
@@ -171,7 +185,13 @@
 		{/snippet}
 
 		{#if user?.isAdmin}
-			<a href="/admin" role="menuitem" data-marker="left" class={headerActionMenuItemClass}>
+			<a
+				href="/admin"
+				role="menuitem"
+				data-marker="left"
+				class={headerActionMenuItemClass}
+				onclick={closeMenu}
+			>
 				<span class="action-menu-label">Admin</span>
 				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
 					<CogIcon />
@@ -191,7 +211,13 @@
 		>
 			Dark theme
 		</ActionMenuCheckboxItem>
-		<a href="/oauth2/logout" role="menuitem" data-marker="left" class={headerActionMenuItemClass}>
+		<a
+			href="/oauth2/logout"
+			role="menuitem"
+			data-marker="left"
+			class={headerActionMenuItemClass}
+			onclick={closeMenu}
+		>
 			<span class="action-menu-label">Logout</span>
 			<div aria-hidden="true" class={headerActionMenuMarkerClass}>
 				<LeaveIcon />

--- a/src/routes/PageHeader.svelte
+++ b/src/routes/PageHeader.svelte
@@ -47,6 +47,10 @@
 		{ href: '/deployments', label: 'Deployments' }
 	];
 
+	const headerActionMenuItemClass =
+		'ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item';
+	const headerActionMenuMarkerClass = 'aksel-action-menu__marker aksel-action-menu__marker--left';
+
 	function isActive(pathname: string) {
 		return page.url.pathname === pathname || page.url.pathname.startsWith(pathname + '/');
 	}
@@ -80,8 +84,7 @@
 				<a
 					href={item.href}
 					role="menuitem"
-					tabindex="0"
-					class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+					class={headerActionMenuItemClass}
 					aria-current={isActive(item.href) ? 'page' : undefined}
 				>
 					<span
@@ -98,13 +101,12 @@
 			<button
 				type="button"
 				role="menuitem"
-				tabindex="0"
 				data-marker="left"
-				class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+				class={headerActionMenuItemClass}
 				onclick={() => (feedbackOpen = true)}
 			>
 				<span class="action-menu-label">Feedback</span>
-				<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
 					<ChatElipsisIcon />
 				</div>
 			</button>
@@ -140,12 +142,11 @@
 				target="_blank"
 				rel="noopener noreferrer"
 				role="menuitem"
-				tabindex="0"
 				data-marker="left"
-				class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+				class={headerActionMenuItemClass}
 			>
 				<span class="action-menu-label">Docs <ExternalLinkIcon /></span>
-				<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
 					<BooksIcon />
 				</div>
 			</a>
@@ -154,12 +155,11 @@
 				target="_blank"
 				rel="noopener noreferrer"
 				role="menuitem"
-				tabindex="0"
 				data-marker="left"
-				class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+				class={headerActionMenuItemClass}
 			>
 				<span class="action-menu-label">Grafana <ExternalLinkIcon /></span>
-				<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
 					<GrafanaIcon />
 				</div>
 			</a>
@@ -171,15 +171,9 @@
 		{/snippet}
 
 		{#if user?.isAdmin}
-			<a
-				href="/admin"
-				role="menuitem"
-				tabindex="0"
-				data-marker="left"
-				class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
-			>
+			<a href="/admin" role="menuitem" data-marker="left" class={headerActionMenuItemClass}>
 				<span class="action-menu-label">Admin</span>
-				<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
 					<CogIcon />
 				</div>
 			</a>
@@ -197,15 +191,9 @@
 		>
 			Dark theme
 		</ActionMenuCheckboxItem>
-		<a
-			href="/oauth2/logout"
-			role="menuitem"
-			tabindex="0"
-			data-marker="left"
-			class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
-		>
+		<a href="/oauth2/logout" role="menuitem" data-marker="left" class={headerActionMenuItemClass}>
 			<span class="action-menu-label">Logout</span>
-			<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+			<div aria-hidden="true" class={headerActionMenuMarkerClass}>
 				<LeaveIcon />
 			</div>
 		</a>

--- a/src/routes/PageHeader.svelte
+++ b/src/routes/PageHeader.svelte
@@ -177,7 +177,12 @@
 		>
 			Dark theme
 		</ActionMenuCheckboxItem>
-		<HeaderActionMenuItem href="/oauth2/logout" icon={LeaveIcon} onSelect={closeMenu}>
+		<HeaderActionMenuItem
+			href="/oauth2/logout"
+			icon={LeaveIcon}
+			onSelect={closeMenu}
+			data-sveltekit-reload
+		>
 			Logout
 		</HeaderActionMenuItem>
 	</ActionMenu>

--- a/src/routes/PageHeader.svelte
+++ b/src/routes/PageHeader.svelte
@@ -5,6 +5,7 @@
 	import Feedback from '$lib/feedback/Feedback.svelte';
 	import GrafanaIcon from '$lib/icons/GrafanaIcon.svelte';
 	import { themeSwitch } from '$lib/stores/theme.svelte';
+	import HeaderActionMenuItem from '$lib/ui/HeaderActionMenuItem.svelte';
 	import { Button, Spacer } from '@nais/ds-svelte-community';
 	import {
 		ActionMenu,
@@ -47,10 +48,6 @@
 		{ href: '/deployments', label: 'Deployments' }
 	];
 
-	const headerActionMenuItemClass =
-		'ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item';
-	const headerActionMenuMarkerClass = 'aksel-action-menu__marker aksel-action-menu__marker--left';
-
 	function isActive(pathname: string) {
 		return page.url.pathname === pathname || page.url.pathname.startsWith(pathname + '/');
 	}
@@ -89,39 +86,27 @@
 		{/snippet}
 		<ActionMenuGroup label="Navigation">
 			{#each navItems as item (item.href)}
-				<a
+				<HeaderActionMenuItem
 					href={item.href}
-					role="menuitem"
-					class={headerActionMenuItemClass}
-					aria-current={isActive(item.href) ? 'page' : undefined}
-					onclick={closeMenu}
+					active={isActive(item.href)}
+					ariaCurrent={isActive(item.href) ? 'page' : undefined}
+					onSelect={closeMenu}
 				>
-					<span
-						class="action-menu-label"
-						style:font-weight={isActive(item.href) ? 'bold' : 'normal'}
-					>
-						{item.label}
-					</span>
-				</a>
+					{item.label}
+				</HeaderActionMenuItem>
 			{/each}
 		</ActionMenuGroup>
 		<ActionMenuDivider />
 		<ActionMenuGroup label="Tools">
-			<button
-				type="button"
-				role="menuitem"
-				data-marker="left"
-				class={headerActionMenuItemClass}
-				onclick={(event) => {
+			<HeaderActionMenuItem
+				icon={ChatElipsisIcon}
+				onSelect={(event) => {
 					closeMenu(event);
 					feedbackOpen = true;
 				}}
 			>
-				<span class="action-menu-label">Feedback</span>
-				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
-					<ChatElipsisIcon />
-				</div>
-			</button>
+				Feedback
+			</HeaderActionMenuItem>
 		</ActionMenuGroup>
 	</ActionMenu>
 
@@ -149,34 +134,24 @@
 			</InternalHeaderButton>
 		{/snippet}
 		<ActionMenuGroup label="Nais resources">
-			<a
+			<HeaderActionMenuItem
 				href={docURL()}
 				target="_blank"
 				rel="noopener noreferrer"
-				role="menuitem"
-				data-marker="left"
-				class={headerActionMenuItemClass}
-				onclick={closeMenu}
+				icon={BooksIcon}
+				onSelect={closeMenu}
 			>
-				<span class="action-menu-label">Docs <ExternalLinkIcon /></span>
-				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
-					<BooksIcon />
-				</div>
-			</a>
-			<a
+				Docs <ExternalLinkIcon />
+			</HeaderActionMenuItem>
+			<HeaderActionMenuItem
 				href={tenantURL('grafana')}
 				target="_blank"
 				rel="noopener noreferrer"
-				role="menuitem"
-				data-marker="left"
-				class={headerActionMenuItemClass}
-				onclick={closeMenu}
+				icon={GrafanaIcon}
+				onSelect={closeMenu}
 			>
-				<span class="action-menu-label">Grafana <ExternalLinkIcon /></span>
-				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
-					<GrafanaIcon />
-				</div>
-			</a>
+				Grafana <ExternalLinkIcon />
+			</HeaderActionMenuItem>
 		</ActionMenuGroup>
 	</ActionMenu>
 	<ActionMenu>
@@ -185,18 +160,9 @@
 		{/snippet}
 
 		{#if user?.isAdmin}
-			<a
-				href="/admin"
-				role="menuitem"
-				data-marker="left"
-				class={headerActionMenuItemClass}
-				onclick={closeMenu}
-			>
-				<span class="action-menu-label">Admin</span>
-				<div aria-hidden="true" class={headerActionMenuMarkerClass}>
-					<CogIcon />
-				</div>
-			</a>
+			<HeaderActionMenuItem href="/admin" icon={CogIcon} onSelect={closeMenu}>
+				Admin
+			</HeaderActionMenuItem>
 			<ActionMenuDivider />
 		{/if}
 		<ActionMenuCheckboxItem
@@ -211,18 +177,9 @@
 		>
 			Dark theme
 		</ActionMenuCheckboxItem>
-		<a
-			href="/oauth2/logout"
-			role="menuitem"
-			data-marker="left"
-			class={headerActionMenuItemClass}
-			onclick={closeMenu}
-		>
-			<span class="action-menu-label">Logout</span>
-			<div aria-hidden="true" class={headerActionMenuMarkerClass}>
-				<LeaveIcon />
-			</div>
-		</a>
+		<HeaderActionMenuItem href="/oauth2/logout" icon={LeaveIcon} onSelect={closeMenu}>
+			Logout
+		</HeaderActionMenuItem>
 	</ActionMenu>
 </InternalHeader>
 
@@ -302,24 +259,5 @@
 		:global(.mobile-nav-trigger) {
 			display: inline-flex;
 		}
-	}
-
-	.action-menu-label {
-		color: var(--ax-text-neutral);
-		display: inline-flex;
-		align-items: center;
-		gap: var(--ax-space-2);
-	}
-
-	.header-action-menu-item {
-		width: 100%;
-		box-sizing: border-box;
-		background: transparent;
-		border: none;
-		color: inherit;
-		text-decoration: none;
-		text-align: left;
-		font: inherit;
-		cursor: pointer;
 	}
 </style>

--- a/src/routes/PageHeader.svelte
+++ b/src/routes/PageHeader.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { docURL, tenantURL } from '$lib/doc';
 	import SearchButton from '$lib/domain/search/SearchButton.svelte';
@@ -12,7 +11,6 @@
 		ActionMenuCheckboxItem,
 		ActionMenuDivider,
 		ActionMenuGroup,
-		ActionMenuItem,
 		InternalHeader,
 		InternalHeaderButton,
 		InternalHeaderTitle,
@@ -52,22 +50,6 @@
 	function isActive(pathname: string) {
 		return page.url.pathname === pathname || page.url.pathname.startsWith(pathname + '/');
 	}
-
-	function navigateTo(pathname: string) {
-		void goto(pathname);
-	}
-
-	function openExternal(url: string) {
-		if (typeof window !== 'undefined') {
-			window.open(url, '_blank', 'noopener,noreferrer');
-		}
-	}
-
-	function logout() {
-		if (typeof window !== 'undefined') {
-			window.location.assign('/oauth2/logout');
-		}
-	}
 </script>
 
 <InternalHeader>
@@ -95,21 +77,37 @@
 		{/snippet}
 		<ActionMenuGroup label="Navigation">
 			{#each navItems as item (item.href)}
-				<ActionMenuItem onSelect={() => navigateTo(item.href)}>
+				<a
+					href={item.href}
+					role="menuitem"
+					tabindex="0"
+					class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+					aria-current={isActive(item.href) ? 'page' : undefined}
+				>
 					<span
 						class="action-menu-label"
 						style:font-weight={isActive(item.href) ? 'bold' : 'normal'}
 					>
 						{item.label}
 					</span>
-				</ActionMenuItem>
+				</a>
 			{/each}
 		</ActionMenuGroup>
 		<ActionMenuDivider />
 		<ActionMenuGroup label="Tools">
-			<ActionMenuItem icon={ChatElipsisIcon} onSelect={() => (feedbackOpen = true)}>
+			<button
+				type="button"
+				role="menuitem"
+				tabindex="0"
+				data-marker="left"
+				class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+				onclick={() => (feedbackOpen = true)}
+			>
 				<span class="action-menu-label">Feedback</span>
-			</ActionMenuItem>
+				<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+					<ChatElipsisIcon />
+				</div>
+			</button>
 		</ActionMenuGroup>
 	</ActionMenu>
 
@@ -137,12 +135,34 @@
 			</InternalHeaderButton>
 		{/snippet}
 		<ActionMenuGroup label="Nais resources">
-			<ActionMenuItem icon={BooksIcon} onSelect={() => openExternal(docURL())}>
+			<a
+				href={docURL()}
+				target="_blank"
+				rel="noopener noreferrer"
+				role="menuitem"
+				tabindex="0"
+				data-marker="left"
+				class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+			>
 				<span class="action-menu-label">Docs <ExternalLinkIcon /></span>
-			</ActionMenuItem>
-			<ActionMenuItem icon={GrafanaIcon} onSelect={() => openExternal(tenantURL('grafana'))}>
+				<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+					<BooksIcon />
+				</div>
+			</a>
+			<a
+				href={tenantURL('grafana')}
+				target="_blank"
+				rel="noopener noreferrer"
+				role="menuitem"
+				tabindex="0"
+				data-marker="left"
+				class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+			>
 				<span class="action-menu-label">Grafana <ExternalLinkIcon /></span>
-			</ActionMenuItem>
+				<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+					<GrafanaIcon />
+				</div>
+			</a>
 		</ActionMenuGroup>
 	</ActionMenu>
 	<ActionMenu>
@@ -151,9 +171,18 @@
 		{/snippet}
 
 		{#if user?.isAdmin}
-			<ActionMenuItem icon={CogIcon} onSelect={() => navigateTo('/admin')}>
+			<a
+				href="/admin"
+				role="menuitem"
+				tabindex="0"
+				data-marker="left"
+				class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+			>
 				<span class="action-menu-label">Admin</span>
-			</ActionMenuItem>
+				<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+					<CogIcon />
+				</div>
+			</a>
 			<ActionMenuDivider />
 		{/if}
 		<ActionMenuCheckboxItem
@@ -168,9 +197,18 @@
 		>
 			Dark theme
 		</ActionMenuCheckboxItem>
-		<ActionMenuItem icon={LeaveIcon} onSelect={logout}>
+		<a
+			href="/oauth2/logout"
+			role="menuitem"
+			tabindex="0"
+			data-marker="left"
+			class="ds-svelte-action-menu__item aksel-action-menu__item header-action-menu-item"
+		>
 			<span class="action-menu-label">Logout</span>
-		</ActionMenuItem>
+			<div aria-hidden="true" class="aksel-action-menu__marker aksel-action-menu__marker--left">
+				<LeaveIcon />
+			</div>
+		</a>
 	</ActionMenu>
 </InternalHeader>
 
@@ -257,5 +295,17 @@
 		display: inline-flex;
 		align-items: center;
 		gap: var(--ax-space-2);
+	}
+
+	.header-action-menu-item {
+		width: 100%;
+		box-sizing: border-box;
+		background: transparent;
+		border: none;
+		color: inherit;
+		text-decoration: none;
+		text-align: left;
+		font: inherit;
+		cursor: pointer;
 	}
 </style>


### PR DESCRIPTION
## What

- replace the non-interactive header `ActionMenuItem` usages in `PageHeader.svelte` with real links and buttons
- keep the existing action-menu styling and active-state presentation
- fix mobile navigation links, feedback action, docs/grafana links, admin, and logout items

## Why

The page header menu looked interactive, but the menu items did not actually trigger navigation/actions. The design-system `ActionMenuItem` used here rendered an inert wrapper, so clicks in the menu did not work.

## Verification

- `npm run check`
- verified the header menu items are now rendered as actual interactive elements
