### PR TITLE
Standardize delete action placement

### DIFF
--- a/src/lib/menuItems.test.ts
+++ b/src/lib/menuItems.test.ts
@@ -205,16 +205,15 @@ describe('menuItems', () => {
 						label: 'Manifest',
 						href: '/team/devteam/dev/app/app-w-all-storage/manifest'
 					}
-				],
-				[{ label: 'Delete', href: '/team/devteam/dev/app/app-w-all-storage/delete' }]
+				]
 			]);
 		});
 
-		test('when not member', () => {
+		test('does not include delete', () => {
 			expect(
 				menuItems({
 					path: '/team/devteam/dev/job/dataproduct-apps-topics/vulnerabilities',
-					member: false,
+					member: true,
 					isAdmin: false
 				})
 					.flatMap((g) => g)

--- a/src/lib/menuItems.ts
+++ b/src/lib/menuItems.ts
@@ -86,8 +86,7 @@ export const menuItems = ({
 				workloadType === 'app' && menuItem('Ingresses', 'ingresses'),
 				menuItem('Logs', 'logs')
 			].filter(Boolean),
-			[menuItem('Manifest', 'manifest')],
-			member && [menuItem('Delete', 'delete')]
+			[menuItem('Manifest', 'manifest')]
 		].filter(Boolean) as { label: string; href: string; active?: boolean }[][];
 	}
 	const [, , team, page] = split;

--- a/src/lib/ui/Menu.stories.svelte
+++ b/src/lib/ui/Menu.stories.svelte
@@ -63,8 +63,7 @@
 				},
 				{ label: 'Logs', href: '/team/devteam/dev/app/app-w-all-storage/logs' }
 			],
-			[{ label: 'Manifest', href: '/team/devteam/dev/app/app-w-all-storage/manifest' }],
-			[{ label: 'Delete', href: '/team/devteam/dev/app/app-w-all-storage/delete' }]
+			[{ label: 'Manifest', href: '/team/devteam/dev/app/app-w-all-storage/manifest' }]
 		]}
 	/>
 </Story>
@@ -82,8 +81,7 @@
 				{ label: 'Cost', href: '/team/devteam/dev/app/app-w-all-storage/cost' },
 				{ label: 'Logs', href: '/team/devteam/dev/app/app-w-all-storage/logs' }
 			],
-			[{ label: 'Manifest', href: '/team/devteam/dev/app/app-w-all-storage/manifest' }],
-			[{ label: 'Delete', href: '/team/devteam/dev/app/app-w-all-storage/delete' }]
+			[{ label: 'Manifest', href: '/team/devteam/dev/app/app-w-all-storage/manifest' }]
 		]}
 	/>
 </Story>

--- a/src/routes/team/[team]/[env]/app/[app]/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/+page.svelte
@@ -17,7 +17,7 @@
 	import RunningIndicator from '$lib/ui/RunningIndicator.svelte';
 	import Time from '$lib/ui/Time.svelte';
 	import { Alert, Button, Heading, Loader, Tag } from '@nais/ds-svelte-community';
