### PR TITLE
Add mobile side drawer navigation

### DIFF
--- a/src/lib/ui/Menu.svelte
+++ b/src/lib/ui/Menu.svelte
@@ -4,7 +4,8 @@
 	import IconLabel from './IconLabel.svelte';
 
 	const {
-		items
+		items,
+		onItemSelect
 	}: {
 		items: {
 			label: string;
@@ -12,6 +13,7 @@
 			active?: boolean;
 			count?: number;
 		}[][];
+		onItemSelect?: () => void;
 	} = $props();
 </script>
 
@@ -19,7 +21,7 @@
 	{#each items as group (group)}
 		<div class="list">
 			{#each group as { label: text, href, active, count } (href)}
-				<a {href} class:active>
+				<a {href} class:active onclick={onItemSelect}>
 					<IconLabel>
 						{#snippet label()}
 							<span class="label">

--- a/src/lib/ui/MobileSideDrawer.svelte
+++ b/src/lib/ui/MobileSideDrawer.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+	import { Modal } from '@nais/ds-svelte-community';
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		id?: string;
+		headerContent?: Snippet;
+		title?: string;
+		open?: boolean;
+		width?: number | 'small' | 'medium' | `${number}${string}`;
+		children: Snippet;
+	}
+
+	let {
+		id,
+		headerContent,
+		title,
+		open = $bindable(false),
+		width = '22rem',
+		children
+	}: Props = $props();
+</script>
+
+<Modal
+	bind:open
+	{id}
+	{width}
+	header={headerContent ?? (title ? { heading: title, size: 'small' } : undefined)}
+	class="mobile-side-drawer"
+>
+	<div class="drawer-content">
+		{@render children()}
+	</div>
+</Modal>
+
+<style>
+	:global(dialog.mobile-side-drawer.aksel-modal) {
+		inset: 0 auto 0 0;
+		margin: 0;
+		display: flex;
+		max-width: calc(100vw - var(--ax-space-16));
+		max-height: 100dvh;
+		height: 100dvh;
+		flex-direction: column;
+		border: none;
+		border-radius: 0;
+		padding: 0;
+		background: var(--ax-bg-default);
+		box-shadow: 0 20px 48px rgb(15 23 42 / 0.24);
+		animation: drawer-enter 160ms ease-out;
+	}
+
+	:global(dialog.mobile-side-drawer::backdrop) {
+		background: rgb(15 23 42 / 0.38);
+		animation: backdrop-enter 160ms ease-out;
+	}
+
+	:global(dialog.mobile-side-drawer .aksel-modal__header) {
+		padding: var(--ax-space-12);
+		border-bottom: 1px solid var(--ax-border-neutral-subtleA);
+		background: var(--ax-bg-raised);
+	}
+
+	:global(dialog.mobile-side-drawer .aksel-modal__body) {
+		flex: 1;
+		min-height: 0;
+		padding: 0;
+		overflow: auto;
+	}
+
+	.drawer-content {
+		min-height: 100%;
+		padding: var(--ax-space-12);
+		background: var(--ax-bg-default);
+	}
+
+	@keyframes drawer-enter {
+		from {
+			transform: translateX(-24px);
+			opacity: 0;
+		}
+
+		to {
+			transform: translateX(0);
+			opacity: 1;
+		}
+	}
+
+	@keyframes backdrop-enter {
+		from {
+			opacity: 0;
+		}
+
+		to {
+			opacity: 1;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		:global(dialog.mobile-side-drawer.aksel-modal) {
+			animation: none;
+		}
+
+		:global(dialog.mobile-side-drawer::backdrop) {
+			animation: none;
+		}
+	}
+</style>

--- a/src/lib/ui/PageHeader.svelte
+++ b/src/lib/ui/PageHeader.svelte
@@ -7,6 +7,9 @@
 	import { pageHeaderState } from '$lib/stores/pageHeaderState.svelte';
 	import AddToFavorites from '$lib/ui/AddToFavorites.svelte';
 	import { Heading, Tag } from '@nais/ds-svelte-community';
+	import type { Snippet } from 'svelte';
+
+	const { beforeBreadcrumbs }: { beforeBreadcrumbs?: Snippet } = $props();
 
 	const breadcrumbs = $derived(page.data?.meta?.breadcrumbs ?? []);
 	const heading = $derived(page.data?.meta?.title ?? '');
@@ -26,18 +29,26 @@
 <div class="page-header">
 	{#if breadcrumbs.length}
 		<div class="breadcrumbs-wrapper">
-			<div class="breadcrumbs">
-				{#each breadcrumbs as breadcrumb (breadcrumb)}
-					{#if breadcrumb.href}
-						<a href={resolveRouteHref(breadcrumb.href)} class="link">{breadcrumb.label}</a>
-					{:else}
-						{breadcrumb.label}
-					{/if}
-					<span class="divider">/</span>
-				{/each}
+			<div class="breadcrumbs-left">
+				{#if beforeBreadcrumbs}
+					<div class="breadcrumbs-trigger">{@render beforeBreadcrumbs()}</div>
+				{/if}
+				<div class="breadcrumbs">
+					{#each breadcrumbs as breadcrumb (breadcrumb)}
+						{#if breadcrumb.href}
+							<a href={resolveRouteHref(breadcrumb.href)} class="link">{breadcrumb.label}</a>
+						{:else}
+							{breadcrumb.label}
+						{/if}
+						<span class="divider">/</span>
+					{/each}
+				</div>
 			</div>
 			<AddToFavorites path={page.url.pathname} />
 		</div>
+	{/if}
+	{#if !breadcrumbs.length && beforeBreadcrumbs}
+		<div class="breadcrumbs-trigger breadcrumbs-trigger-row">{@render beforeBreadcrumbs()}</div>
 	{/if}
 	<div class="header-row">
 		<div class="heading-wrapper">
@@ -77,10 +88,18 @@
 			gap: var(--ax-space-8);
 			margin-bottom: var(--ax-space-4);
 
+			.breadcrumbs-left {
+				display: flex;
+				align-items: center;
+				gap: var(--ax-space-8);
+				min-width: 0;
+			}
+
 			.breadcrumbs {
 				display: flex;
 				gap: var(--ax-space-8);
 				align-items: center;
+				min-width: 0;
 
 				.link {
 					text-decoration: none;
@@ -101,16 +120,31 @@
 			align-items: center;
 			flex-wrap: wrap;
 		}
+
+		.breadcrumbs-trigger-row {
+			display: none;
+		}
 	}
 
 	@media (max-width: 767px), (max-height: 500px) {
 		.page-header {
 			.breadcrumbs-wrapper {
-				align-items: flex-start;
+				align-items: center;
+				flex-wrap: wrap;
+			}
+
+			.breadcrumbs-wrapper .breadcrumbs-left {
+				width: 100%;
+				align-items: center;
 			}
 
 			.breadcrumbs-wrapper .breadcrumbs {
 				flex-wrap: wrap;
+			}
+
+			.breadcrumbs-trigger-row {
+				display: flex;
+				margin-bottom: var(--ax-space-4);
 			}
 
 			.header-row {

--- a/src/routes/PageHeader.svelte
+++ b/src/routes/PageHeader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { afterNavigate } from '$app/navigation';
 	import { page } from '$app/state';
 	import { docURL, tenantURL } from '$lib/doc';
 	import SearchButton from '$lib/domain/search/SearchButton.svelte';
@@ -6,6 +7,7 @@
 	import GrafanaIcon from '$lib/icons/GrafanaIcon.svelte';
 	import { themeSwitch } from '$lib/stores/theme.svelte';
 	import HeaderActionMenuItem from '$lib/ui/HeaderActionMenuItem.svelte';
+	import MobileSideDrawer from '$lib/ui/MobileSideDrawer.svelte';
 	import { Button, Spacer } from '@nais/ds-svelte-community';
 	import {
 		ActionMenu,
@@ -40,6 +42,7 @@
 	let { user }: Props = $props();
 
 	let feedbackOpen = $state(false);
+	let mobileNavOpen = $state(false);
 
 	const navItems = [
 		{ href: '/utilization', label: 'Utilization' },
@@ -59,6 +62,10 @@
 
 		popover?.hidePopover?.();
 	}
+
+	afterNavigate(() => {
+		mobileNavOpen = false;
+	});
 </script>
 
 <InternalHeader>
@@ -77,38 +84,49 @@
 		{/each}
 	</div>
 
-	<!-- Mobile navigation menu -->
-	<ActionMenu>
-		{#snippet trigger(props)}
-			<InternalHeaderButton class="mobile-nav-trigger" aria-label="Open navigation menu" {...props}>
-				<MenuHamburgerIcon title="Navigation" />
-			</InternalHeaderButton>
-		{/snippet}
-		<ActionMenuGroup label="Navigation">
-			{#each navItems as item (item.href)}
-				<HeaderActionMenuItem
-					href={item.href}
-					active={isActive(item.href)}
-					ariaCurrent={isActive(item.href) ? 'page' : undefined}
-					onSelect={closeMenu}
+	<InternalHeaderButton
+		class="mobile-nav-trigger"
+		aria-label="Open navigation menu"
+		aria-expanded={mobileNavOpen}
+		aria-controls="mobile-navigation-drawer"
+		onclick={() => {
+			mobileNavOpen = true;
+		}}
+	>
+		<MenuHamburgerIcon title="Navigation" />
+	</InternalHeaderButton>
+	<MobileSideDrawer bind:open={mobileNavOpen} id="mobile-navigation-drawer" title="Navigation">
+		<nav class="mobile-drawer-nav" aria-label="Navigation">
+			<div class="mobile-drawer-section">
+				{#each navItems as item (item.href)}
+					<a
+						href={item.href}
+						class:active={isActive(item.href)}
+						class="mobile-drawer-link"
+						aria-current={isActive(item.href) ? 'page' : undefined}
+						onclick={() => {
+							mobileNavOpen = false;
+						}}
+					>
+						{item.label}
+					</a>
+				{/each}
+			</div>
+			<div class="mobile-drawer-section">
+				<p class="mobile-drawer-section-label">Tools</p>
+				<button
+					type="button"
+					class="mobile-drawer-link mobile-drawer-button"
+					onclick={() => {
+						mobileNavOpen = false;
+						feedbackOpen = true;
+					}}
 				>
-					{item.label}
-				</HeaderActionMenuItem>
-			{/each}
-		</ActionMenuGroup>
-		<ActionMenuDivider />
-		<ActionMenuGroup label="Tools">
-			<HeaderActionMenuItem
-				icon={ChatElipsisIcon}
-				onSelect={(event) => {
-					closeMenu(event);
-					feedbackOpen = true;
-				}}
-			>
-				Feedback
-			</HeaderActionMenuItem>
-		</ActionMenuGroup>
-	</ActionMenu>
+					Feedback
+				</button>
+			</div>
+		</nav>
+	</MobileSideDrawer>
 
 	<Spacer />
 	<div class="feedback-button-wrapper">
@@ -214,6 +232,65 @@
 	/* Mobile nav trigger is hidden on desktop by default */
 	:global(.mobile-nav-trigger) {
 		display: none;
+	}
+
+	.mobile-drawer-nav {
+		display: flex;
+		flex-direction: column;
+		gap: var(--ax-space-20);
+	}
+
+	.mobile-drawer-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--ax-space-4);
+	}
+
+	.mobile-drawer-section-label {
+		margin: 0;
+		padding: 0 var(--ax-space-8);
+		color: var(--ax-text-neutral-subtle);
+		font-size: var(--ax-font-size-small);
+		font-weight: var(--ax-font-weight-bold);
+	}
+
+	.mobile-drawer-link {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		min-height: 44px;
+		padding: var(--ax-space-8);
+		border: none;
+		border-radius: 4px;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		font-weight: var(--ax-font-weight-bold);
+		text-align: left;
+		text-decoration: none;
+		transition: background-color 50ms;
+		cursor: pointer;
+
+		&:focus-visible,
+		&:hover {
+			background-color: color-mix(in oklab, var(--active-color) 60%, transparent);
+			box-shadow: none;
+			color: inherit;
+		}
+
+		&:active {
+			background-color: var(--active-color-strong);
+			box-shadow: none;
+			color: inherit;
+		}
+
+		&.active {
+			background-color: var(--active-color);
+		}
+	}
+
+	.mobile-drawer-button {
+		appearance: none;
 	}
 
 	/* Mobile responsive behavior */

--- a/src/routes/team/[team]/+layout.svelte
+++ b/src/routes/team/[team]/+layout.svelte
@@ -3,6 +3,7 @@
 	import { Alert } from '@nais/ds-svelte-community';
 	import type { LayoutProps } from './$types';
 	import Menu from './Menu.svelte';
+	import MenuTrigger from './MenuTrigger.svelte';
 	import { createTeamContext } from './teamContext.svelte';
 
 	let { data, children }: LayoutProps = $props();
@@ -32,7 +33,11 @@
 	<div class="main">
 		<Menu features={$UserInfo.data?.features} member={viewerIsMember} {teamSlug} {isAdmin} />
 		<div class="container">
-			<PageHeader />
+			<PageHeader>
+				{#snippet beforeBreadcrumbs()}
+					<MenuTrigger />
+				{/snippet}
+			</PageHeader>
 			<div>{@render children?.()}</div>
 		</div>
 	</div>

--- a/src/routes/team/[team]/Menu.svelte
+++ b/src/routes/team/[team]/Menu.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
+	import { afterNavigate } from '$app/navigation';
 	import { page } from '$app/state';
 	import { graphql } from '$houdini';
 	import { menuItems } from '$lib/menuItems';
+	import Icon from '$lib/ui/Icon.svelte';
+	import IconLabel from '$lib/ui/IconLabel.svelte';
 	import Menu from '$lib/ui/Menu.svelte';
-	import { setInventoryRefetcher } from './teamContext.svelte';
+	import MobileSideDrawer from '$lib/ui/MobileSideDrawer.svelte';
+	import { getTeamContext, setInventoryRefetcher } from './teamContext.svelte';
 
 	const {
 		member,
@@ -90,61 +94,101 @@
 		})
 	);
 
-	let mobileMenuOpen = $state(false);
+	const teamContext = getTeamContext();
+	const overviewItem = $derived(items[0]?.[0]);
+	const navigationItems = $derived(overviewItem ? items.slice(1) : items);
 
 	const activeLabel = $derived(
 		items.flat().find((item) => item.active)?.label ?? 'Team navigation'
 	);
 
-	$effect(() => {
-		const pathname = page.url.pathname;
-		if (pathname) {
-			mobileMenuOpen = false;
-		}
+	afterNavigate(() => {
+		teamContext.closeMobileMenu();
 	});
 </script>
 
 <nav class="team-menu" aria-label="Team menu">
-	<button
-		type="button"
-		class="mobile-menu-toggle"
-		onclick={() => (mobileMenuOpen = !mobileMenuOpen)}
-		aria-expanded={mobileMenuOpen}
-		aria-controls="team-menu-items"
-	>
-		{activeLabel}
-	</button>
-	<div id="team-menu-items" class:mobile-hidden={!mobileMenuOpen}>
+	<div class="desktop-menu">
 		<Menu {items} />
 	</div>
+	{#if overviewItem}
+		<MobileSideDrawer bind:open={teamContext.mobileMenuOpen} id="team-menu-items">
+			{#snippet headerContent()}
+				<a
+					href={overviewItem.href}
+					class="overview-link"
+					class:active={overviewItem.active}
+					onclick={() => teamContext.closeMobileMenu()}
+				>
+					<IconLabel>
+						{#snippet label()}
+							<span class="label">{overviewItem.label}</span>
+						{/snippet}
+						{#snippet icon()}
+							<span class="icon"><Icon icon={overviewItem.label} /></span>
+						{/snippet}
+					</IconLabel>
+				</a>
+			{/snippet}
+			<Menu items={navigationItems} onItemSelect={() => teamContext.closeMobileMenu()} />
+		</MobileSideDrawer>
+	{:else}
+		<MobileSideDrawer
+			bind:open={teamContext.mobileMenuOpen}
+			id="team-menu-items"
+			title={activeLabel}
+		>
+			<Menu {items} onItemSelect={() => teamContext.closeMobileMenu()} />
+		</MobileSideDrawer>
+	{/if}
 </nav>
 
 <style>
-	.mobile-menu-toggle {
-		display: none;
+	.desktop-menu {
+		display: block;
+	}
+
+	.overview-link {
+		display: block;
+		min-width: 0;
+		border-radius: 4px;
+		padding: var(--ax-space-4) var(--ax-space-8);
+		text-decoration: none;
+		color: inherit;
+		transition: background-color 50ms;
+
+		&:focus-visible,
+		&:hover {
+			background-color: color-mix(in oklab, var(--active-color) 60%, transparent);
+			box-shadow: none;
+			color: inherit;
+		}
+
+		&:active {
+			background-color: var(--active-color-strong);
+			box-shadow: none;
+			color: inherit;
+		}
+
+		&.active {
+			background-color: var(--active-color);
+		}
+
+		&.active .icon {
+			color: var(--ax-text-subtle);
+		}
+
+		&:not(.active) .icon {
+			color: var(--ax-text-subtle);
+		}
+
+		.icon {
+			display: contents;
+		}
 	}
 
 	@media (max-width: 767px) {
-		.team-menu {
-			display: flex;
-			flex-direction: column;
-			gap: var(--ax-space-8);
-		}
-
-		.mobile-menu-toggle {
-			display: block;
-			width: 100%;
-			text-align: left;
-			padding: var(--ax-space-8) var(--ax-space-12);
-			border: 1px solid var(--ax-border-neutral-subtleA);
-			border-radius: 6px;
-			background: var(--ax-bg-raised);
-			color: var(--ax-text-neutral);
-			font-size: var(--ax-font-size-medium);
-			font-weight: var(--ax-font-weight-bold);
-		}
-
-		.mobile-hidden {
+		.desktop-menu {
 			display: none;
 		}
 	}

--- a/src/routes/team/[team]/Menu.svelte
+++ b/src/routes/team/[team]/Menu.svelte
@@ -187,7 +187,7 @@
 		}
 	}
 
-	@media (max-width: 767px) {
+	@media (max-width: 767px), (max-height: 500px) {
 		.desktop-menu {
 			display: none;
 		}

--- a/src/routes/team/[team]/MenuTrigger.svelte
+++ b/src/routes/team/[team]/MenuTrigger.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { Button } from '@nais/ds-svelte-community';
+	import { MenuHamburgerIcon } from '@nais/ds-svelte-community/icons';
+	import { getTeamContext } from './teamContext.svelte';
+
+	const teamContext = getTeamContext();
+</script>
+
+<Button
+	variant="tertiary-neutral"
+	size="small"
+	icon={MenuHamburgerIcon}
+	class="mobile-menu-trigger"
+	type="button"
+	aria-label="Open team navigation"
+	aria-controls="team-menu-items"
+	aria-expanded={teamContext.mobileMenuOpen}
+	onclick={() => teamContext.openMobileMenu()}
+/>
+
+<style>
+	:global(.mobile-menu-trigger) {
+		display: none;
+		flex-shrink: 0;
+	}
+
+	@media (max-width: 767px), (max-height: 500px) {
+		:global(.mobile-menu-trigger) {
+			display: inline-flex;
+		}
+	}
+</style>

--- a/src/routes/team/[team]/teamContext.svelte.ts
+++ b/src/routes/team/[team]/teamContext.svelte.ts
@@ -3,6 +3,16 @@ import { getContext, setContext } from 'svelte';
 const ctxKey = Symbol('team');
 
 class TeamContext {
+	mobileMenuOpen = $state(false);
+
+	openMobileMenu() {
+		this.mobileMenuOpen = true;
+	}
+
+	closeMobileMenu() {
+		this.mobileMenuOpen = false;
+	}
+
 	refetchInventory() {
 		this.inventoryFetcher?.();
 	}


### PR DESCRIPTION
## Summary
This updates mobile navigation to use side drawers instead of the previous dropdown/button treatment.

## What changed
- add a shared mobile side drawer component for mobile navigation
- replace the root mobile header ActionMenu navigation with a side drawer
- move the team mobile menu trigger inline before breadcrumbs on mobile
- reuse team/app/job overview as the clickable drawer header for team navigation
- keep desktop navigation behavior unchanged
- align the inline trigger and normalize drawer icon styling

## Validation
- npm run check
- npm run lint
- npm run test -- --run