### PR TITLE
Fix environment variables mobile layout

### DIFF
--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/EnvironmentVariables.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/EnvironmentVariables.svelte
@@ -195,6 +195,28 @@
 			gap: var(--ax-space-8);
 		}
 
+		.table-container {
+			padding-bottom: var(--ax-space-4);
+			overscroll-behavior-x: contain;
+			-webkit-overflow-scrolling: touch;
+		}
+
+		.table-container :global(table) {
+			width: max-content;
+			min-width: 100%;
+		}
+
+		.table-container :global(th.name-column),
+		.table-container :global(td.name-cell),
+		.table-container :global(th.source-column),
+		.table-container :global(td.source-cell) {
+			white-space: nowrap;
+		}
+
+		.table-container :global(td.value-cell) {
+			min-width: 16rem;
+		}
+
 		.table-container :global(th.source-column) {
 			width: 1%;
 		}


### PR DESCRIPTION
## Summary
- make the environment variables table scroll horizontally on small screens
- keep the name and source columns non-wrapping while giving the value column a minimum width on mobile
- avoid the value column collapsing into one-character-per-line wrapping

## Validation
- npm run check