-	import { ArrowCirclepathIcon } from '@nais/ds-svelte-community/icons';
+	import { ArrowCirclepathIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 	import Ingresses from './Ingresses.svelte';
 
@@ -97,6 +97,19 @@
 	<div class="wrapper">
 		<div class="app-content">
 			<div class="main-section">
+				{#if viewerIsMember}
+					<div class="detail-actions">
+						<Button
+							as="a"
+							variant="danger"
+							size="small"
+							href="/team/{page.params.team}/{page.params.env}/app/{page.params.app}/delete"
+							icon={TrashIcon}
+						>
+							Delete
+						</Button>
+					</div>
+				{/if}
 				{#if app.deletionStartedAt}
 					<Alert variant="info" size="small" fullWidth={false}>
 						This application is being deleted. Deletion started <Time
@@ -225,6 +238,13 @@
 		align-items: center;
 	}
 
+	.detail-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--ax-space-8);
+		flex-wrap: wrap;
+	}
+
 	.sidebar {
 		display: flex;
 		flex-direction: column;
@@ -281,6 +301,11 @@
 
 		.workload-deploy-wrapper {
 			margin-top: 0;
+		}
+
+		.detail-actions :global(button),
+		.detail-actions :global(a) {
+			width: 100%;
 		}
 
 		.instances-header {

--- a/src/routes/team/[team]/[env]/job/[job]/+page.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/+page.svelte
@@ -15,6 +15,7 @@
 	import Time from '$lib/ui/Time.svelte';
 	import { generateJobRunName } from '$lib/utils/jobRunName';
 	import { Alert, BodyShort, Button, Heading, Loader } from '@nais/ds-svelte-community';
+	import { TrashIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 	import Runs from './Runs.svelte';
 	import Schedule from './Schedule.svelte';
@@ -124,6 +125,19 @@
 	<div class="wrapper">
 		<div class="job-content">
 			<div class="main-section">
+				{#if viewerIsMember}
+					<div class="detail-actions">
+						<Button
+							as="a"
+							variant="danger"
+							size="small"
+							href="/team/{page.params.team}/{page.params.env}/job/{page.params.job}/delete"
+							icon={TrashIcon}
+						>
+							Delete
+						</Button>
+					</div>
+				{/if}
 				{#if job.deletionStartedAt}
 					<Alert variant="info" size="small" fullWidth={false}>
 						This job is being deleted. Deletion started <Time
@@ -243,6 +257,13 @@
 		align-items: center;
 	}
 
+	.detail-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--ax-space-8);
+		flex-wrap: wrap;
+	}
+
 	.sidebar {
 		display: flex;
 		flex-direction: column;
@@ -263,6 +284,11 @@
 
 		.workload-deploy-wrapper {
 			margin-top: 0;
+		}
+
+		.detail-actions :global(button),
+		.detail-actions :global(a) {
+			width: 100%;
 		}
 
 		.runs-header {

--- a/src/routes/team/[team]/[env]/opensearch/[opensearch]/(single)/+page.svelte
+++ b/src/routes/team/[team]/[env]/opensearch/[opensearch]/(single)/+page.svelte
@@ -116,6 +116,20 @@
 					</ExternalLink>.
 				</Alert>
 			{/if}
+			{#if viewerIsMember && isManagedByConsole}
+				<div class="detail-actions">
+					<Button
+						as="a"
+						variant="danger"
+						size="small"
+						href="/team/{page.params.team}/{page.params.env}/opensearch/{page.params
+							.opensearch}/delete"
+						icon={TrashIcon}
+					>
+						Delete
+					</Button>
+				</div>
+			{/if}
 			<div class="spacing">
 				<Heading as="h2" spacing>OpenSearch Instance Access List</Heading>
 
@@ -252,20 +266,6 @@
 
 			<Manifest openSearch={instance} teamSlug={page.params.team!} />
 
-			{#if viewerIsMember && isManagedByConsole}
-				<Button
-					as="a"
-					variant="danger"
-					size="small"
-					href="/team/{page.params.team}/{page.params.env}/opensearch/{page.params
-						.opensearch}/delete"
-					icon={TrashIcon}
-					class="self-start"
-				>
-					Delete OpenSearch
-				</Button>
-			{/if}
-
 			<SidebarActivity activityLog={instance} direct={instance.activityLog} />
 		</div>
 	</div>
@@ -282,6 +282,14 @@
 
 	.content {
 		min-width: 0;
+	}
+
+	.detail-actions {
+		display: flex;
+		justify-content: flex-end;
+		margin-bottom: var(--ax-space-16);
+		gap: var(--ax-space-8);
+		flex-wrap: wrap;
 	}
 
 	.spacing {
@@ -318,6 +326,11 @@
 	@media (max-width: 767px) {
 		.wrapper {
 			grid-template-columns: 1fr;
+		}
+
+		.detail-actions :global(button),
+		.detail-actions :global(a) {
+			width: 100%;
 		}
 
 		.service-maintenance-list-heading {

--- a/src/routes/team/[team]/[env]/valkey/[valkey]/(single)/+page.svelte
+++ b/src/routes/team/[team]/[env]/valkey/[valkey]/(single)/+page.svelte
@@ -112,6 +112,19 @@
 					</ExternalLink>.
 				</Alert>
 			{/if}
+			{#if viewerIsMember && isManagedByConsole}
+				<div class="detail-actions">
+					<Button
+						as="a"
+						variant="danger"
+						size="small"
+						href="/team/{page.params.team}/{page.params.env}/valkey/{page.params.valkey}/delete"
+						icon={TrashIcon}
+					>
+						Delete
+					</Button>
+				</div>
+			{/if}
 			<div class="spacing">
 				<Heading as="h3" spacing>Valkey Access List</Heading>
 				<div class="table-container">
@@ -252,18 +265,6 @@
 			{/if}
 
 			<Manifest valkey={instance} teamSlug={page.params.team!} />
-			{#if viewerIsMember && isManagedByConsole}
-				<Button
-					as="a"
-					variant="danger"
-					size="small"
-					href="/team/{page.params.team}/{page.params.env}/valkey/{page.params.valkey}/delete"
-					icon={TrashIcon}
-					class="self-start"
-				>
-					Delete Valkey
-				</Button>
-			{/if}
 
 			<SidebarActivity activityLog={instance} direct={instance.activityLog} />
 		</div>
@@ -281,6 +282,14 @@
 
 	.content {
 		min-width: 0;
+	}
+
+	.detail-actions {
+		display: flex;
+		justify-content: flex-end;
+		margin-bottom: var(--ax-space-16);
+		gap: var(--ax-space-8);
+		flex-wrap: wrap;
 	}
 
 	.spacing {
@@ -317,6 +326,11 @@
 	@media (max-width: 767px) {
 		.wrapper {
 			grid-template-columns: 1fr;
+		}
+
+		.detail-actions :global(button),
+		.detail-actions :global(a) {
+			width: 100%;
 		}
 
 		.service-maintenance-list-heading {

--- a/src/routes/team/[team]/repositories/+page.svelte
+++ b/src/routes/team/[team]/repositories/+page.svelte
@@ -334,28 +334,17 @@
 											<ExternalLink href="https://github.com/{repo.name}">{repo.name}</ExternalLink>
 											{#if viewerIsMember}
 												<div class="right">
-													<div class="remove-btn-full">
-														<Button
-															variant="danger"
-															size="xsmall"
-															onclick={() => removeRepository(repo.team.slug, repo.name)}
-															icon={TrashIcon}
-														>
-															Remove
-														</Button>
-													</div>
-													<div class="remove-btn-icon">
-														<Button
-															variant="tertiary-neutral"
-															size="xsmall"
-															onclick={() => removeRepository(repo.team.slug, repo.name)}
-															aria-label="Remove repository"
-														>
-															{#snippet icon()}
-																<TrashIcon style="color: var(--ax-text-danger-decoration);" />
-															{/snippet}
-														</Button>
-													</div>
+													<Button
+														variant="tertiary-neutral"
+														size="xsmall"
+														onclick={() => removeRepository(repo.team.slug, repo.name)}
+														aria-label="Remove repository"
+														title="Remove repository"
+													>
+														{#snippet icon()}
+															<TrashIcon style="color: var(--ax-text-danger-decoration);" />
+														{/snippet}
+													</Button>
 												</div>
 											{/if}
 										</div>
@@ -431,21 +420,11 @@
 		.search {
 			justify-content: stretch;
 		}
-
-		.remove-btn-full {
-			display: none;
-		}
 	}
 
 	@media (max-height: 500px) {
 		.search {
 			justify-content: stretch;
-		}
-	}
-
-	@media (min-width: 768px) {
-		.remove-btn-icon {
-			display: none;
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary
- move workload delete actions onto the overview page action row for app, job, valkey, and opensearch
- remove the redundant app/job `Delete` menu entry now that delete is exposed from the overview page
- keep row-based destructive actions compact by using the icon-only repository remove action

## Validation
- npm run check
- npm run lint
- npx vitest run src/lib/menuItems.test.ts