### PR TITLE
feat: add Nais APM links throughout console

### DIFF
--- a/src/lib/doc.ts
+++ b/src/lib/doc.ts
@@ -14,3 +14,16 @@ export const tenantURL = (host: string, path: string = '') => {
 
 	return `https://${host}.${tn}.cloud.nais.io${path}`;
 };
+
+export const apmURL = (namespace: string, service: string, tab?: string) => {
+	const params = tab ? `?tab=${tab}` : '';
+	return tenantURL('grafana', `/a/nais-apm-app/services/${namespace}/${service}${params}`);
+};
+
+export const apmNamespaceURL = (namespace: string) => {
+	return tenantURL('grafana', `/a/nais-apm-app/namespaces/${namespace}`);
+};
+
+export const apmServicesURL = () => {
+	return tenantURL('grafana', '/a/nais-apm-app/services');
+};

--- a/src/routes/PageHeader.svelte
+++ b/src/routes/PageHeader.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { afterNavigate } from '$app/navigation';
 	import { page } from '$app/state';
-	import { docURL, tenantURL } from '$lib/doc';
+	import { apmServicesURL, docURL, tenantURL } from '$lib/doc';
 	import SearchButton from '$lib/domain/search/SearchButton.svelte';
 	import Feedback from '$lib/feedback/Feedback.svelte';
 	import GrafanaIcon from '$lib/icons/GrafanaIcon.svelte';
@@ -25,6 +25,7 @@
 		CogIcon,
 		ExternalLinkIcon,
 		LeaveIcon,
+		LineGraphIcon,
 		MenuGridIcon,
 		MenuHamburgerIcon
 	} from '@nais/ds-svelte-community/icons';
@@ -160,6 +161,15 @@
 				onSelect={closeMenu}
 			>
 				Docs <ExternalLinkIcon />
+			</HeaderActionMenuItem>
+			<HeaderActionMenuItem
+				href={apmServicesURL()}
+				target="_blank"
+				rel="noopener noreferrer"
+				icon={LineGraphIcon}
+				onSelect={closeMenu}
+			>
+				APM <ExternalLinkIcon />
 			</HeaderActionMenuItem>
 			<HeaderActionMenuItem
 				href={tenantURL('grafana')}

--- a/src/routes/team/[team]/[env]/app/[app]/ingresses/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/ingresses/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import LegendWrapper, { legendSnippet } from '$lib/chart/LegendWrapper.svelte';
+	import { apmURL } from '$lib/doc';
 	import WarningIcon from '$lib/icons/WarningIcon.svelte';
+	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import IconLabel from '$lib/ui/IconLabel.svelte';
 	import TooltipAlignHack from '$lib/ui/TooltipAlignHack.svelte';
@@ -95,6 +97,9 @@
 		</div>
 	{:else if $IngressMetrics.data?.team.environment.application.ingresses && $IngressMetrics.data.team.environment.application.ingresses.length > 0}
 		<div class="controls">
+			<ExternalLink href={apmURL(page.params.team!, page.params.app!, 'server')}
+				>View full metrics in APM</ExternalLink
+			>
 			<ToggleGroup
 				value={interval}
 				onchange={(interval) => changeParams({ interval }, { noScroll: true })}
@@ -170,7 +175,10 @@
 
 	.controls {
 		display: flex;
-		justify-content: flex-end;
+		justify-content: space-between;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: var(--ax-space-8);
 	}
 
 	.section {

--- a/src/routes/team/[team]/[env]/app/[app]/logs/Logs.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/logs/Logs.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { graphql } from '$houdini';
+	import { apmURL } from '$lib/doc';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import {
 		createBufferedLogAppender,
@@ -297,6 +298,11 @@
 						<ExternalLink href={logDestination.grafanaURL}>View logs in Grafana</ExternalLink>
 					{/if}
 				{/each}
+				<span style="padding-left: var(--ax-space-8);">
+					<ExternalLink href={apmURL(page.params.team!, page.params.app!, 'traces')}
+						>View traces in APM</ExternalLink
+					>
+				</span>
 			</div>
 		</div>
 	</div>

--- a/src/routes/team/[team]/[env]/job/[job]/logs/JobLogs.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/logs/JobLogs.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { graphql, JobRunState, type JobRunState$options } from '$houdini';
+	import { apmURL } from '$lib/doc';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import {
 		createBufferedLogAppender,
@@ -331,6 +332,11 @@
 						<ExternalLink href={logDestination.grafanaURL}>View logs in Grafana</ExternalLink>
 					{/if}
 				{/each}
+				<span style="padding-left: var(--ax-space-8);">
+					<ExternalLink href={apmURL(page.params.team!, page.params.job!, 'traces')}
+						>View traces in APM</ExternalLink
+					>
+				</span>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Adds contextual deep links to [Nais APM](https://github.com/nais/grafana-apm-app) from relevant Console pages:

| Location | Link target | Why |
|----------|------------|-----|
| Header nav (tools menu) | APM services list | Global discoverability |
| App logs page | APM traces tab | Natural log → trace workflow |
| Job logs page | APM traces tab | Same for jobs |
| Ingresses metrics page | APM server/RED tab | Full metrics from the sparkline view |

Also adds reusable URL helpers in `src/lib/doc.ts`:
- `apmURL(namespace, service, tab?)` — deep link to a service in APM
- `apmNamespaceURL(namespace)` — link to team/namespace overview
- `apmServicesURL()` — link to the services inventory
