### PR TITLE
Fix mobile and tablet layout regressions

### DIFF
--- a/src/lib/domain/issues/IssueLabel.svelte
+++ b/src/lib/domain/issues/IssueLabel.svelte
@@ -41,7 +41,7 @@
 	});
 </script>
 
-<div style="display: flex; align-items: center; gap: var(--ax-space-8);">
+<div class="issue-label">
 	<TooltipAlignHack
 		content={{
 			TODO: 'Todo',
@@ -73,6 +73,35 @@
 </div>
 
 <style>
+	.issue-label {
+		display: flex;
+		align-items: center;
+		gap: var(--ax-space-8);
+		min-width: 0;
+		max-width: 100%;
+	}
+
+	.issue-label :global(.icon-label) {
+		min-width: 0;
+		max-width: 100%;
+	}
+
+	.issue-label :global(.icon-label .content),
+	.issue-label :global(.icon-label .desc) {
+		min-width: 0;
+	}
+
+	.issue-label :global(.icon-label .desc) {
+		flex-wrap: wrap;
+	}
+
+	.issue-label :global(.aksel-detail),
+	.issue-label :global(.aksel-body-short),
+	.issue-label :global(.aksel-heading) {
+		overflow-wrap: anywhere;
+		word-break: break-word;
+	}
+
 	@media (prefers-reduced-motion: reduce) {
 	}
 </style>

--- a/src/lib/domain/resources/NetworkPolicy.svelte
+++ b/src/lib/domain/resources/NetworkPolicy.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { fragment, graphql, type NetworkPolicy, type NetworkPolicy$data } from '$houdini';
+	import WorkloadLink from '$lib/domain/workload/WorkloadLink.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
 	import WarningIcon from '$lib/icons/WarningIcon.svelte';
-	import { Heading, Tag } from '@nais/ds-svelte-community';
-	import { GlobeIcon } from '@nais/ds-svelte-community/icons';
 	import IconLabel from '$lib/ui/IconLabel.svelte';
 	import TooltipAlignHack from '$lib/ui/TooltipAlignHack.svelte';
-	import WorkloadLink from '$lib/domain/workload/WorkloadLink.svelte';
+	import { Heading, Tag } from '@nais/ds-svelte-community';
+	import { GlobeIcon } from '@nais/ds-svelte-community/icons';
 
 	interface Props {
 		workload: NetworkPolicy;
@@ -171,6 +171,7 @@
 		display: grid;
 		grid-template-columns: 1fr 1fr;
 		gap: 2rem;
+		min-width: 0;
 	}
 
 	ul {
@@ -180,5 +181,21 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--ax-space-4);
+		min-width: 0;
+	}
+
+	li {
+		min-width: 0;
+	}
+
+	li :global(*) {
+		min-width: 0;
+	}
+
+	@media (max-width: 767px), (max-height: 500px) {
+		.grid {
+			grid-template-columns: 1fr;
+			gap: var(--ax-space-24);
+		}
 	}
 </style>

--- a/src/lib/domain/search/SearchButton.svelte
+++ b/src/lib/domain/search/SearchButton.svelte
@@ -39,7 +39,7 @@
 		padding-top: 2px;
 	}
 
