### PR TITLE
Clean up and expand activity log texts

### DIFF
--- a/src/lib/domain/activity/activity-log-icons.ts
+++ b/src/lib/domain/activity/activity-log-icons.ts
@@ -35,15 +35,20 @@ import ValkeyIcon from '$lib/icons/ValkeyIcon.svelte';
  */
 export const icons: { [typename: string]: Component } = {
 	/* Applications (various operations) */
+	ApplicationCreatedActivityLogEntry: PackageIcon,
 	ApplicationDeletedActivityLogEntry: PackageIcon,
 	ApplicationRestartedActivityLogEntry: PackageIcon,
 	ApplicationScaledActivityLogEntry: PackageIcon,
+	ApplicationUpdatedActivityLogEntry: PackageIcon,
 
 	/* Deployments & jobs */
 	DeploymentActivityLogEntry: RocketIcon,
+	ServiceMaintenanceActivityLogEntry: CogIcon,
+	JobCreatedActivityLogEntry: BriefcaseClockIcon,
 	JobTriggeredActivityLogEntry: BriefcaseClockIcon,
 	JobDeletedActivityLogEntry: BriefcaseClockIcon,
 	JobRunDeletedActivityLogEntry: BriefcaseClockIcon,
+	JobUpdatedActivityLogEntry: BriefcaseClockIcon,
 
 	/* Credentials */
 	CredentialsActivityLogEntry: PadlockLockedIcon,
@@ -60,6 +65,7 @@ export const icons: { [typename: string]: Component } = {
 	ConfigCreatedActivityLogEntry: FileTextIcon,
 	ConfigDeletedActivityLogEntry: FileTextIcon,
 	ConfigUpdatedActivityLogEntry: FileTextIcon,
+	GenericKubernetesResourceActivityLogEntry: TerminalIcon,
 
 	/* Repositories */
 	RepositoryAddedActivityLogEntry: BranchingIcon,
@@ -77,6 +83,7 @@ export const icons: { [typename: string]: Component } = {
 
 	/* Unleash */
 	UnleashInstanceCreatedActivityLogEntry: UnleashIcon,
+	UnleashInstanceDeletedActivityLogEntry: UnleashIcon,
 	UnleashInstanceUpdatedActivityLogEntry: UnleashIcon,
 
 	/* Stores */

--- a/src/lib/domain/activity/activity-log-tooltip.ts
+++ b/src/lib/domain/activity/activity-log-tooltip.ts
@@ -5,15 +5,21 @@
  */
 export function activityTooltip(typename: string): string {
 	switch (typename) {
+		case 'ApplicationCreatedActivityLogEntry':
 		case 'ApplicationDeletedActivityLogEntry':
 		case 'ApplicationRestartedActivityLogEntry':
 		case 'ApplicationScaledActivityLogEntry':
+		case 'ApplicationUpdatedActivityLogEntry':
 			return 'Application';
 		case 'DeploymentActivityLogEntry':
 			return 'Deployment';
+		case 'ServiceMaintenanceActivityLogEntry':
+			return 'Maintenance';
+		case 'JobCreatedActivityLogEntry':
 		case 'JobTriggeredActivityLogEntry':
 		case 'JobDeletedActivityLogEntry':
 		case 'JobRunDeletedActivityLogEntry':
+		case 'JobUpdatedActivityLogEntry':
 			return 'Job';
 		case 'SecretCreatedActivityLogEntry':
 		case 'SecretDeletedActivityLogEntry':
@@ -28,14 +34,19 @@ export function activityTooltip(typename: string): string {
 		case 'TeamMemberAddedActivityLogEntry':
 		case 'TeamMemberRemovedActivityLogEntry':
 		case 'TeamMemberSetRoleActivityLogEntry':
+		case 'TeamConfirmDeleteKeyActivityLogEntry':
+		case 'TeamCreateDeleteKeyActivityLogEntry':
 		case 'TeamCreatedActivityLogEntry':
 		case 'TeamUpdatedActivityLogEntry':
 		case 'TeamEnvironmentUpdatedActivityLogEntry':
 		case 'TeamDeployKeyUpdatedActivityLogEntry':
 			return 'Team';
 		case 'UnleashInstanceCreatedActivityLogEntry':
+		case 'UnleashInstanceDeletedActivityLogEntry':
 		case 'UnleashInstanceUpdatedActivityLogEntry':
 			return 'Unleash';
+		case 'GenericKubernetesResourceActivityLogEntry':
+			return 'Kubernetes resource';
 		case 'OpenSearchCreatedActivityLogEntry':
 		case 'OpenSearchDeletedActivityLogEntry':
 		case 'OpenSearchUpdatedActivityLogEntry':

--- a/src/lib/domain/activity/activity-log-tooltip.ts
+++ b/src/lib/domain/activity/activity-log-tooltip.ts
@@ -5,6 +5,10 @@
  */
 export function activityTooltip(typename: string): string {
 	switch (typename) {
+		case 'ConfigCreatedActivityLogEntry':
+		case 'ConfigDeletedActivityLogEntry':
+		case 'ConfigUpdatedActivityLogEntry':
+			return 'Config';
 		case 'ApplicationCreatedActivityLogEntry':
 		case 'ApplicationDeletedActivityLogEntry':
 		case 'ApplicationRestartedActivityLogEntry':

--- a/src/lib/domain/activity/shared/texts/ApplicationCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ApplicationCreatedActivityLogEntryText.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import { activityLogResourceLink } from '../../utils';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'ApplicationCreatedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Application
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
+	created
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}
+
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/shared/texts/ApplicationDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ApplicationDeletedActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import type { ActivityLogEntry } from './types';
 
 	let {
@@ -15,7 +14,7 @@
 	Application <strong>{data.resourceName}</strong> was deleted
 
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/ApplicationRestartedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ApplicationRestartedActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 	import type { ActivityLogEntry } from './types';
 
@@ -23,7 +22,7 @@
 	>
 	restarted
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/ApplicationRestartedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ApplicationRestartedActivityLogEntryText.svelte
@@ -12,14 +12,19 @@
 </script>
 
 <div>
-	Application <a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	Application
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	restarted
 	{#if data.environmentName}
 		in {data.environmentName}

--- a/src/lib/domain/activity/shared/texts/ApplicationScaledActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ApplicationScaledActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 	import type { ActivityLogEntry } from './types';
 
@@ -23,7 +22,7 @@
 	>
 	scaled {data.appScaled.direction} to {data.appScaled.newSize} instances
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/ApplicationScaledActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ApplicationScaledActivityLogEntryText.svelte
@@ -12,14 +12,19 @@
 </script>
 
 <div>
-	Application <a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	Application
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	scaled {data.appScaled.direction} to {data.appScaled.newSize} instances
 	{#if data.environmentName}
 		in {data.environmentName}

--- a/src/lib/domain/activity/shared/texts/ApplicationUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ApplicationUpdatedActivityLogEntryText.svelte
@@ -67,7 +67,7 @@
 	}
 
 	code {
-		font-family: monospace;
+		font-family: 'Courier New', Courier, monospace;
 		background-color: var(--ax-bg-neutral-soft);
 		padding: 0.1rem 0.3rem;
 		border-radius: 0.3rem;

--- a/src/lib/domain/activity/shared/texts/ApplicationUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ApplicationUpdatedActivityLogEntryText.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort, ReadMore } from '@nais/ds-svelte-community';
+	import { activityLogResourceLink } from '../../utils';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'ApplicationUpdatedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Application
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
+	updated
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}.
+	<ReadMore header="Updated fields">
+		<dl>
+			{#each data.applicationUpdated.changedFields as field (field.field)}
+				<dt>
+					<code>{field.field}</code>:
+				</dt>
+				<dd>
+					<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
+				</dd>
+			{/each}
+		</dl>
+	</ReadMore>
+
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>
+
+<style>
+	dl {
+		display: grid;
+		grid-template-columns: max-content auto;
+		gap: 0 0.5rem;
+		margin: 0.5rem 0;
+	}
+
+	code {
+		font-family: monospace;
+		background-color: var(--ax-bg-neutral-soft);
+		padding: 0.1rem 0.3rem;
+		border-radius: 0.3rem;
+	}
+</style>

--- a/src/lib/domain/activity/shared/texts/ApplicationUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ApplicationUpdatedActivityLogEntryText.svelte
@@ -29,18 +29,28 @@
 	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}.
-	<ReadMore header="Updated fields">
-		<dl>
-			{#each data.applicationUpdated.changedFields as field (field.field)}
-				<dt>
-					<code>{field.field}</code>:
-				</dt>
-				<dd>
-					<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
-				</dd>
-			{/each}
-		</dl>
-	</ReadMore>
+	{#if data.applicationUpdated.changedFields.length > 0}
+		<ReadMore header="Updated fields">
+			<dl>
+				{#each data.applicationUpdated.changedFields as field (field.field)}
+					<dt>
+						<code>{field.field}</code>:
+					</dt>
+					<dd>
+						{#if field.oldValue != null && field.newValue != null}
+							<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
+						{:else if field.oldValue == null && field.newValue != null}
+							set to <code>{field.newValue}</code>
+						{:else if field.oldValue != null && field.newValue == null}
+							removed (was <code>{field.oldValue}</code>)
+						{:else}
+							changed
+						{/if}
+					</dd>
+				{/each}
+			</dl>
+		</ReadMore>
+	{/if}
 
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/shared/texts/ClusterAuditActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ClusterAuditActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import type { ActivityLogEntry } from './types';
 
 	let {
@@ -14,7 +13,7 @@
 <div>
 	{data.message}
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/ConfigCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ConfigCreatedActivityLogEntryText.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'ConfigCreatedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Config <strong>{data.resourceName}</strong> created
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/shared/texts/ConfigDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ConfigDeletedActivityLogEntryText.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'ConfigDeletedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Config <strong>{data.resourceName}</strong> deleted
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/shared/texts/ConfigUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ConfigUpdatedActivityLogEntryText.svelte
@@ -1,21 +1,19 @@
 <script lang="ts">
-	import type { SidebarActivityLogFragment$data } from '$houdini';
 	import Time from '$lib/ui/Time.svelte';
 	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
 
 	let {
 		data
 	}: {
-		data: Extract<
-			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
-			{ __typename: 'ConfigUpdatedActivityLogEntry' }
-		>;
+		data: ActivityLogEntry<'ConfigUpdatedActivityLogEntry'>;
 	} = $props();
 
 	const formatFieldName = (field: string): string => {
 		if (field.startsWith('value ')) {
 			return 'key ' + field.slice('value '.length);
 		}
+
 		return field;
 	};
 </script>
@@ -25,8 +23,8 @@
 	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}.
-	{#if data.configUpdatedData.updatedFields.length > 0}
-		{#each data.configUpdatedData.updatedFields as field (field)}
+	{#if data.configUpdated?.updatedFields.length}
+		{#each data.configUpdated.updatedFields as field (field.field)}
 			<strong>{formatFieldName(field.field)}</strong>
 			{#if field.oldValue != null && field.newValue != null}
 				changed from <i>{field.oldValue}</i> to <i>{field.newValue}</i>.

--- a/src/lib/domain/activity/shared/texts/DefaultText.svelte
+++ b/src/lib/domain/activity/shared/texts/DefaultText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import type { ActivityLogEntry } from './types';
 
 	let {
@@ -15,7 +14,7 @@
 	{data.message}
 
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/DeploymentActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/DeploymentActivityLogEntryText.svelte
@@ -25,14 +25,18 @@
 	{:else}
 		Deployed
 	{/if}
-	<a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}

--- a/src/lib/domain/activity/shared/texts/DeploymentActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/DeploymentActivityLogEntryText.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <div>
-	{#if triggerURL}
+	{#if triggerURL && data.environmentName}
 		<a
 			href="/team/{data.teamSlug}/{data.environmentName}/{workloadType}/{data.resourceName}/deploys?deployId={id}"
 			>Deployed</a

--- a/src/lib/domain/activity/shared/texts/DeploymentActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/DeploymentActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 	import type { ActivityLogEntry } from './types';
 
@@ -35,7 +34,7 @@
 		)}>{data.resourceName}</a
 	>
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/GenericKubernetesResourceActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/GenericKubernetesResourceActivityLogEntryText.svelte
@@ -11,10 +11,8 @@
 </script>
 
 <div>
-	Applied {data.genericKubernetesData.kind.toLowerCase()} <strong>{data.resourceName}</strong>
-	{#if data.environmentName}
-		in {data.environmentName}
-	{/if}
+	Applied {data.genericKubernetesData.kind.toLowerCase()}
+	<strong>{data.resourceName}</strong>{data.environmentName ? ` in ${data.environmentName}` : ''}.
 	{#if data.genericKubernetesData.changedFields.length > 0}
 		<ReadMore header="Changed fields">
 			<dl>

--- a/src/lib/domain/activity/shared/texts/GenericKubernetesResourceActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/GenericKubernetesResourceActivityLogEntryText.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort, ReadMore } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'GenericKubernetesResourceActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Applied {data.genericKubernetesData.kind.toLowerCase()} <strong>{data.resourceName}</strong>
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}
+	{#if data.genericKubernetesData.changedFields.length > 0}
+		<ReadMore header="Changed fields">
+			<dl>
+				{#each data.genericKubernetesData.changedFields as field (field.field)}
+					<dt>
+						<code>{field.field}</code>:
+					</dt>
+					<dd>
+						<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
+					</dd>
+				{/each}
+			</dl>
+		</ReadMore>
+	{/if}
+
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>
+
+<style>
+	dl {
+		display: grid;
+		grid-template-columns: max-content auto;
+		gap: 0 0.5rem;
+		margin: 0.5rem 0;
+	}
+
+	code {
+		font-family: 'Courier New', Courier, monospace;
+		background-color: var(--ax-bg-neutral-soft);
+		padding: 0.1rem 0.3rem;
+		border-radius: 0.3rem;
+	}
+</style>

--- a/src/lib/domain/activity/shared/texts/GenericKubernetesResourceActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/GenericKubernetesResourceActivityLogEntryText.svelte
@@ -23,7 +23,15 @@
 						<code>{field.field}</code>:
 					</dt>
 					<dd>
-						<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
+						{#if field.oldValue != null && field.newValue != null}
+							<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
+						{:else if field.oldValue == null && field.newValue != null}
+							set to <code>{field.newValue}</code>
+						{:else if field.oldValue != null && field.newValue == null}
+							removed (was <code>{field.oldValue}</code>)
+						{:else}
+							changed
+						{/if}
 					</dd>
 				{/each}
 			</dl>

--- a/src/lib/domain/activity/shared/texts/JobCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/JobCreatedActivityLogEntryText.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import { activityLogResourceLink } from '../../utils';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'JobCreatedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Job
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
+	created
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}
+
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/shared/texts/JobDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/JobDeletedActivityLogEntryText.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Time from '$lib/ui/Time.svelte';
-	import type { ActivityLogEntry } from './types';
 	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
 
 	let {
 		data

--- a/src/lib/domain/activity/shared/texts/JobDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/JobDeletedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
 	import type { ActivityLogEntry } from './types';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -15,7 +14,7 @@
 	Job <strong>{data.resourceName}</strong> was deleted
 
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/JobRunDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/JobRunDeletedActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 	import type { ActivityLogEntry } from './types';
 
@@ -25,7 +24,7 @@
 	deleted
 
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/JobRunDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/JobRunDeletedActivityLogEntryText.svelte
@@ -13,14 +13,18 @@
 
 <div>
 	Job run <strong>{data.jobRunDeletedData?.runName}</strong> from job
-	<a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	deleted
 
 	{#if data.environmentName}

--- a/src/lib/domain/activity/shared/texts/JobTriggeredActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/JobTriggeredActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 	import type { ActivityLogEntry } from './types';
 
@@ -23,7 +22,7 @@
 	>
 	triggered
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/JobTriggeredActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/JobTriggeredActivityLogEntryText.svelte
@@ -12,14 +12,19 @@
 </script>
 
 <div>
-	Job <a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	Job
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	triggered
 	{#if data.environmentName}
 		in {data.environmentName}

--- a/src/lib/domain/activity/shared/texts/JobUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/JobUpdatedActivityLogEntryText.svelte
@@ -29,18 +29,28 @@
 	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}.
-	<ReadMore header="Updated fields">
-		<dl>
-			{#each data.jobUpdated.changedFields as field (field.field)}
-				<dt>
-					<code>{field.field}</code>:
-				</dt>
-				<dd>
-					<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
-				</dd>
-			{/each}
-		</dl>
-	</ReadMore>
+	{#if data.jobUpdated.changedFields.length > 0}
+		<ReadMore header="Updated fields">
+			<dl>
+				{#each data.jobUpdated.changedFields as field (field.field)}
+					<dt>
+						<code>{field.field}</code>:
+					</dt>
+					<dd>
+						{#if field.oldValue != null && field.newValue != null}
+							<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
+						{:else if field.oldValue == null && field.newValue != null}
+							set to <code>{field.newValue}</code>
+						{:else if field.oldValue != null && field.newValue == null}
+							removed (was <code>{field.oldValue}</code>)
+						{:else}
+							changed
+						{/if}
+					</dd>
+				{/each}
+			</dl>
+		</ReadMore>
+	{/if}
 
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/shared/texts/JobUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/JobUpdatedActivityLogEntryText.svelte
@@ -67,7 +67,7 @@
 	}
 
 	code {
-		font-family: monospace;
+		font-family: 'Courier New', Courier, monospace;
 		background-color: var(--ax-bg-neutral-soft);
 		padding: 0.1rem 0.3rem;
 		border-radius: 0.3rem;

--- a/src/lib/domain/activity/shared/texts/JobUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/JobUpdatedActivityLogEntryText.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort, ReadMore } from '@nais/ds-svelte-community';
+	import { activityLogResourceLink } from '../../utils';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'JobUpdatedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Job
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
+	updated
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}.
+	<ReadMore header="Updated fields">
+		<dl>
+			{#each data.jobUpdated.changedFields as field (field.field)}
+				<dt>
+					<code>{field.field}</code>:
+				</dt>
+				<dd>
+					<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
+				</dd>
+			{/each}
+		</dl>
+	</ReadMore>
+
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>
+
+<style>
+	dl {
+		display: grid;
+		grid-template-columns: max-content auto;
+		gap: 0 0.5rem;
+		margin: 0.5rem 0;
+	}
+
+	code {
+		font-family: monospace;
+		background-color: var(--ax-bg-neutral-soft);
+		padding: 0.1rem 0.3rem;
+		border-radius: 0.3rem;
+	}
+</style>

--- a/src/lib/domain/activity/shared/texts/OpenSearchCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/OpenSearchCreatedActivityLogEntryText.svelte
@@ -14,14 +14,18 @@
 
 <div>
 	{resourceTypeToText(data.resourceType)}
-	<a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	created
 	{#if data.environmentName}
 		in {data.environmentName}

--- a/src/lib/domain/activity/shared/texts/OpenSearchCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/OpenSearchCreatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { resourceTypeToText } from '$lib/domain/activity/sidebar/texts/utils';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 	import type { ActivityLogEntry } from './types';
 
@@ -25,7 +24,7 @@
 	>
 	created
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/OpenSearchDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/OpenSearchDeletedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { resourceTypeToText } from '$lib/domain/activity/sidebar/texts/utils';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import type { ActivityLogEntry } from './types';
 
 	let {
@@ -16,7 +15,7 @@
 	{resourceTypeToText(data.resourceType)}
 	<strong>{data.resourceName}</strong> deleted
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/OpenSearchUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/OpenSearchUpdatedActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, ReadMore, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort, ReadMore } from '@nais/ds-svelte-community';
 	import { resourceTypeToText } from '../../sidebar/texts/utils';
 	import { activityLogResourceLink } from '../../utils';
 	import type { ActivityLogEntry } from './types';
@@ -25,7 +24,7 @@
 	>
 	updated
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<ReadMore header="Updated fields">
 		<dl>

--- a/src/lib/domain/activity/shared/texts/OpenSearchUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/OpenSearchUpdatedActivityLogEntryText.svelte
@@ -14,14 +14,18 @@
 
 <div>
 	{resourceTypeToText(data.resourceType)}
-	<a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	updated
 	{#if data.environmentName}
 		in {data.environmentName}

--- a/src/lib/domain/activity/shared/texts/OpenSearchUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/OpenSearchUpdatedActivityLogEntryText.svelte
@@ -30,18 +30,28 @@
 	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}.
-	<ReadMore header="Updated fields">
-		<dl>
-			{#each data.opensearchData.updatedFields as field (field)}
-				<dt>
-					<code>{field.field}</code>:
-				</dt>
-				<dd>
-					<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
-				</dd>
-			{/each}
-		</dl>
-	</ReadMore>
+	{#if data.opensearchData.updatedFields.length > 0}
+		<ReadMore header="Updated fields">
+			<dl>
+				{#each data.opensearchData.updatedFields as field (field)}
+					<dt>
+						<code>{field.field}</code>:
+					</dt>
+					<dd>
+						{#if field.oldValue != null && field.newValue != null}
+							<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
+						{:else if field.oldValue == null && field.newValue != null}
+							set to <code>{field.newValue}</code>
+						{:else if field.oldValue != null && field.newValue == null}
+							removed (was <code>{field.oldValue}</code>)
+						{:else}
+							changed
+						{/if}
+					</dd>
+				{/each}
+			</dl>
+		</ReadMore>
+	{/if}
 
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/shared/texts/PostgresDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/PostgresDeletedActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import type { ActivityLogEntry } from './types';
 
 	let {
@@ -15,7 +14,7 @@
 	Postgres instance <strong>{data.resourceName}</strong> was deleted
 
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/PostgresGrantAccessActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/PostgresGrantAccessActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import type { ActivityLogEntry } from './types';
 
 	let {
@@ -16,7 +15,7 @@
 	<strong>{data.resourceName}</strong>
 	until <Time time={data.postgresGrantAccessData.until} dateFormat="dd/MM/yyyy HH:mm" />
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/SecretCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/SecretCreatedActivityLogEntryText.svelte
@@ -12,14 +12,19 @@
 </script>
 
 <div>
-	Secret <a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	Secret
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	created
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/shared/texts/SecretValueAddedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/SecretValueAddedActivityLogEntryText.svelte
@@ -14,14 +14,18 @@
 <div>
 	Value
 	<span class="valueName">{data.secretValueAdded.valueName}</span> was added to secret
-	<a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/shared/texts/SecretValueRemovedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/SecretValueRemovedActivityLogEntryText.svelte
@@ -13,14 +13,18 @@
 
 <div>
 	Value <strong>{data.secretValueRemoved.valueName}</strong> in secret
-	<a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	was removed
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/shared/texts/SecretValueUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/SecretValueUpdatedActivityLogEntryText.svelte
@@ -13,14 +13,18 @@
 
 <div>
 	Value <strong>{data.secretValueUpdated.valueName}</strong> in secret
-	<a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	was updated
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/shared/texts/SecretValuesViewedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/SecretValuesViewedActivityLogEntryText.svelte
@@ -13,14 +13,18 @@
 
 <div>
 	Viewed secret values for
-	<a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	{#if data.secretValuesViewed?.reason}
 		<BodyShort size="small"><em>Reason: {data.secretValuesViewed.reason}</em></BodyShort>
 	{/if}

--- a/src/lib/domain/activity/shared/texts/ServiceMaintenanceActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ServiceMaintenanceActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 	import type { ActivityLogEntry } from './types';
 
@@ -29,7 +28,7 @@
 	<a href={link}><strong>{data.resourceName}</strong></a>
 
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/ServiceMaintenanceActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ServiceMaintenanceActivityLogEntryText.svelte
@@ -11,12 +11,14 @@
 	} = $props();
 
 	const link = $derived(
-		activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)
+		data.environmentName
+			? activityLogResourceLink(
+					data.environmentName,
+					data.resourceType,
+					data.resourceName,
+					data.teamSlug
+				)
+			: null
 	);
 
 	const properServiceName = (t: string) =>
@@ -25,7 +27,11 @@
 
 <div>
 	Started maintenance on {properServiceName(data.resourceType)}
-	<a href={link}><strong>{data.resourceName}</strong></a>
+	{#if link}
+		<a href={link}><strong>{data.resourceName}</strong></a>
+	{:else}
+		<strong>{data.resourceName}</strong>
+	{/if}
 
 	{#if data.environmentName}
 		in {data.environmentName}

--- a/src/lib/domain/activity/shared/texts/ServiceMaintenanceActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ServiceMaintenanceActivityLogEntryText.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resourceTypeToText } from '$lib/domain/activity/sidebar/texts/utils';
 	import Time from '$lib/ui/Time.svelte';
 	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
@@ -20,13 +21,10 @@
 				)
 			: null
 	);
-
-	const properServiceName = (t: string) =>
-		t === 'OPENSEARCH' ? 'OpenSearch' : t === 'VALKEY' ? 'Valkey' : 'service';
 </script>
 
 <div>
-	Started maintenance on {properServiceName(data.resourceType)}
+	Started maintenance on {resourceTypeToText(data.resourceType)}
 	{#if link}
 		<a href={link}><strong>{data.resourceName}</strong></a>
 	{:else}

--- a/src/lib/domain/activity/shared/texts/TeamConfirmDeleteKeyActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/TeamConfirmDeleteKeyActivityLogEntryText.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'TeamConfirmDeleteKeyActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Confirmed delete key for team <a href="/team/{data.teamSlug}">{data.resourceName}</a>
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/shared/texts/TeamCreateDeleteKeyActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/TeamCreateDeleteKeyActivityLogEntryText.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'TeamCreateDeleteKeyActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Created delete key for team <a href="/team/{data.teamSlug}">{data.resourceName}</a>
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/shared/texts/TeamCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/TeamCreatedActivityLogEntryText.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'TeamCreatedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Created team <a href="/team/{data.teamSlug}">{data.resourceName}</a>
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/shared/texts/TeamDeployKeyUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/TeamDeployKeyUpdatedActivityLogEntryText.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'TeamDeployKeyUpdatedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Updated deploy key for team <a href="/team/{data.teamSlug}">{data.resourceName}</a>
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/shared/texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte
@@ -11,16 +11,15 @@
 </script>
 
 <div>
-	{data.message}.
+	{data.message}
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}.
 	{#if data.teamEnvironmentUpdated.updatedFields.length > 0}
 		{#each data.teamEnvironmentUpdated.updatedFields as field (field)}
 			<strong>{field.field}</strong>: Changed from <i>{field.oldValue}</i> to
 			<i>{field.newValue}</i>.
 		{/each}
-	{/if}
-
-	{#if data.environmentName}
-		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import type { ActivityLogEntry } from './types';
 
 	let {
@@ -21,7 +20,7 @@
 	{/if}
 
 	{#if data.environmentName}
-		<Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/TeamUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/TeamUpdatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
 	import type { ActivityLogEntry } from './types';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -20,7 +19,7 @@
 	{/if}
 
 	{#if data.environmentName}
-		<Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/TeamUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/TeamUpdatedActivityLogEntryText.svelte
@@ -12,14 +12,13 @@
 
 <div>
 	{data.message}
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}.
 	{#if data.teamUpdated?.updatedFields.length}
 		{#each data.teamUpdated?.updatedFields as field (field)}
 			{field.field}. Changed from <i>{field.oldValue}</i> to <i>{field.newValue}</i>.
 		{/each}
-	{/if}
-
-	{#if data.environmentName}
-		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/TeamUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/TeamUpdatedActivityLogEntryText.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Time from '$lib/ui/Time.svelte';
-	import type { ActivityLogEntry } from './types';
 	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
 
 	let {
 		data

--- a/src/lib/domain/activity/shared/texts/UnleashInstanceCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/UnleashInstanceCreatedActivityLogEntryText.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'UnleashInstanceCreatedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Unleash instance <a href="/team/{data.teamSlug}/unleash">{data.resourceName}</a> created
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/shared/texts/UnleashInstanceDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/UnleashInstanceDeletedActivityLogEntryText.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import type { ActivityLogEntry } from './types';
+
+	let {
+		data
+	}: {
+		data: ActivityLogEntry<'UnleashInstanceDeletedActivityLogEntry'>;
+	} = $props();
+</script>
+
+<div>
+	Unleash instance <strong>{data.resourceName}</strong> deleted
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/shared/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import type { ActivityLogEntry } from './types';
 
 	let {
@@ -24,7 +23,7 @@
 	{/if}
 
 	{#if data.environmentName}
-		<Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
@@ -10,25 +10,19 @@
 	} = $props();
 
 	const u = $derived(data.unleashInstanceUpdated);
+	const environmentSuffix = $derived(data.environmentName ? ` in ${data.environmentName}` : '');
 </script>
 
 <div>
 	{data.message}
 	{#if u.allowedTeamSlug}
-		Allowed <a href="/team/{u.allowedTeamSlug}">{u.allowedTeamSlug}</a> to access the instance
-		{#if data.environmentName}
-			in {data.environmentName}
-		{/if}.
+		Allowed <a href="/team/{u.allowedTeamSlug}">{u.allowedTeamSlug}</a> to access the instance{environmentSuffix}.
 	{:else if u.revokedTeamSlug}
-		Revoked access for <a href="/team/{u.revokedTeamSlug}">{u.revokedTeamSlug}</a> to the instance
-		{#if data.environmentName}
-			in {data.environmentName}
-		{/if}.
+		Revoked access for <a href="/team/{u.revokedTeamSlug}">{u.revokedTeamSlug}</a> to the instance{environmentSuffix}.
 	{:else if u.updatedReleaseChannel}
-		Changed release channel to <strong>{u.updatedReleaseChannel}</strong>
-		{#if data.environmentName}
-			in {data.environmentName}
-		{/if}.
+		Changed release channel to <strong>{u.updatedReleaseChannel}</strong>{environmentSuffix}.
+	{:else}
+		{environmentSuffix}.
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
@@ -15,15 +15,20 @@
 <div>
 	{data.message}
 	{#if u.allowedTeamSlug}
-		Allowed <a href="/team/{u.allowedTeamSlug}">{u.allowedTeamSlug}</a> to access the instance.
+		Allowed <a href="/team/{u.allowedTeamSlug}">{u.allowedTeamSlug}</a> to access the instance
+		{#if data.environmentName}
+			in {data.environmentName}
+		{/if}.
 	{:else if u.revokedTeamSlug}
-		Revoked access for <a href="/team/{u.revokedTeamSlug}">{u.revokedTeamSlug}</a> to the instance.
+		Revoked access for <a href="/team/{u.revokedTeamSlug}">{u.revokedTeamSlug}</a> to the instance
+		{#if data.environmentName}
+			in {data.environmentName}
+		{/if}.
 	{:else if u.updatedReleaseChannel}
-		Changed release channel to <strong>{u.updatedReleaseChannel}</strong>.
-	{/if}
-
-	{#if data.environmentName}
-		in {data.environmentName}
+		Changed release channel to <strong>{u.updatedReleaseChannel}</strong>
+		{#if data.environmentName}
+			in {data.environmentName}
+		{/if}.
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/ValkeyCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ValkeyCreatedActivityLogEntryText.svelte
@@ -14,14 +14,18 @@
 
 <div>
 	{resourceTypeToText(data.resourceType)}
-	<a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	created
 	{#if data.environmentName}
 		in {data.environmentName}

--- a/src/lib/domain/activity/shared/texts/ValkeyCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ValkeyCreatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { resourceTypeToText } from '$lib/domain/activity/sidebar/texts/utils';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 	import type { ActivityLogEntry } from './types';
 
@@ -25,7 +24,7 @@
 	>
 	created
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/ValkeyDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ValkeyDeletedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { resourceTypeToText } from '$lib/domain/activity/sidebar/texts/utils';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import type { ActivityLogEntry } from './types';
 
 	let {
@@ -16,7 +15,7 @@
 	{resourceTypeToText(data.resourceType)}
 	<strong>{data.resourceName}</strong> deleted
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/shared/texts/ValkeyUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ValkeyUpdatedActivityLogEntryText.svelte
@@ -14,14 +14,18 @@
 
 <div>
 	{resourceTypeToText(data.resourceType)}
-	<a
-		href={activityLogResourceLink(
-			data.environmentName ?? '',
-			data.resourceType,
-			data.resourceName,
-			data.teamSlug
-		)}>{data.resourceName}</a
-	>
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
 	updated
 	{#if data.environmentName}
 		in {data.environmentName}

--- a/src/lib/domain/activity/shared/texts/ValkeyUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ValkeyUpdatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { resourceTypeToText } from '$lib/domain/activity/sidebar/texts/utils';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, ReadMore, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort, ReadMore } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 	import type { ActivityLogEntry } from './types';
 
@@ -25,7 +24,7 @@
 	>
 	updated
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<ReadMore header="Updated fields">
 		<dl>

--- a/src/lib/domain/activity/shared/texts/ValkeyUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/ValkeyUpdatedActivityLogEntryText.svelte
@@ -30,18 +30,28 @@
 	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}.
-	<ReadMore header="Updated fields">
-		<dl>
-			{#each data.valkeyData.updatedFields as field (field)}
-				<dt>
-					<code>{field.field}</code>:
-				</dt>
-				<dd>
-					<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
-				</dd>
-			{/each}
-		</dl>
-	</ReadMore>
+	{#if data.valkeyData.updatedFields.length > 0}
+		<ReadMore header="Updated fields">
+			<dl>
+				{#each data.valkeyData.updatedFields as field (field)}
+					<dt>
+						<code>{field.field}</code>:
+					</dt>
+					<dd>
+						{#if field.oldValue != null && field.newValue != null}
+							<code>{field.oldValue}</code> -> <code>{field.newValue}</code>
+						{:else if field.oldValue == null && field.newValue != null}
+							set to <code>{field.newValue}</code>
+						{:else if field.oldValue != null && field.newValue == null}
+							removed (was <code>{field.oldValue}</code>)
+						{:else}
+							changed
+						{/if}
+					</dd>
+				{/each}
+			</dl>
+		</ReadMore>
+	{/if}
 
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/shared/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
@@ -63,13 +63,13 @@
 					{#if vuln.previousSuppression?.state}
 						<p>
 							<strong>Previous state:</strong>
-							{vuln.previousSuppression.state.replace('_', ' ').toLowerCase()}
+							{vuln.previousSuppression.state.replaceAll('_', ' ').toLowerCase()}
 						</p>
 					{/if}
 					{#if vuln.newSuppression?.state}
 						<p>
 							<strong>New state:</strong>
-							{vuln.newSuppression.state.replace('_', ' ').toLowerCase()}
+							{vuln.newSuppression.state.replaceAll('_', ' ').toLowerCase()}
 						</p>
 					{/if}
 				{/if}

--- a/src/lib/domain/activity/shared/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
@@ -27,7 +27,7 @@
 	function getSeverityClass(severity: string | undefined | null): string {
 		if (!severity) return '';
 		const normalized = severity.toLowerCase();
-		const validSeverities = ['critical', 'high', 'medium', 'low'];
+		const validSeverities = ['critical', 'high', 'medium', 'low', 'unassigned'];
 		return validSeverities.includes(normalized) ? `severity-${normalized}` : '';
 	}
 </script>
@@ -125,6 +125,11 @@
 
 	.vulnerability-severity.severity-low {
 		background-color: var(--ax-bg-default);
+		color: var(--ax-text-subtle);
+	}
+
+	.vulnerability-severity.severity-unassigned {
+		background-color: var(--ax-neutral-200);
 		color: var(--ax-text-subtle);
 	}
 

--- a/src/lib/domain/activity/shared/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
@@ -15,10 +15,14 @@
 		vuln?.newSuppression?.reason !== vuln?.previousSuppression?.reason
 	);
 	const isNewSuppression = $derived(
-		vuln?.newSuppression?.state && !vuln?.previousSuppression?.state
+		Boolean(vuln?.newSuppression?.state && !vuln?.previousSuppression?.state)
 	);
-	const isUnsuppressed = $derived(vuln?.previousSuppression?.state && !vuln?.newSuppression?.state);
-	const isStateChange = $derived(vuln?.newSuppression?.state && vuln?.previousSuppression?.state);
+	const isUnsuppressed = $derived(
+		Boolean(vuln?.previousSuppression?.state && !vuln?.newSuppression?.state)
+	);
+	const isStateChange = $derived(
+		Boolean(vuln?.newSuppression?.state && vuln?.previousSuppression?.state)
+	);
 
 	function getSeverityClass(severity: string | undefined | null): string {
 		if (!severity) return '';

--- a/src/lib/domain/activity/sidebar/SidebarActivity.svelte
+++ b/src/lib/domain/activity/sidebar/SidebarActivity.svelte
@@ -10,8 +10,10 @@
 	import type { Component } from 'svelte';
 
 	import { icons } from '../activity-log-icons';
+	import ApplicationCreatedActivityLogEntryText from './texts/ApplicationCreatedActivityLogEntryText.svelte';
 	import ApplicationRestartedActivityLogEntryText from './texts/ApplicationRestartedActivityLogEntryText.svelte';
 	import ApplicationScaledActivityLogEntryText from './texts/ApplicationScaledActivityLogEntryText.svelte';
+	import ApplicationUpdatedActivityLogEntryText from './texts/ApplicationUpdatedActivityLogEntryText.svelte';
 	import ClusterAuditActivityLogEntryText from './texts/ClusterAuditActivityLogEntryText.svelte';
 	import ConfigCreatedActivityLogEntryText from './texts/ConfigCreatedActivityLogEntryText.svelte';
 	import ConfigDeletedActivityLogEntryText from './texts/ConfigDeletedActivityLogEntryText.svelte';
@@ -19,12 +21,16 @@
 	import CredentialsActivityLogEntryText from './texts/CredentialsActivityLogEntryText.svelte';
 	import DefaultText from './texts/DefaultText.svelte';
 	import DeploymentActivityLogEntryText from './texts/DeploymentActivityLogEntryText.svelte';
+	import GenericKubernetesResourceActivityLogEntryText from './texts/GenericKubernetesResourceActivityLogEntryText.svelte';
+	import JobCreatedActivityLogEntryText from './texts/JobCreatedActivityLogEntryText.svelte';
 	import JobRunDeletedActivityLogEntryText from './texts/JobRunDeletedActivityLogEntryText.svelte';
 	import JobTriggeredActivityLogEntryText from './texts/JobTriggeredActivityLogEntryText.svelte';
+	import JobUpdatedActivityLogEntryText from './texts/JobUpdatedActivityLogEntryText.svelte';
 	import OpenSearchCreatedActivityLogEntryText from './texts/OpenSearchCreatedActivityLogEntryText.svelte';
 	import OpenSearchDeletedActivityLogEntryText from './texts/OpenSearchDeletedActivityLogEntryText.svelte';
 	import OpenSearchUpdatedActivityLogEntryText from './texts/OpenSearchUpdatedActivityLogEntryText.svelte';
 	import PostgresDeletedActivityLogEntryText from './texts/PostgresDeletedActivityLogEntryText.svelte';
+	import PostgresGrantAccessActivityLogEntryText from './texts/PostgresGrantAccessActivityLogEntryText.svelte';
 	import RepositoryAddedActivityLogEntryText from './texts/RepositoryAddedActivityLogEntryText.svelte';
 	import RepositoryRemovedActivityLogEntryText from './texts/RepositoryRemovedActivityLogEntryText.svelte';
 	import ResourceDeletedActivityLogEntryText from './texts/ResourceDeletedActivityLogEntryText.svelte';
@@ -34,14 +40,23 @@
 	import SecretValueRemovedActivityLogEntryText from './texts/SecretValueRemovedActivityLogEntryText.svelte';
 	import SecretValueUpdatedActivityLogEntryText from './texts/SecretValueUpdatedActivityLogEntryText.svelte';
 	import SecretValuesViewedActivityLogEntryText from './texts/SecretValuesViewedActivityLogEntryText.svelte';
+	import ServiceMaintenanceActivityLogEntryText from './texts/ServiceMaintenanceActivityLogEntryText.svelte';
+	import TeamConfirmDeleteKeyActivityLogEntryText from './texts/TeamConfirmDeleteKeyActivityLogEntryText.svelte';
+	import TeamCreateDeleteKeyActivityLogEntryText from './texts/TeamCreateDeleteKeyActivityLogEntryText.svelte';
+	import TeamCreatedActivityLogEntryText from './texts/TeamCreatedActivityLogEntryText.svelte';
+	import TeamDeployKeyUpdatedActivityLogEntryText from './texts/TeamDeployKeyUpdatedActivityLogEntryText.svelte';
 	import TeamEnvironmentUpdatedActivityLogEntryText from './texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte';
 	import TeamMemberAddedActivityLogEntryText from './texts/TeamMemberAddedActivityLogEntryText.svelte';
 	import TeamMemberRemovedActivityLogEntryText from './texts/TeamMemberRemovedActivityLogEntryText.svelte';
 	import TeamMemberSetRoleActivityLogEntryText from './texts/TeamMemberSetRoleActivityLogEntryText.svelte';
 	import TeamUpdatedActivityLogEntryText from './texts/TeamUpdatedActivityLogEntryText.svelte';
+	import UnleashInstanceCreatedActivityLogEntryText from './texts/UnleashInstanceCreatedActivityLogEntryText.svelte';
+	import UnleashInstanceDeletedActivityLogEntryText from './texts/UnleashInstanceDeletedActivityLogEntryText.svelte';
+	import UnleashInstanceUpdatedActivityLogEntryText from './texts/UnleashInstanceUpdatedActivityLogEntryText.svelte';
 	import ValkeyCreatedActivityLogEntryText from './texts/ValkeyCreatedActivityLogEntryText.svelte';
 	import ValkeyDeletedActivityLogEntryText from './texts/ValkeyDeletedActivityLogEntryText.svelte';
 	import ValkeyUpdatedActivityLogEntryText from './texts/ValkeyUpdatedActivityLogEntryText.svelte';
+	import VulnerabilityUpdatedActivityLogEntryText from './texts/VulnerabilityUpdatedActivityLogEntryText.svelte';
 
 	interface Props {
 		activityLog: SidebarActivityLogFragment;
@@ -73,10 +88,32 @@
 									triggerURL
 								}
 							}
+							... on GenericKubernetesResourceActivityLogEntry {
+								genericKubernetesData: data {
+									kind
+									changedFields {
+										field
+										oldValue
+										newValue
+									}
+								}
+							}
 							... on ApplicationScaledActivityLogEntry {
 								appScaled: data {
 									newSize
 									direction
+								}
+							}
+							... on ApplicationCreatedActivityLogEntry {
+								id
+							}
+							... on ApplicationUpdatedActivityLogEntry {
+								applicationUpdatedData: data {
+									changedFields {
+										field
+										oldValue
+										newValue
+									}
 								}
 							}
 							... on ClusterAuditActivityLogEntry {
@@ -144,6 +181,15 @@
 									}
 								}
 							}
+							... on TeamConfirmDeleteKeyActivityLogEntry {
+								id
+							}
+							... on TeamCreateDeleteKeyActivityLogEntry {
+								id
+							}
+							... on TeamCreatedActivityLogEntry {
+								id
+							}
 							... on TeamDeployKeyUpdatedActivityLogEntry {
 								id
 							}
@@ -153,8 +199,20 @@
 									runName
 								}
 							}
+							... on JobCreatedActivityLogEntry {
+								id
+							}
 							... on JobTriggeredActivityLogEntry {
 								id
+							}
+							... on JobUpdatedActivityLogEntry {
+								jobUpdatedData: data {
+									changedFields {
+										field
+										oldValue
+										newValue
+									}
+								}
 							}
 							... on TeamMemberAddedActivityLogEntry {
 								addedData: data {
@@ -201,6 +259,9 @@
 									ttl
 								}
 							}
+							... on ServiceMaintenanceActivityLogEntry {
+								id
+							}
 							... on ValkeyCreatedActivityLogEntry {
 								id
 							}
@@ -224,6 +285,40 @@
 							}
 							... on PostgresDeletedActivityLogEntry {
 								id
+							}
+							... on PostgresGrantAccessActivityLogEntry {
+								postgresGrantAccessData: data {
+									grantee
+									until
+								}
+							}
+							... on UnleashInstanceCreatedActivityLogEntry {
+								id
+							}
+							... on UnleashInstanceDeletedActivityLogEntry {
+								id
+							}
+							... on UnleashInstanceUpdatedActivityLogEntry {
+								unleashInstanceUpdatedData: data {
+									allowedTeamSlug
+									revokedTeamSlug
+									updatedReleaseChannel
+								}
+							}
+							... on VulnerabilityUpdatedActivityLogEntry {
+								vulnerabilityUpdatedData: data {
+									identifier
+									package
+									severity
+									previousSuppression {
+										reason
+										state
+									}
+									newSuppression {
+										reason
+										state
+									}
+								}
 							}
 							... on OpenSearchUpdatedActivityLogEntry {
 								opensearchData: data {
@@ -249,8 +344,14 @@
 		switch (kind) {
 			case 'DeploymentActivityLogEntry':
 				return DeploymentActivityLogEntryText as Component<{ data: unknown }>;
+			case 'ApplicationCreatedActivityLogEntry':
+				return ApplicationCreatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ApplicationScaledActivityLogEntry':
 				return ApplicationScaledActivityLogEntryText as Component<{ data: unknown }>;
+			case 'ApplicationUpdatedActivityLogEntry':
+				return ApplicationUpdatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'GenericKubernetesResourceActivityLogEntry':
+				return GenericKubernetesResourceActivityLogEntryText as Component<{ data: unknown }>;
 			case 'RepositoryAddedActivityLogEntry':
 				return RepositoryAddedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'RepositoryRemovedActivityLogEntry':
@@ -273,10 +374,22 @@
 				return ConfigDeletedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ConfigUpdatedActivityLogEntry':
 				return ConfigUpdatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'JobCreatedActivityLogEntry':
+				return JobCreatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'JobRunDeletedActivityLogEntry':
 				return JobRunDeletedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'JobTriggeredActivityLogEntry':
 				return JobTriggeredActivityLogEntryText as Component<{ data: unknown }>;
+			case 'JobUpdatedActivityLogEntry':
+				return JobUpdatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'TeamConfirmDeleteKeyActivityLogEntry':
+				return TeamConfirmDeleteKeyActivityLogEntryText as Component<{ data: unknown }>;
+			case 'TeamCreateDeleteKeyActivityLogEntry':
+				return TeamCreateDeleteKeyActivityLogEntryText as Component<{ data: unknown }>;
+			case 'TeamCreatedActivityLogEntry':
+				return TeamCreatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'TeamDeployKeyUpdatedActivityLogEntry':
+				return TeamDeployKeyUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'TeamEnvironmentUpdatedActivityLogEntry':
 				return TeamEnvironmentUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'TeamMemberAddedActivityLogEntry':
@@ -296,6 +409,8 @@
 				return ApplicationRestartedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'CredentialsActivityLogEntry':
 				return CredentialsActivityLogEntryText as Component<{ data: unknown }>;
+			case 'ServiceMaintenanceActivityLogEntry':
+				return ServiceMaintenanceActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ValkeyCreatedActivityLogEntry':
 				return ValkeyCreatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ValkeyDeletedActivityLogEntry':
@@ -310,6 +425,16 @@
 				return OpenSearchUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'PostgresDeletedActivityLogEntry':
 				return PostgresDeletedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'PostgresGrantAccessActivityLogEntry':
+				return PostgresGrantAccessActivityLogEntryText as Component<{ data: unknown }>;
+			case 'UnleashInstanceCreatedActivityLogEntry':
+				return UnleashInstanceCreatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'UnleashInstanceDeletedActivityLogEntry':
+				return UnleashInstanceDeletedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'UnleashInstanceUpdatedActivityLogEntry':
+				return UnleashInstanceUpdatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'VulnerabilityUpdatedActivityLogEntry':
+				return VulnerabilityUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			default:
 				return DefaultText as Component<{ data: unknown }>;
 		}

--- a/src/lib/domain/activity/sidebar/SidebarActivity.svelte
+++ b/src/lib/domain/activity/sidebar/SidebarActivity.svelte
@@ -244,6 +244,13 @@
 									}
 								}
 							}
+							... on UnleashInstanceUpdatedActivityLogEntry {
+								unleashInstanceUpdatedData: data {
+									allowedTeamSlug
+									revokedTeamSlug
+									updatedReleaseChannel
+								}
+							}
 							... on ApplicationRestartedActivityLogEntry {
 								id
 							}
@@ -298,11 +305,13 @@
 							... on UnleashInstanceDeletedActivityLogEntry {
 								id
 							}
-							... on UnleashInstanceUpdatedActivityLogEntry {
-								unleashInstanceUpdatedData: data {
-									allowedTeamSlug
-									revokedTeamSlug
-									updatedReleaseChannel
+							... on OpenSearchUpdatedActivityLogEntry {
+								opensearchData: data {
+									updatedFields {
+										field
+										newValue
+										oldValue
+									}
 								}
 							}
 							... on VulnerabilityUpdatedActivityLogEntry {
@@ -311,21 +320,12 @@
 									package
 									severity
 									previousSuppression {
-										reason
 										state
+										reason
 									}
 									newSuppression {
-										reason
 										state
-									}
-								}
-							}
-							... on OpenSearchUpdatedActivityLogEntry {
-								opensearchData: data {
-									updatedFields {
-										field
-										newValue
-										oldValue
+										reason
 									}
 								}
 							}
@@ -400,6 +400,8 @@
 				return TeamMemberSetRoleActivityLogEntryText as Component<{ data: unknown }>;
 			case 'TeamUpdatedActivityLogEntry':
 				return TeamUpdatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'UnleashInstanceUpdatedActivityLogEntry':
+				return UnleashInstanceUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ClusterAuditActivityLogEntry':
 				return ClusterAuditActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ApplicationDeletedActivityLogEntry':
@@ -431,8 +433,6 @@
 				return UnleashInstanceCreatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'UnleashInstanceDeletedActivityLogEntry':
 				return UnleashInstanceDeletedActivityLogEntryText as Component<{ data: unknown }>;
-			case 'UnleashInstanceUpdatedActivityLogEntry':
-				return UnleashInstanceUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'VulnerabilityUpdatedActivityLogEntry':
 				return VulnerabilityUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			default:

--- a/src/lib/domain/activity/sidebar/texts/ApplicationCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ApplicationCreatedActivityLogEntryText.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import { activityLogResourceLink } from '../../utils';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'ApplicationCreatedActivityLogEntry' }
+		>;
+	} = $props();
+</script>
+
+<div>
+	Application
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
+	created
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}.
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/ApplicationCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ApplicationCreatedActivityLogEntryText.svelte
@@ -28,10 +28,7 @@
 	{:else}
 		{data.resourceName}
 	{/if}
-	created
-	{#if data.environmentName}
-		in {data.environmentName}
-	{/if}.
+	created{data.environmentName ? ` in ${data.environmentName}` : ''}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}
 		<Time time={data.createdAt} distance />

--- a/src/lib/domain/activity/sidebar/texts/ApplicationRestartedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ApplicationRestartedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 
 	let {
@@ -31,7 +30,7 @@
 	{/if}
 	restarted
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/ApplicationScaledActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ApplicationScaledActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 
 	let {
@@ -31,7 +30,7 @@
 	{/if}
 	scaled {data.appScaled.direction} to {data.appScaled.newSize} replicas
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/sidebar/texts/ApplicationUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ApplicationUpdatedActivityLogEntryText.svelte
@@ -2,32 +2,39 @@
 	import type { SidebarActivityLogFragment$data } from '$houdini';
 	import Time from '$lib/ui/Time.svelte';
 	import { BodyShort } from '@nais/ds-svelte-community';
+	import { activityLogResourceLink } from '../../utils';
 
 	let {
 		data
 	}: {
 		data: Extract<
 			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
-			{ __typename: 'ConfigUpdatedActivityLogEntry' }
+			{ __typename: 'ApplicationUpdatedActivityLogEntry' }
 		>;
 	} = $props();
-
-	const formatFieldName = (field: string): string => {
-		if (field.startsWith('value ')) {
-			return 'key ' + field.slice('value '.length);
-		}
-		return field;
-	};
 </script>
 
 <div>
-	Updated config <strong>{data.resourceName}</strong>
+	Application
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
+	updated
 	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}.
-	{#if data.configUpdatedData.updatedFields.length > 0}
-		{#each data.configUpdatedData.updatedFields as field (field)}
-			<strong>{formatFieldName(field.field)}</strong>
+	{#if data.applicationUpdatedData.changedFields.length > 0}
+		{#each data.applicationUpdatedData.changedFields as field (field.field)}
+			<strong>{field.field}</strong>
 			{#if field.oldValue != null && field.newValue != null}
 				changed from <i>{field.oldValue}</i> to <i>{field.newValue}</i>.
 			{:else if field.oldValue == null && field.newValue != null}
@@ -39,7 +46,6 @@
 			{/if}
 		{/each}
 	{/if}
-
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}
 		<Time time={data.createdAt} distance />

--- a/src/lib/domain/activity/sidebar/texts/ClusterAuditActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ClusterAuditActivityLogEntryText.svelte
@@ -16,7 +16,9 @@
 
 <div>
 	{capitalizeFirstLetter(data.message.toLowerCase())}
-	in {data.environmentName}
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}
 
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/ClusterAuditActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ClusterAuditActivityLogEntryText.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
 	import { capitalizeFirstLetter } from '$lib/utils/formatters';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -17,8 +16,7 @@
 
 <div>
 	{capitalizeFirstLetter(data.message.toLowerCase())}
-	in
-	<Tag size="small" variant={envTagVariant(data.environmentName || '')}>{data.environmentName}</Tag>
+	in {data.environmentName}
 
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/ConfigCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ConfigCreatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -17,7 +16,7 @@
 <div>
 	Config <strong>{data.resourceName}</strong> created
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/ConfigDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ConfigDeletedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -17,7 +16,7 @@
 <div>
 	Config <strong>{data.resourceName}</strong> deleted
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/ConfigUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ConfigUpdatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -39,7 +38,7 @@
 	{/if}
 
 	{#if data.environmentName}
-		<Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/sidebar/texts/CredentialsActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/CredentialsActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -32,7 +31,7 @@
 	{/if}
 	(TTL: {data.credentialsData.ttl})
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/DeploymentActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/DeploymentActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 
 	let {
@@ -26,9 +25,7 @@
 			href="/team/{data.teamSlug}/{data.environmentName}/{workloadType}/{data.resourceName}/deploys?deployId={id}"
 			>Deployed</a
 		>
-		{data.resourceName} to <Tag size="small" variant={envTagVariant(data.environmentName || '')}
-			>{data.environmentName}</Tag
-		>
+		{data.resourceName} to {data.environmentName}
 	{:else}
 		Deployed
 		{#if data.environmentName}
@@ -44,8 +41,7 @@
 			{data.resourceName}
 		{/if}
 		{#if data.environmentName}
-			to <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag
-			>
+			to {data.environmentName}
 		{/if}
 	{/if}
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/sidebar/texts/DeploymentActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/DeploymentActivityLogEntryText.svelte
@@ -20,7 +20,7 @@
 </script>
 
 <div>
-	{#if triggerURL}
+	{#if triggerURL && data.environmentName}
 		<a
 			href="/team/{data.teamSlug}/{data.environmentName}/{workloadType}/{data.resourceName}/deploys?deployId={id}"
 			>Deployed</a

--- a/src/lib/domain/activity/sidebar/texts/GenericKubernetesResourceActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/GenericKubernetesResourceActivityLogEntryText.svelte
@@ -14,10 +14,8 @@
 </script>
 
 <div>
-	Applied {data.genericKubernetesData.kind.toLowerCase()} <strong>{data.resourceName}</strong>
-	{#if data.environmentName}
-		in {data.environmentName}
-	{/if}.
+	Applied {data.genericKubernetesData.kind.toLowerCase()}
+	<strong>{data.resourceName}</strong>{data.environmentName ? ` in ${data.environmentName}` : ''}.
 	{#if data.genericKubernetesData.changedFields.length > 0}
 		{#each data.genericKubernetesData.changedFields as field (field.field)}
 			<strong>{field.field}</strong>

--- a/src/lib/domain/activity/sidebar/texts/GenericKubernetesResourceActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/GenericKubernetesResourceActivityLogEntryText.svelte
@@ -8,26 +8,19 @@
 	}: {
 		data: Extract<
 			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
-			{ __typename: 'ConfigUpdatedActivityLogEntry' }
+			{ __typename: 'GenericKubernetesResourceActivityLogEntry' }
 		>;
 	} = $props();
-
-	const formatFieldName = (field: string): string => {
-		if (field.startsWith('value ')) {
-			return 'key ' + field.slice('value '.length);
-		}
-		return field;
-	};
 </script>
 
 <div>
-	Updated config <strong>{data.resourceName}</strong>
+	Applied {data.genericKubernetesData.kind.toLowerCase()} <strong>{data.resourceName}</strong>
 	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}.
-	{#if data.configUpdatedData.updatedFields.length > 0}
-		{#each data.configUpdatedData.updatedFields as field (field)}
-			<strong>{formatFieldName(field.field)}</strong>
+	{#if data.genericKubernetesData.changedFields.length > 0}
+		{#each data.genericKubernetesData.changedFields as field (field.field)}
+			<strong>{field.field}</strong>
 			{#if field.oldValue != null && field.newValue != null}
 				changed from <i>{field.oldValue}</i> to <i>{field.newValue}</i>.
 			{:else if field.oldValue == null && field.newValue != null}
@@ -39,7 +32,6 @@
 			{/if}
 		{/each}
 	{/if}
-
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}
 		<Time time={data.createdAt} distance />

--- a/src/lib/domain/activity/sidebar/texts/JobCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/JobCreatedActivityLogEntryText.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import { activityLogResourceLink } from '../../utils';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'JobCreatedActivityLogEntry' }
+		>;
+	} = $props();
+</script>
+
+<div>
+	Job
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
+	created
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}.
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/JobRunDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/JobRunDeletedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -19,7 +18,7 @@
 	<strong>{data.resourceName}</strong>
 	deleted
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/JobTriggeredActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/JobTriggeredActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 
 	let {
@@ -31,7 +30,7 @@
 	{/if}
 	triggered
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/JobUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/JobUpdatedActivityLogEntryText.svelte
@@ -2,32 +2,39 @@
 	import type { SidebarActivityLogFragment$data } from '$houdini';
 	import Time from '$lib/ui/Time.svelte';
 	import { BodyShort } from '@nais/ds-svelte-community';
+	import { activityLogResourceLink } from '../../utils';
 
 	let {
 		data
 	}: {
 		data: Extract<
 			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
-			{ __typename: 'ConfigUpdatedActivityLogEntry' }
+			{ __typename: 'JobUpdatedActivityLogEntry' }
 		>;
 	} = $props();
-
-	const formatFieldName = (field: string): string => {
-		if (field.startsWith('value ')) {
-			return 'key ' + field.slice('value '.length);
-		}
-		return field;
-	};
 </script>
 
 <div>
-	Updated config <strong>{data.resourceName}</strong>
+	Job
+	{#if data.environmentName}
+		<a
+			href={activityLogResourceLink(
+				data.environmentName,
+				data.resourceType,
+				data.resourceName,
+				data.teamSlug
+			)}>{data.resourceName}</a
+		>
+	{:else}
+		{data.resourceName}
+	{/if}
+	updated
 	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}.
-	{#if data.configUpdatedData.updatedFields.length > 0}
-		{#each data.configUpdatedData.updatedFields as field (field)}
-			<strong>{formatFieldName(field.field)}</strong>
+	{#if data.jobUpdatedData.changedFields.length > 0}
+		{#each data.jobUpdatedData.changedFields as field (field.field)}
+			<strong>{field.field}</strong>
 			{#if field.oldValue != null && field.newValue != null}
 				changed from <i>{field.oldValue}</i> to <i>{field.newValue}</i>.
 			{:else if field.oldValue == null && field.newValue != null}
@@ -39,7 +46,6 @@
 			{/if}
 		{/each}
 	{/if}
-
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}
 		<Time time={data.createdAt} distance />

--- a/src/lib/domain/activity/sidebar/texts/JobUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/JobUpdatedActivityLogEntryText.svelte
@@ -28,10 +28,7 @@
 	{:else}
 		{data.resourceName}
 	{/if}
-	updated
-	{#if data.environmentName}
-		in {data.environmentName}
-	{/if}.
+	updated{data.environmentName ? ` in ${data.environmentName}` : ''}.
 	{#if data.jobUpdatedData.changedFields.length > 0}
 		{#each data.jobUpdatedData.changedFields as field (field.field)}
 			<strong>{field.field}</strong>

--- a/src/lib/domain/activity/sidebar/texts/OpenSearchCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/OpenSearchCreatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 
 	let {
@@ -31,7 +30,7 @@
 	{/if}
 	created
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/OpenSearchDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/OpenSearchDeletedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -17,7 +16,7 @@
 <div>
 	OpenSearch <strong>{data.resourceName}</strong> deleted
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/OpenSearchUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/OpenSearchUpdatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 
 	let {
@@ -31,7 +30,7 @@
 	{/if}
 	updated
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	{#if data.opensearchData?.updatedFields.length > 0}
 		{#each data.opensearchData.updatedFields as field (field)}

--- a/src/lib/domain/activity/sidebar/texts/PostgresDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/PostgresDeletedActivityLogEntryText.svelte
@@ -11,7 +11,8 @@
 </script>
 
 <div>
-	Postgres instance <strong>{data.resourceName}</strong> deleted{#if data.environmentName}
+	Postgres instance <strong>{data.resourceName}</strong> deleted
+	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}.
 

--- a/src/lib/domain/activity/sidebar/texts/PostgresDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/PostgresDeletedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -13,7 +12,7 @@
 
 <div>
 	Postgres instance <strong>{data.resourceName}</strong> deleted{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/sidebar/texts/PostgresGrantAccessActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/PostgresGrantAccessActivityLogEntryText.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'PostgresGrantAccessActivityLogEntry' }
+		>;
+	} = $props();
+</script>
+
+<div>
+	Granted access to <strong>{data.postgresGrantAccessData.grantee}</strong> on postgres
+	<strong>{data.resourceName}</strong>
+	until <Time time={data.postgresGrantAccessData.until} dateFormat="dd/MM/yyyy HH:mm" />
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/ResourceDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ResourceDeletedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { resourceTypeToText } from './utils';
 
 	let {
@@ -16,7 +15,7 @@
 	{resourceTypeToText(data.resourceType)}
 	<strong>{data.resourceName}</strong> deleted
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/SecretCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/SecretCreatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -17,7 +16,7 @@
 <div>
 	Secret <strong>{data.resourceName}</strong> created
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/SecretDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/SecretDeletedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -17,7 +16,7 @@
 <div>
 	Secret <strong>{data.resourceName}</strong> deleted
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/SecretValueAddedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/SecretValueAddedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -19,7 +18,7 @@
 	<span class="valueName">{data.secretValueAddedData.valueName}</span> added to secret
 	<strong>{data.resourceName}</strong>
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/SecretValueRemovedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/SecretValueRemovedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -18,7 +17,7 @@
 	Value <strong>{data.secretValueRemovedData.valueName}</strong> removed from secret
 	<strong>{data.resourceName}</strong>
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/SecretValueUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/SecretValueUpdatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -18,7 +17,7 @@
 	Value <strong>{data.secretValueUpdatedData.valueName}</strong> updated in secret
 	<strong>{data.resourceName}</strong>
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/SecretValuesViewedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/SecretValuesViewedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 
 	let {
@@ -30,7 +29,7 @@
 		{data.resourceName}
 	{/if}
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	{#if data.secretValuesViewedData?.reason}
 		<BodyShort size="small"><em>Reason: {data.secretValuesViewedData.reason}</em></BodyShort>

--- a/src/lib/domain/activity/sidebar/texts/ServiceMaintenanceActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ServiceMaintenanceActivityLogEntryText.svelte
@@ -3,6 +3,7 @@
 	import Time from '$lib/ui/Time.svelte';
 	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
+	import { resourceTypeToText } from './utils';
 
 	let {
 		data
@@ -23,13 +24,10 @@
 				)
 			: null
 	);
-
-	const properServiceName = (type: string) =>
-		type === 'OPENSEARCH' ? 'OpenSearch' : type === 'VALKEY' ? 'Valkey' : 'service';
 </script>
 
 <div>
-	Started maintenance on {properServiceName(data.resourceType)}
+	Started maintenance on {resourceTypeToText(data.resourceType)}
 	{#if link}
 		<a href={link}><strong>{data.resourceName}</strong></a>
 	{:else}

--- a/src/lib/domain/activity/sidebar/texts/ServiceMaintenanceActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ServiceMaintenanceActivityLogEntryText.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+	import { activityLogResourceLink } from '../../utils';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'ServiceMaintenanceActivityLogEntry' }
+		>;
+	} = $props();
+
+	const link = $derived(
+		data.environmentName
+			? activityLogResourceLink(
+					data.environmentName,
+					data.resourceType,
+					data.resourceName,
+					data.teamSlug
+				)
+			: null
+	);
+
+	const properServiceName = (type: string) =>
+		type === 'OPENSEARCH' ? 'OpenSearch' : type === 'VALKEY' ? 'Valkey' : 'service';
+</script>
+
+<div>
+	Started maintenance on {properServiceName(data.resourceType)}
+	{#if link}
+		<a href={link}><strong>{data.resourceName}</strong></a>
+	{:else}
+		<strong>{data.resourceName}</strong>
+	{/if}
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/TeamConfirmDeleteKeyActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/TeamConfirmDeleteKeyActivityLogEntryText.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'TeamConfirmDeleteKeyActivityLogEntry' }
+		>;
+	} = $props();
+</script>
+
+<div>
+	Confirmed delete key for team <strong>{data.resourceName}</strong>
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/TeamCreateDeleteKeyActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/TeamCreateDeleteKeyActivityLogEntryText.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'TeamCreateDeleteKeyActivityLogEntry' }
+		>;
+	} = $props();
+</script>
+
+<div>
+	Created delete key for team <strong>{data.resourceName}</strong>
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/TeamCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/TeamCreatedActivityLogEntryText.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'TeamCreatedActivityLogEntry' }
+		>;
+	} = $props();
+</script>
+
+<div>
+	Team <strong>{data.resourceName}</strong> created
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/TeamDeployKeyUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/TeamDeployKeyUpdatedActivityLogEntryText.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'TeamDeployKeyUpdatedActivityLogEntry' }
+		>;
+	} = $props();
+</script>
+
+<div>
+	Updated deploy key for team <strong>{data.resourceName}</strong>
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -24,7 +23,7 @@
 	{/if}
 
 	{#if data.environmentName}
-		<Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/sidebar/texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte
@@ -14,16 +14,15 @@
 </script>
 
 <div>
-	Updated team <strong>{data.resourceName}</strong>.
+	Updated team <strong>{data.resourceName}</strong>
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}.
 	{#if data.teamEnvironmentUpdatedData.updatedFields.length > 0}
 		{#each data.teamEnvironmentUpdatedData.updatedFields as field (field)}
 			<strong>{field.field}</strong> changed from <i>{field.oldValue}</i> to
 			<i>{field.newValue}</i>.
 		{/each}
-	{/if}
-
-	{#if data.environmentName}
-		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/sidebar/texts/TeamUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/TeamUpdatedActivityLogEntryText.svelte
@@ -14,16 +14,15 @@
 </script>
 
 <div>
-	Updated team <strong>{data.resourceName}</strong>.
+	Updated team <strong>{data.resourceName}</strong>
+	{#if data.environmentName}
+		in {data.environmentName}
+	{/if}.
 	{#if data.teamUpdatedData.updatedFields.length > 0}
 		{#each data.teamUpdatedData.updatedFields as field (field)}
 			<strong>{field.field}</strong> changed from <i>{field.oldValue}</i> to
 			<i>{field.newValue}</i>.
 		{/each}
-	{/if}
-
-	{#if data.environmentName}
-		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/sidebar/texts/TeamUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/TeamUpdatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -24,7 +23,7 @@
 	{/if}
 
 	{#if data.environmentName}
-		<Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}
 
 	<BodyShort textColor="subtle" size="small">

--- a/src/lib/domain/activity/sidebar/texts/UnleashInstanceCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/UnleashInstanceCreatedActivityLogEntryText.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'UnleashInstanceCreatedActivityLogEntry' }
+		>;
+	} = $props();
+</script>
+
+<div>
+	Unleash instance <strong>{data.resourceName}</strong> created
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/UnleashInstanceDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/UnleashInstanceDeletedActivityLogEntryText.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'UnleashInstanceDeletedActivityLogEntry' }
+		>;
+	} = $props();
+</script>
+
+<div>
+	Unleash instance <strong>{data.resourceName}</strong> deleted
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort } from '@nais/ds-svelte-community';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'UnleashInstanceUpdatedActivityLogEntry' }
+		>;
+	} = $props();
+</script>
+
+<div>
+	Updated unleash instance <strong>{data.resourceName}</strong>
+	{#if data.unleashInstanceUpdatedData.allowedTeamSlug}
+		Allowed <a href="/team/{data.unleashInstanceUpdatedData.allowedTeamSlug}"
+			>{data.unleashInstanceUpdatedData.allowedTeamSlug}</a
+		>
+		to access the instance.
+	{:else if data.unleashInstanceUpdatedData.revokedTeamSlug}
+		Revoked access for <a href="/team/{data.unleashInstanceUpdatedData.revokedTeamSlug}"
+			>{data.unleashInstanceUpdatedData.revokedTeamSlug}</a
+		>
+		to the instance.
+	{:else if data.unleashInstanceUpdatedData.updatedReleaseChannel}
+		Changed release channel to <strong
+			>{data.unleashInstanceUpdatedData.updatedReleaseChannel}</strong
+		>.
+	{/if}
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>

--- a/src/lib/domain/activity/sidebar/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
@@ -29,6 +29,8 @@
 		Changed release channel to <strong
 			>{data.unleashInstanceUpdatedData.updatedReleaseChannel}</strong
 		>.
+	{:else}
+		.
 	{/if}
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div>
-	Updated Unleash instance <strong>{data.resourceName}</strong>
+	Updated Unleash instance <strong>{data.resourceName}</strong>.
 	{#if data.unleashInstanceUpdatedData.allowedTeamSlug}
 		Allowed <a href="/team/{data.unleashInstanceUpdatedData.allowedTeamSlug}"
 			>{data.unleashInstanceUpdatedData.allowedTeamSlug}</a
@@ -29,8 +29,6 @@
 		Changed release channel to <strong
 			>{data.unleashInstanceUpdatedData.updatedReleaseChannel}</strong
 		>.
-	{:else}
-		.
 	{/if}
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div>
-	Updated unleash instance <strong>{data.resourceName}</strong>
+	Updated Unleash instance <strong>{data.resourceName}</strong>
 	{#if data.unleashInstanceUpdatedData.allowedTeamSlug}
 		Allowed <a href="/team/{data.unleashInstanceUpdatedData.allowedTeamSlug}"
 			>{data.unleashInstanceUpdatedData.allowedTeamSlug}</a

--- a/src/lib/domain/activity/sidebar/texts/ValkeyCreatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ValkeyCreatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 
 	let {
@@ -31,7 +30,7 @@
 	{/if}
 	created
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/ValkeyDeletedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ValkeyDeletedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 
 	let {
 		data
@@ -17,7 +16,7 @@
 <div>
 	Valkey <strong>{data.resourceName}</strong> deleted
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	<BodyShort textColor="subtle" size="small">
 		By {data.actor}

--- a/src/lib/domain/activity/sidebar/texts/ValkeyUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/ValkeyUpdatedActivityLogEntryText.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import type { SidebarActivityLogFragment$data } from '$houdini';
-	import { envTagVariant } from '$lib/envTagVariant';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyShort, Tag } from '@nais/ds-svelte-community';
+	import { BodyShort } from '@nais/ds-svelte-community';
 	import { activityLogResourceLink } from '../../utils';
 
 	let {
@@ -31,7 +30,7 @@
 	{/if}
 	updated
 	{#if data.environmentName}
-		in <Tag size="small" variant={envTagVariant(data.environmentName)}>{data.environmentName}</Tag>
+		in {data.environmentName}
 	{/if}.
 	{#if data.valkeyData?.updatedFields.length > 0}
 		{#each data.valkeyData.updatedFields as field (field)}

--- a/src/lib/domain/activity/sidebar/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
@@ -30,7 +30,7 @@
 	function getSeverityClass(severity: string | undefined | null): string {
 		if (!severity) return '';
 		const normalized = severity.toLowerCase();
-		const validSeverities = ['critical', 'high', 'medium', 'low'];
+		const validSeverities = ['critical', 'high', 'medium', 'low', 'unassigned'];
 		return validSeverities.includes(normalized) ? `severity-${normalized}` : '';
 	}
 </script>
@@ -118,6 +118,11 @@
 
 	.vulnerability-severity.severity-low {
 		background-color: var(--ax-bg-default);
+		color: var(--ax-text-subtle);
+	}
+
+	.vulnerability-severity.severity-unassigned {
+		background-color: var(--ax-neutral-200);
 		color: var(--ax-text-subtle);
 	}
 

--- a/src/lib/domain/activity/sidebar/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import type { SidebarActivityLogFragment$data } from '$houdini';
+	import Time from '$lib/ui/Time.svelte';
+	import { BodyShort, ReadMore } from '@nais/ds-svelte-community';
+
+	let {
+		data
+	}: {
+		data: Extract<
+			SidebarActivityLogFragment$data['activityLog']['nodes'][number],
+			{ __typename: 'VulnerabilityUpdatedActivityLogEntry' }
+		>;
+	} = $props();
+
+	const vuln = $derived(data.vulnerabilityUpdatedData);
+	const hasStateChange = $derived(vuln.previousSuppression?.state !== vuln.newSuppression?.state);
+	const hasReasonChange = $derived(
+		vuln.newSuppression?.reason !== vuln.previousSuppression?.reason
+	);
+	const isNewSuppression = $derived(vuln.newSuppression?.state && !vuln.previousSuppression?.state);
+	const isUnsuppressed = $derived(vuln.previousSuppression?.state && !vuln.newSuppression?.state);
+	const isStateChange = $derived(vuln.newSuppression?.state && vuln.previousSuppression?.state);
+
+	function getSeverityClass(severity: string | undefined | null): string {
+		if (!severity) return '';
+		const normalized = severity.toLowerCase();
+		const validSeverities = ['critical', 'high', 'medium', 'low'];
+		return validSeverities.includes(normalized) ? `severity-${normalized}` : '';
+	}
+</script>
+
+<div>
+	{#if hasStateChange}
+		{#if isNewSuppression}
+			Suppressed vulnerability in image
+		{:else if isUnsuppressed}
+			Unsuppressed vulnerability in image
+		{:else if isStateChange}
+			Changed vulnerability suppression in image
+		{:else}
+			Updated vulnerability in image
+		{/if}
+	{:else if hasReasonChange}
+		Updated vulnerability suppression reason in image
+	{:else}
+		Updated vulnerability in image
+	{/if}
+	<strong>{data.resourceName}</strong>
+
+	<ReadMore header="Vulnerability details" size="small">
+		<div class="vulnerability-details">
+			<p><strong>Identifier:</strong> {vuln.identifier}</p>
+			<p><strong>Package:</strong> {vuln.package}</p>
+			{#if vuln.severity}
+				<p>
+					<strong>Severity:</strong>
+					<span class="vulnerability-severity {getSeverityClass(vuln.severity)}"
+						>{vuln.severity}</span
+					>
+				</p>
+			{/if}
+			{#if hasStateChange}
+				{#if vuln.previousSuppression?.state}
+					<p>
+						<strong>Previous state:</strong>
+						{vuln.previousSuppression.state.replace('_', ' ').toLowerCase()}
+					</p>
+				{/if}
+				{#if vuln.newSuppression?.state}
+					<p>
+						<strong>New state:</strong>
+						{vuln.newSuppression.state.replace('_', ' ').toLowerCase()}
+					</p>
+				{/if}
+			{/if}
+			{#if vuln.newSuppression?.reason}
+				<p><strong>Reason:</strong> {vuln.newSuppression.reason}</p>
+			{/if}
+		</div>
+	</ReadMore>
+
+	<BodyShort textColor="subtle" size="small">
+		By {data.actor}
+		<Time time={data.createdAt} distance />
+	</BodyShort>
+</div>
+
+<style>
+	.vulnerability-severity {
+		font-size: 0.75rem;
+		font-weight: 600;
+		padding: 0.125rem 0.375rem;
+		border-radius: 0.25rem;
+		text-transform: uppercase;
+		margin-left: 0.5rem;
+	}
+
+	.vulnerability-severity.severity-critical {
+		background-color: var(--ax-bg-danger-strong);
+		color: var(--ax-text-danger);
+	}
+
+	.vulnerability-severity.severity-high {
+		background-color: var(--ax-bg-warning-strong);
+		color: var(--ax-text-warning);
+	}
+
+	.vulnerability-severity.severity-medium {
+		background-color: var(--ax-bg-info-soft);
+		color: var(--ax-text-subtle);
+	}
+
+	.vulnerability-severity.severity-low {
+		background-color: var(--ax-bg-default);
+		color: var(--ax-text-subtle);
+	}
+
+	.vulnerability-details {
+		margin-top: 0.5rem;
+	}
+
+	.vulnerability-details p {
+		margin: 0.25rem 0;
+		font-size: 0.875rem;
+	}
+</style>

--- a/src/lib/domain/activity/sidebar/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
@@ -63,13 +63,13 @@
 				{#if vuln.previousSuppression?.state}
 					<p>
 						<strong>Previous state:</strong>
-						{vuln.previousSuppression.state.replace('_', ' ').toLowerCase()}
+						{vuln.previousSuppression.state.replaceAll('_', ' ').toLowerCase()}
 					</p>
 				{/if}
 				{#if vuln.newSuppression?.state}
 					<p>
 						<strong>New state:</strong>
-						{vuln.newSuppression.state.replace('_', ' ').toLowerCase()}
+						{vuln.newSuppression.state.replaceAll('_', ' ').toLowerCase()}
 					</p>
 				{/if}
 			{/if}

--- a/src/lib/domain/activity/sidebar/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/sidebar/texts/VulnerabilityUpdatedActivityLogEntryText.svelte
@@ -17,9 +17,15 @@
 	const hasReasonChange = $derived(
 		vuln.newSuppression?.reason !== vuln.previousSuppression?.reason
 	);
-	const isNewSuppression = $derived(vuln.newSuppression?.state && !vuln.previousSuppression?.state);
-	const isUnsuppressed = $derived(vuln.previousSuppression?.state && !vuln.newSuppression?.state);
-	const isStateChange = $derived(vuln.newSuppression?.state && vuln.previousSuppression?.state);
+	const isNewSuppression = $derived(
+		Boolean(vuln.newSuppression?.state && !vuln.previousSuppression?.state)
+	);
+	const isUnsuppressed = $derived(
+		Boolean(vuln.previousSuppression?.state && !vuln.newSuppression?.state)
+	);
+	const isStateChange = $derived(
+		Boolean(vuln.newSuppression?.state && vuln.previousSuppression?.state)
+	);
 
 	function getSeverityClass(severity: string | undefined | null): string {
 		if (!severity) return '';

--- a/src/lib/domain/list-items/ActivityLogListItem.svelte
+++ b/src/lib/domain/list-items/ActivityLogListItem.svelte
@@ -8,15 +8,23 @@
 	import { activityTooltip } from '../activity/activity-log-tooltip';
 	import '../activity/activity-log.css';
 	import ApplicationDeletedActivityLogEntryText from '../activity/shared/texts/ApplicationDeletedActivityLogEntryText.svelte';
+	import ApplicationCreatedActivityLogEntryText from '../activity/shared/texts/ApplicationCreatedActivityLogEntryText.svelte';
 	import ApplicationRestartedActivityLogEntryText from '../activity/shared/texts/ApplicationRestartedActivityLogEntryText.svelte';
 	import ApplicationScaledActivityLogEntryText from '../activity/shared/texts/ApplicationScaledActivityLogEntryText.svelte';
+	import ApplicationUpdatedActivityLogEntryText from '../activity/shared/texts/ApplicationUpdatedActivityLogEntryText.svelte';
 	import ClusterAuditActivityLogEntryText from '../activity/shared/texts/ClusterAuditActivityLogEntryText.svelte';
+	import ConfigCreatedActivityLogEntryText from '../activity/shared/texts/ConfigCreatedActivityLogEntryText.svelte';
+	import ConfigDeletedActivityLogEntryText from '../activity/shared/texts/ConfigDeletedActivityLogEntryText.svelte';
+	import ConfigUpdatedActivityLogEntryText from '../activity/shared/texts/ConfigUpdatedActivityLogEntryText.svelte';
 	import CredentialsActivityLogEntryText from '../activity/shared/texts/CredentialsActivityLogEntryText.svelte';
 	import DefaultText from '../activity/shared/texts/DefaultText.svelte';
 	import DeploymentActivityLogEntryText from '../activity/shared/texts/DeploymentActivityLogEntryText.svelte';
+	import GenericKubernetesResourceActivityLogEntryText from '../activity/shared/texts/GenericKubernetesResourceActivityLogEntryText.svelte';
+	import JobCreatedActivityLogEntryText from '../activity/shared/texts/JobCreatedActivityLogEntryText.svelte';
 	import JobDeletedActivityLogEntryText from '../activity/shared/texts/JobDeletedActivityLogEntryText.svelte';
 	import JobRunDeletedActivityLogEntryText from '../activity/shared/texts/JobRunDeletedActivityLogEntryText.svelte';
 	import JobTriggeredActivityLogEntryText from '../activity/shared/texts/JobTriggeredActivityLogEntryText.svelte';
+	import JobUpdatedActivityLogEntryText from '../activity/shared/texts/JobUpdatedActivityLogEntryText.svelte';
 	import OpenSearchCreatedActivityLogEntryText from '../activity/shared/texts/OpenSearchCreatedActivityLogEntryText.svelte';
 	import OpenSearchDeletedActivityLogEntryText from '../activity/shared/texts/OpenSearchDeletedActivityLogEntryText.svelte';
 	import OpenSearchUpdatedActivityLogEntryText from '../activity/shared/texts/OpenSearchUpdatedActivityLogEntryText.svelte';
@@ -31,11 +39,17 @@
 	import SecretValueUpdatedActivityLogEntryText from '../activity/shared/texts/SecretValueUpdatedActivityLogEntryText.svelte';
 	import SecretValuesViewedActivityLogEntryText from '../activity/shared/texts/SecretValuesViewedActivityLogEntryText.svelte';
 	import ServiceMaintenanceActivityLogEntryText from '../activity/shared/texts/ServiceMaintenanceActivityLogEntryText.svelte';
+	import TeamConfirmDeleteKeyActivityLogEntryText from '../activity/shared/texts/TeamConfirmDeleteKeyActivityLogEntryText.svelte';
+	import TeamCreateDeleteKeyActivityLogEntryText from '../activity/shared/texts/TeamCreateDeleteKeyActivityLogEntryText.svelte';
+	import TeamCreatedActivityLogEntryText from '../activity/shared/texts/TeamCreatedActivityLogEntryText.svelte';
+	import TeamDeployKeyUpdatedActivityLogEntryText from '../activity/shared/texts/TeamDeployKeyUpdatedActivityLogEntryText.svelte';
 	import TeamEnvironmentUpdatedActivityLogEntryText from '../activity/shared/texts/TeamEnvironmentUpdatedActivityLogEntryText.svelte';
 	import TeamMemberAddedActivityLogEntryText from '../activity/shared/texts/TeamMemberAddedActivityLogEntryText.svelte';
 	import TeamMemberRemovedActivityLogEntryText from '../activity/shared/texts/TeamMemberRemovedActivityLogEntryText.svelte';
 	import TeamMemberSetRoleActivityLogEntryText from '../activity/shared/texts/TeamMemberSetRoleActivityLogEntryText.svelte';
 	import TeamUpdatedActivityLogEntryText from '../activity/shared/texts/TeamUpdatedActivityLogEntryText.svelte';
+	import UnleashInstanceCreatedActivityLogEntryText from '../activity/shared/texts/UnleashInstanceCreatedActivityLogEntryText.svelte';
+	import UnleashInstanceDeletedActivityLogEntryText from '../activity/shared/texts/UnleashInstanceDeletedActivityLogEntryText.svelte';
 	import UnleashInstanceUpdatedActivityLogEntryText from '../activity/shared/texts/UnleashInstanceUpdatedActivityLogEntryText.svelte';
 	import ValkeyCreatedActivityLogEntryText from '../activity/shared/texts/ValkeyCreatedActivityLogEntryText.svelte';
 	import ValkeyDeletedActivityLogEntryText from '../activity/shared/texts/ValkeyDeletedActivityLogEntryText.svelte';
@@ -66,6 +80,9 @@
 					... on ApplicationDeletedActivityLogEntry {
 						__typename
 					}
+					... on ApplicationCreatedActivityLogEntry {
+						__typename
+					}
 					... on ApplicationRestartedActivityLogEntry {
 						__typename
 					}
@@ -75,11 +92,35 @@
 							direction
 						}
 					}
+					... on ApplicationUpdatedActivityLogEntry {
+						applicationUpdated: data {
+							changedFields {
+								field
+								newValue
+								oldValue
+							}
+						}
+					}
 					... on ClusterAuditActivityLogEntry {
 						id
 						clusterAuditData: data {
 							action
 							resourceKind
+						}
+					}
+					... on ConfigCreatedActivityLogEntry {
+						__typename
+					}
+					... on ConfigDeletedActivityLogEntry {
+						__typename
+					}
+					... on ConfigUpdatedActivityLogEntry {
+						configUpdated: data {
+							updatedFields {
+								field
+								newValue
+								oldValue
+							}
 						}
 					}
 					... on CredentialsActivityLogEntry {
@@ -93,7 +134,20 @@
 							triggerURL
 						}
 					}
+					... on GenericKubernetesResourceActivityLogEntry {
+						genericKubernetesData: data {
+							kind
+							changedFields {
+								field
+								newValue
+								oldValue
+							}
+						}
+					}
 					... on JobDeletedActivityLogEntry {
+						__typename
+					}
+					... on JobCreatedActivityLogEntry {
 						__typename
 					}
 					... on JobRunDeletedActivityLogEntry {
@@ -103,6 +157,15 @@
 					}
 					... on JobTriggeredActivityLogEntry {
 						__typename
+					}
+					... on JobUpdatedActivityLogEntry {
+						jobUpdated: data {
+							changedFields {
+								field
+								newValue
+								oldValue
+							}
+						}
 					}
 					... on OpenSearchCreatedActivityLogEntry {
 						__typename
@@ -164,6 +227,18 @@
 					... on ServiceMaintenanceActivityLogEntry {
 						__typename
 					}
+					... on TeamConfirmDeleteKeyActivityLogEntry {
+						__typename
+					}
+					... on TeamCreateDeleteKeyActivityLogEntry {
+						__typename
+					}
+					... on TeamCreatedActivityLogEntry {
+						__typename
+					}
+					... on TeamDeployKeyUpdatedActivityLogEntry {
+						__typename
+					}
 					... on TeamEnvironmentUpdatedActivityLogEntry {
 						teamEnvironmentUpdated: data {
 							updatedFields {
@@ -205,6 +280,12 @@
 							revokedTeamSlug
 							updatedReleaseChannel
 						}
+					}
+					... on UnleashInstanceCreatedActivityLogEntry {
+						__typename
+					}
+					... on UnleashInstanceDeletedActivityLogEntry {
+						__typename
 					}
 					... on ValkeyCreatedActivityLogEntry {
 						__typename
@@ -248,22 +329,38 @@
 		switch (typename) {
 			case 'ApplicationDeletedActivityLogEntry':
 				return ApplicationDeletedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'ApplicationCreatedActivityLogEntry':
+				return ApplicationCreatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ApplicationRestartedActivityLogEntry':
 				return ApplicationRestartedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ApplicationScaledActivityLogEntry':
 				return ApplicationScaledActivityLogEntryText as Component<{ data: unknown }>;
+			case 'ApplicationUpdatedActivityLogEntry':
+				return ApplicationUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ClusterAuditActivityLogEntry':
 				return ClusterAuditActivityLogEntryText as Component<{ data: unknown }>;
+			case 'ConfigCreatedActivityLogEntry':
+				return ConfigCreatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'ConfigDeletedActivityLogEntry':
+				return ConfigDeletedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'ConfigUpdatedActivityLogEntry':
+				return ConfigUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'CredentialsActivityLogEntry':
 				return CredentialsActivityLogEntryText as Component<{ data: unknown }>;
 			case 'DeploymentActivityLogEntry':
 				return DeploymentActivityLogEntryText as Component<{ data: unknown }>;
+			case 'GenericKubernetesResourceActivityLogEntry':
+				return GenericKubernetesResourceActivityLogEntryText as Component<{ data: unknown }>;
+			case 'JobCreatedActivityLogEntry':
+				return JobCreatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'JobDeletedActivityLogEntry':
 				return JobDeletedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'JobRunDeletedActivityLogEntry':
 				return JobRunDeletedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'JobTriggeredActivityLogEntry':
 				return JobTriggeredActivityLogEntryText as Component<{ data: unknown }>;
+			case 'JobUpdatedActivityLogEntry':
+				return JobUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'OpenSearchCreatedActivityLogEntry':
 				return OpenSearchCreatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'OpenSearchDeletedActivityLogEntry':
@@ -292,6 +389,14 @@
 				return SecretValuesViewedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ServiceMaintenanceActivityLogEntry':
 				return ServiceMaintenanceActivityLogEntryText as Component<{ data: unknown }>;
+			case 'TeamConfirmDeleteKeyActivityLogEntry':
+				return TeamConfirmDeleteKeyActivityLogEntryText as Component<{ data: unknown }>;
+			case 'TeamCreateDeleteKeyActivityLogEntry':
+				return TeamCreateDeleteKeyActivityLogEntryText as Component<{ data: unknown }>;
+			case 'TeamCreatedActivityLogEntry':
+				return TeamCreatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'TeamDeployKeyUpdatedActivityLogEntry':
+				return TeamDeployKeyUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'TeamEnvironmentUpdatedActivityLogEntry':
 				return TeamEnvironmentUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'TeamMemberAddedActivityLogEntry':
@@ -302,6 +407,10 @@
 				return TeamMemberSetRoleActivityLogEntryText as Component<{ data: unknown }>;
 			case 'TeamUpdatedActivityLogEntry':
 				return TeamUpdatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'UnleashInstanceCreatedActivityLogEntry':
+				return UnleashInstanceCreatedActivityLogEntryText as Component<{ data: unknown }>;
+			case 'UnleashInstanceDeletedActivityLogEntry':
+				return UnleashInstanceDeletedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'UnleashInstanceUpdatedActivityLogEntry':
 				return UnleashInstanceUpdatedActivityLogEntryText as Component<{ data: unknown }>;
 			case 'ValkeyCreatedActivityLogEntry':

--- a/src/routes/team/[team]/activity-log/+page.svelte
+++ b/src/routes/team/[team]/activity-log/+page.svelte
@@ -37,11 +37,21 @@
 			ActivityLogActivityType.APPLICATION_SCALED
 		],
 		'Cluster Audit': [ActivityLogActivityType.CLUSTER_AUDIT],
+		Config: [
+			ActivityLogActivityType.CONFIG_CREATED,
+			ActivityLogActivityType.CONFIG_DELETED,
+			ActivityLogActivityType.CONFIG_UPDATED
+		],
+		Credentials: [ActivityLogActivityType.CREDENTIALS_CREATED],
 		Deployment: [ActivityLogActivityType.DEPLOYMENT],
 		Job: [
 			ActivityLogActivityType.JOB_DELETED,
 			ActivityLogActivityType.JOB_RUN_DELETED,
 			ActivityLogActivityType.JOB_TRIGGERED
+		],
+		'Kubernetes Resource': [
+			ActivityLogActivityType.GENERIC_KUBERNETES_RESOURCE_CREATED,
+			ActivityLogActivityType.GENERIC_KUBERNETES_RESOURCE_UPDATED
 		],
 		OpenSearch: [
 			ActivityLogActivityType.OPENSEARCH_CREATED,
@@ -89,6 +99,7 @@
 		],
 		Unleash: [
 			ActivityLogActivityType.UNLEASH_INSTANCE_CREATED,
+			ActivityLogActivityType.UNLEASH_INSTANCE_DELETED,
 			ActivityLogActivityType.UNLEASH_INSTANCE_UPDATED
 		],
 		Vulnerability: [ActivityLogActivityType.VULNERABILITY_UPDATED]


### PR DESCRIPTION
## Summary
- replace environment `Tag` components in activity log text renderers with plain text and guard nullable `environmentName` cases so the texts and links degrade cleanly
- add missing grouped activity filters for `Config`, `Credentials`, generic Kubernetes resources, and `UNLEASH_INSTANCE_DELETED`
- add shared and sidebar activity text coverage for config events, generic Kubernetes resources, team lifecycle and key events, Unleash instance create/delete/update, service maintenance, Postgres grant access, vulnerability updates, and application/job create/update events
- wire the new activity types into the activity log fragments, renderer registries, icons, and tooltips, and tighten the config update wording so the environment stays in the main sentence

## Verification
- `npm run lockfile-lint`
- `npx svelte-kit sync`
- `npm run check`
- `npm run lint`
- `npm run test -- --run`
- `helm lint --strict ./charts`