### PR TITLE
Fix repositories filter synchronization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,9 @@ This project uses **Svelte 5 with runes mode** (enforced via `forceRunesMode: tr
 
 - Use `$state()` for reactive state (not `let` with reactivity)
 - Use `$derived()` for computed values (not `$:`)
-- Use `$effect()` for side effects (not `$:` statements)
+- Treat `$effect()` as an escape hatch for browser-side effects such as DOM integration, subscriptions, or external I/O
+- Prefer `$derived()`/`$derived.by()` for derived state and explicit event handlers for input-driven flows like debounced search
+- Do not use `$effect()` to synchronize one piece of state with another unless there is no clearer alternative
 - Use `$props()` for component props with TypeScript types
 
 ### Example:

--- a/src/routes/team/[team]/repositories/+page.svelte
+++ b/src/routes/team/[team]/repositories/+page.svelte
@@ -92,20 +92,10 @@
 	let searchContainer = $state<HTMLDivElement | undefined>(undefined);
 	let pendingFocusedFilter = $state<string | undefined>(undefined);
 
-	const debugSearchFocus = (message: string, details: Record<string, unknown> = {}) => {
-		if (!import.meta.env.DEV) {
-			return;
-		}
-
-		console.debug('[repositories-search-focus]', message, details);
-	};
-
 	const focusSearchField = (attemptsLeft = 4) => {
 		const input = searchContainer?.querySelector<HTMLInputElement>('input[type="search"]');
 
 		if (!input) {
-			debugSearchFocus('input missing', { attemptsLeft, currentFilter, pendingFocusedFilter });
-
 			if (attemptsLeft > 0) {
 				requestAnimationFrame(() => {
 					focusSearchField(attemptsLeft - 1);
@@ -120,16 +110,9 @@
 		input.focus();
 
 		if (document.activeElement === input) {
-			debugSearchFocus('focused input', { attemptsLeft, value: input.value });
 			pendingFocusedFilter = undefined;
 			return;
 		}
-
-		debugSearchFocus('focus not retained', {
-			attemptsLeft,
-			activeElement:
-				document.activeElement instanceof HTMLElement ? document.activeElement.tagName : null
-		});
 
 		if (attemptsLeft > 0) {
 			requestAnimationFrame(() => {
@@ -150,8 +133,6 @@
 		if (requestedFilter === undefined || appliedFilter !== requestedFilter || !container) {
 			return;
 		}
-
-		debugSearchFocus('focus armed', { requestedFilter, appliedFilter });
 
 		requestAnimationFrame(() => {
 			focusSearchField();

--- a/src/routes/team/[team]/repositories/+page.svelte
+++ b/src/routes/team/[team]/repositories/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { page } from '$app/state';
 	import { graphql, RepositoryOrderField } from '$houdini';
 	import SidebarActivity from '$lib/domain/activity/sidebar/SidebarActivity.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
@@ -9,7 +8,15 @@
 	import OrderByMenu from '$lib/ui/OrderByMenu.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
-	import { Alert, BodyLong, Button, Detail, Heading, TextField } from '@nais/ds-svelte-community';
+	import {
+		Alert,
+		BodyLong,
+		Button,
+		Detail,
+		Heading,
+		Search,
+		TextField
+	} from '@nais/ds-svelte-community';
 	import { PlusIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
@@ -74,46 +81,91 @@
 		}
 	};
 
-	let filter = $state('');
+	let filter = $state($Repositories.variables?.filter?.name ?? '');
+	let currentFilter = $derived($Repositories.variables?.filter?.name ?? '');
+	let after: string = $derived($Repositories.variables?.after ?? '');
+	let before: string = $derived($Repositories.variables?.before ?? '');
 	let repositoryAdded = $state(false);
 	let repositoryRemoved = $state(false);
 	let repoOperatedOn = $state('');
 
-	const handleFilter = () => {
-		if (filter === '') {
-			page.url.searchParams.delete('filter');
-		} else {
-			page.url.searchParams.set('filter', filter);
-		}
-		history.replaceState({}, '', page.url.toString());
-		Repositories.fetch({ variables: { team: teamSlug, filter: { name: filter } } });
+	const changeQuery = (
+		params: {
+			after?: string;
+			before?: string;
+			newFilter?: string;
+		} = {},
+		options = {}
+	) => {
+		changeParams(
+			{
+				before: params.before ?? before,
+				after: params.after ?? after,
+				filter: params.newFilter ?? filter
+			},
+			options
+		);
 	};
 
 	let searchTimeout: ReturnType<typeof setTimeout> | undefined = undefined;
 
-	const onKeyUp = (e: KeyboardEvent) => {
+	const clearSearchTimeout = () => {
 		if (searchTimeout) {
 			clearTimeout(searchTimeout);
+			searchTimeout = undefined;
+		}
+	};
+
+	const applyFilter = (newFilter = filter) => {
+		clearSearchTimeout();
+
+		if (newFilter === currentFilter) {
+			return;
 		}
 
-		if (e.key === 'Enter') {
-			handleFilter();
-			return;
-		} else if (e.key === 'Escape') {
-			filter = '';
-			handleFilter();
+		changeQuery(
+			{ before: '', after: '', newFilter },
+			{ keepFocus: true, noScroll: true, replaceState: true }
+		);
+	};
+
+	$effect(() => {
+		clearSearchTimeout();
+
+		if (filter === currentFilter) {
 			return;
 		}
 
 		searchTimeout = setTimeout(() => {
-			handleFilter();
+			applyFilter(filter);
 		}, 1000);
+
+		return () => {
+			clearSearchTimeout();
+		};
+	});
+
+	const onFilterKeyDown = (event: KeyboardEvent) => {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			applyFilter();
+			return;
+		}
+
+		if (event.key === 'Escape' && filter !== '') {
+			event.preventDefault();
+			filter = '';
+		}
 	};
 
 	let repoName = $state('');
 
 	let inputError = $state(false);
 	const errorMessage = `Invalid input`;
+
+	const onRepositoryNameInput = () => {
+		inputError = false;
+	};
 </script>
 
 <GraphErrors errors={$Repositories.errors} />
@@ -159,6 +211,7 @@
 								id="repositoryName"
 								style="width: min(100%, 300px)"
 								bind:value={repoName}
+								oninput={onRepositoryNameInput}
 								error={inputError ? errorMessage : undefined}
 							>
 								{#snippet label()}
@@ -190,20 +243,24 @@
 						>
 					</BodyLong>
 				{:else}
-					<form class="input">
-						<TextField
+					<div class="search">
+						<Search
+							clearButton={true}
+							clearButtonLabel="Clear"
+							label="filter repositories"
+							placeholder="Filter by name"
+							hideLabel={true}
 							size="small"
-							type="text"
-							id="filter"
-							style="width: min(100%, 300px)"
+							variant="simple"
+							width="100%"
+							autocomplete="off"
 							bind:value={filter}
-							onkeyup={onKeyUp}
-						>
-							{#snippet label()}
-								Filter repositories
-							{/snippet}
-						</TextField>
-					</form>
+							onkeydown={onFilterKeyDown}
+							onclear={() => {
+								filter = '';
+							}}
+						/>
+					</div>
 
 					<div>
 						<div>
@@ -252,12 +309,12 @@
 								page={team.repositories.pageInfo}
 								loaders={{
 									loadPreviousPage: () =>
-										changeParams({
+										changeQuery({
 											after: '',
 											before: team.repositories.pageInfo.startCursor ?? ''
 										}),
 									loadNextPage: () =>
-										changeParams({ before: '', after: team.repositories.pageInfo.endCursor ?? '' })
+										changeQuery({ before: '', after: team.repositories.pageInfo.endCursor ?? '' })
 								}}
 							/>
 						</div>
@@ -286,6 +343,12 @@
 		margin: 1rem 0;
 	}
 
+	.search {
+		display: flex;
+		justify-content: flex-end;
+		margin-bottom: 1rem;
+	}
+
 	.right {
 		display: flex;
 		gap: var(--ax-space-6);
@@ -308,8 +371,18 @@
 			grid-template-columns: 1fr;
 		}
 
+		.search {
+			justify-content: stretch;
+		}
+
 		.remove-btn-full {
 			display: none;
+		}
+	}
+
+	@media (max-height: 500px) {
+		.search {
+			justify-content: stretch;
 		}
 	}
 

--- a/src/routes/team/[team]/repositories/+page.svelte
+++ b/src/routes/team/[team]/repositories/+page.svelte
@@ -18,6 +18,7 @@
 		TextField
 	} from '@nais/ds-svelte-community';
 	import { PlusIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
+	import { onDestroy } from 'svelte';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
@@ -81,8 +82,8 @@
 		}
 	};
 
-	let filter = $state($Repositories.variables?.filter?.name ?? '');
 	let currentFilter = $derived($Repositories.variables?.filter?.name ?? '');
+	let filter = $derived(currentFilter);
 	let after: string = $derived($Repositories.variables?.after ?? '');
 	let before: string = $derived($Repositories.variables?.before ?? '');
 	let repositoryAdded = $state(false);
@@ -129,21 +130,22 @@
 		);
 	};
 
-	$effect(() => {
+	const onFilterChange = (newFilter: string) => {
+		filter = newFilter;
+
 		clearSearchTimeout();
 
-		if (filter === currentFilter) {
+		if (newFilter === '') {
+			applyFilter('');
 			return;
 		}
 
 		searchTimeout = setTimeout(() => {
-			applyFilter(filter);
+			applyFilter(newFilter);
 		}, 1000);
+	};
 
-		return () => {
-			clearSearchTimeout();
-		};
-	});
+	onDestroy(clearSearchTimeout);
 
 	const onFilterKeyDown = (event: KeyboardEvent) => {
 		if (event.key === 'Enter') {
@@ -256,6 +258,7 @@
 							width="100%"
 							autocomplete="off"
 							bind:value={filter}
+							onChange={onFilterChange}
 							onkeydown={onFilterKeyDown}
 							onclear={() => {
 								filter = '';

--- a/src/routes/team/[team]/repositories/+page.svelte
+++ b/src/routes/team/[team]/repositories/+page.svelte
@@ -98,6 +98,8 @@
 		} = {},
 		options = {}
 	) => {
+		clearSearchTimeout();
+
 		changeParams(
 			{
 				before: params.before ?? before,

--- a/src/routes/team/[team]/repositories/+page.svelte
+++ b/src/routes/team/[team]/repositories/+page.svelte
@@ -101,7 +101,7 @@
 			{
 				before: params.before ?? before,
 				after: params.after ?? after,
-				filter: params.newFilter ?? filter
+				filter: params.newFilter ?? currentFilter
 			},
 			options
 		);
@@ -155,6 +155,7 @@
 		if (event.key === 'Escape' && filter !== '') {
 			event.preventDefault();
 			filter = '';
+			applyFilter('');
 		}
 	};
 
@@ -258,6 +259,7 @@
 							onkeydown={onFilterKeyDown}
 							onclear={() => {
 								filter = '';
+								applyFilter('');
 							}}
 						/>
 					</div>

--- a/src/routes/team/[team]/repositories/+page.svelte
+++ b/src/routes/team/[team]/repositories/+page.svelte
@@ -89,6 +89,74 @@
 	let repositoryAdded = $state(false);
 	let repositoryRemoved = $state(false);
 	let repoOperatedOn = $state('');
+	let searchContainer = $state<HTMLDivElement | undefined>(undefined);
+	let pendingFocusedFilter = $state<string | undefined>(undefined);
+
+	const debugSearchFocus = (message: string, details: Record<string, unknown> = {}) => {
+		if (!import.meta.env.DEV) {
+			return;
+		}
+
+		console.debug('[repositories-search-focus]', message, details);
+	};
+
+	const focusSearchField = (attemptsLeft = 4) => {
+		const input = searchContainer?.querySelector<HTMLInputElement>('input[type="search"]');
+
+		if (!input) {
+			debugSearchFocus('input missing', { attemptsLeft, currentFilter, pendingFocusedFilter });
+
+			if (attemptsLeft > 0) {
+				requestAnimationFrame(() => {
+					focusSearchField(attemptsLeft - 1);
+				});
+				return;
+			}
+
+			pendingFocusedFilter = undefined;
+			return;
+		}
+
+		input.focus();
+
+		if (document.activeElement === input) {
+			debugSearchFocus('focused input', { attemptsLeft, value: input.value });
+			pendingFocusedFilter = undefined;
+			return;
+		}
+
+		debugSearchFocus('focus not retained', {
+			attemptsLeft,
+			activeElement:
+				document.activeElement instanceof HTMLElement ? document.activeElement.tagName : null
+		});
+
+		if (attemptsLeft > 0) {
+			requestAnimationFrame(() => {
+				focusSearchField(attemptsLeft - 1);
+			});
+			return;
+		}
+
+		pendingFocusedFilter = undefined;
+	};
+
+	// This effect only handles post-render DOM focus after the Search component remounts.
+	$effect(() => {
+		const requestedFilter = pendingFocusedFilter;
+		const appliedFilter = currentFilter;
+		const container = searchContainer;
+
+		if (requestedFilter === undefined || appliedFilter !== requestedFilter || !container) {
+			return;
+		}
+
+		debugSearchFocus('focus armed', { requestedFilter, appliedFilter });
+
+		requestAnimationFrame(() => {
+			focusSearchField();
+		});
+	});
 
 	const changeQuery = (
 		params: {
@@ -99,8 +167,9 @@
 		options = {}
 	) => {
 		clearSearchTimeout();
+		pendingFocusedFilter = params.newFilter;
 
-		changeParams(
+		void changeParams(
 			{
 				before: params.before ?? before,
 				after: params.after ?? after,
@@ -248,7 +317,7 @@
 						>
 					</BodyLong>
 				{:else}
-					<div class="search">
+					<div class="search" bind:this={searchContainer}>
 						<Search
 							clearButton={true}
 							clearButtonLabel="Clear"

--- a/src/routes/team/[team]/repositories/+page.ts
+++ b/src/routes/team/[team]/repositories/+page.ts
@@ -5,7 +5,7 @@ import { addPageMeta } from '$lib/utils/pageMeta';
 const rows = 25;
 
 export async function load(event) {
-	const filter = event.url.searchParams.get('filter');
+	const filter: string = event.url.searchParams.get('filter') || '';
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
 


### PR DESCRIPTION
## Summary
- initialize the repositories filter from URL-backed query variables so reloads keep the input and results in sync
- route filter updates through the shared query-param helper and keep pagination on the applied filter
- replace the `$effect`-driven debounce with the Search component's `onChange` callback, while making clear actions immediate when the value becomes empty
- keep the repositories search field focused across filter-triggered reloads by waiting for the Search component to remount before refocusing its internal input
- keep the new `$effect` scoped to post-render DOM focus rather than state synchronization
- document in `AGENTS.md` that `$effect` should be treated as an escape hatch rather than the default tool for state synchronization

## Validation
- npm run check
- npm run lint