-	@media (max-width: 767px), (max-height: 500px) {
+	@media (max-width: 960px), (max-height: 500px) {
 		.hotkey {
 			display: none;
 		}

--- a/src/lib/ui/ListItem.svelte
+++ b/src/lib/ui/ListItem.svelte
@@ -22,9 +22,16 @@
 		grid-auto-flow: column;
 		align-items: center;
 		column-gap: var(--ax-space-16);
+		min-width: 0;
+		max-width: 100%;
 		padding: var(--ax-space-16) var(--ax-space-24);
 		color: inherit;
 		text-decoration: none;
+	}
+
+	.list-item > :global(*) {
+		min-width: 0;
+		max-width: 100%;
 	}
 
 	@media (max-width: 767px), (max-height: 500px) {

--- a/src/routes/PageHeader.svelte
+++ b/src/routes/PageHeader.svelte
@@ -8,7 +8,7 @@
 	import { themeSwitch } from '$lib/stores/theme.svelte';
 	import HeaderActionMenuItem from '$lib/ui/HeaderActionMenuItem.svelte';
 	import MobileSideDrawer from '$lib/ui/MobileSideDrawer.svelte';
-	import { Button, Spacer } from '@nais/ds-svelte-community';
+	import { Button } from '@nais/ds-svelte-community';
 	import {
 		ActionMenu,
 		ActionMenuCheckboxItem,
@@ -128,17 +128,18 @@
 		</nav>
 	</MobileSideDrawer>
 
-	<Spacer />
+	<div class="header-spacer" aria-hidden="true"></div>
 	<div class="feedback-button-wrapper">
 		<Button
 			variant="tertiary-neutral"
 			icon={ChatElipsisIcon}
 			size="small"
+			aria-label="Feedback"
 			onclick={() => {
 				feedbackOpen = true;
 			}}
 		>
-			<span style="font-weight: 400">Feedback</span>
+			<span class="feedback-button-label">Feedback</span>
 		</Button>
 	</div>
 	{#if feedbackOpen}
@@ -223,10 +224,19 @@
 		padding: 0 1rem;
 	}
 
+	.feedback-button-label {
+		font-weight: 400;
+	}
+
 	/* Desktop navigation */
 	.desktop-nav {
 		display: flex;
 		gap: 0;
+	}
+
+	.header-spacer {
+		flex: 1 1 auto;
+		min-width: 0;
 	}
 
 	/* Mobile nav trigger is hidden on desktop by default */
@@ -293,8 +303,45 @@
 		appearance: none;
 	}
 
+	@media (max-width: 960px) {
+		.logo {
+			gap: 0.75rem;
+			font-size: 1.25rem;
+		}
+
+		.feedback-button-wrapper {
+			padding: 0 var(--ax-space-8);
+		}
+
+		.feedback-button-label {
+			display: none;
+		}
+
+		.desktop-nav :global(.aksel-internalheader__button) {
+			padding-inline: var(--ax-space-8);
+		}
+
+		:global(.aksel-internalheader__user-button) {
+			min-width: 0;
+			max-width: 12rem;
+			padding-inline: var(--ax-space-12);
+			gap: var(--ax-space-8);
+		}
+
+		:global(.aksel-internalheader__user-button > div) {
+			min-width: 0;
+			overflow: hidden;
+		}
+
+		:global(.aksel-internalheader__user-button > div > *) {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+	}
+
 	/* Mobile responsive behavior */
-	@media (max-width: 767px) {
+	@media (max-width: 768px) {
 		.logo {
 			gap: 0.5rem;
 			font-size: 1rem;

--- a/src/routes/team/[team]/+layout.svelte
+++ b/src/routes/team/[team]/+layout.svelte
@@ -55,7 +55,7 @@
 		grid-template-columns: 202px 1fr;
 	}
 
-	@media (max-width: 767px) {
+	@media (max-width: 768px) {
 		.main {
 			grid-template-columns: 1fr;
 		}

--- a/src/routes/team/[team]/+layout.svelte
+++ b/src/routes/team/[team]/+layout.svelte
@@ -55,7 +55,7 @@
 		grid-template-columns: 202px 1fr;
 	}
 
-	@media (max-width: 768px) {
+	@media (max-width: 768px), (max-height: 500px) {
 		.main {
 			grid-template-columns: 1fr;
 		}

--- a/src/routes/team/[team]/Menu.svelte
+++ b/src/routes/team/[team]/Menu.svelte
@@ -187,7 +187,7 @@
 		}
 	}
 
-	@media (max-width: 767px), (max-height: 500px) {
+	@media (max-width: 768px), (max-height: 500px) {
 		.desktop-menu {
 			display: none;
 		}

--- a/src/routes/team/[team]/MenuTrigger.svelte
+++ b/src/routes/team/[team]/MenuTrigger.svelte
@@ -24,7 +24,7 @@
 		flex-shrink: 0;
 	}
 
-	@media (max-width: 767px), (max-height: 500px) {
+	@media (max-width: 768px), (max-height: 500px) {
 		:global(.mobile-menu-trigger) {
 			display: inline-flex;
 		}


### PR DESCRIPTION
## Summary
- prevent issue list items from widening the page by adding shared shrink and wrapping rules
- stack `NetworkPolicy` inbound and outbound sections on mobile widths
- align the team layout, team menu, and menu trigger breakpoint handoff at `768px`
- add a compact tablet mode for the global header and hide the search hotkey earlier to avoid overflow around `769px`

## Validation
- `npm run lockfile-lint`
- `npx svelte-kit sync`
- `npm run check`
- `npm run lint`
- `npm run test -- --run`
- `helm lint --strict ./charts`
