### PR TITLE
Simplify cost card presentation

### DIFF
--- a/src/lib/domain/cost/AggregatedCostForApplications.svelte
+++ b/src/lib/domain/cost/AggregatedCostForApplications.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { graphql } from '$houdini';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
-	import { Heading, HelpText, Loader } from '@nais/ds-svelte-community';
+	import { Heading, Loader } from '@nais/ds-svelte-community';
 	import AggregatedCostForWorkloads from './AggregatedCostForWorkloads.svelte';
 
 	const costQuery = $derived(
@@ -47,9 +47,6 @@
 <div>
 	<div class="heading">
 		<Heading size="small" as="h3">Applications Cost</Heading>
-		<HelpText title="Aggregated workloads cost"
-			>Aggregated cost for workloads. Current month is estimated.</HelpText
-		>
 	</div>
 
 	{#if $costQuery.fetching}

--- a/src/lib/domain/cost/AggregatedCostForJobs.svelte
+++ b/src/lib/domain/cost/AggregatedCostForJobs.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { graphql, PendingValue } from '$houdini';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
-	import { Heading, HelpText, Loader } from '@nais/ds-svelte-community';
+	import { Heading, Loader } from '@nais/ds-svelte-community';
 	import AggregatedCostForWorkloads from './AggregatedCostForWorkloads.svelte';
 
 	const costQuery = graphql(`
@@ -45,10 +45,6 @@
 <div class="wrapper">
 	<div class="heading">
 		<Heading as="h3" size="small">Jobs Cost</Heading>
-
-		<HelpText title="Aggregated jobs cost"
-			>Aggregated cost for jobs. Current month is estimated.</HelpText
-		>
 	</div>
 	{#if $costQuery.data && $costQuery.data.team !== PendingValue}
 		{#if $costQuery.data.team.jobs.nodes.length > 0}

--- a/src/lib/domain/cost/AggregatedCostForWorkload.svelte
+++ b/src/lib/domain/cost/AggregatedCostForWorkload.svelte
@@ -50,15 +50,18 @@
 	let { environment, workload, teamSlug }: Props = $props();
 
 	let data = $derived.by(() => {
-		return prepareMonthlyCostSeries($costQuery.data?.team.environment.workload.cost.monthly.series);
+		return prepareMonthlyCostSeries(
+			$costQuery.data?.team?.environment?.workload?.cost?.monthly?.series
+		);
 	});
 
 	let detailsHref = $derived.by(() => {
 		const team = $costQuery.data?.team;
-		const environmentName = team?.environment.environment.name;
-		const workloadData = team?.environment.workload;
+		const teamEnvironment = team?.environment;
+		const environmentName = teamEnvironment?.environment?.name;
+		const workloadData = teamEnvironment?.workload;
 
-		if (!team || !environmentName || !workloadData) {
+		if (!team?.slug || !environmentName || !workloadData) {
 			return undefined;
 		}
 

--- a/src/lib/domain/cost/AggregatedCostForWorkload.svelte
+++ b/src/lib/domain/cost/AggregatedCostForWorkload.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { graphql } from '$houdini';
+	import CostChart from '$lib/chart/CostChart.svelte';
+	import { prepareMonthlyCostSeries } from '$lib/domain/cost/cost';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
-	import { euroValueFormatter } from '$lib/utils/formatters';
-	import { BodyShort, Heading, HelpText, Link } from '@nais/ds-svelte-community';
+	import { Detail, Heading, Link, Loader } from '@nais/ds-svelte-community';
 
 	const costQuery = graphql(`
 		query AggregatedCost($team: Slug!, $environment: String!, $workload: String!) {
@@ -48,76 +49,45 @@
 
 	let { environment, workload, teamSlug }: Props = $props();
 
-	function getEstimateForMonth(cost: number, date: Date): number {
-		const daysKnown = date.getDate();
-		const daysInMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
-		const costPerDay = cost / daysKnown;
-		return costPerDay * daysInMonth;
-	}
+	let data = $derived.by(() => {
+		return prepareMonthlyCostSeries($costQuery.data?.team.environment.workload.cost.monthly.series);
+	});
 
-	function getFactor(cost: { date: Date; sum: number }[]): number {
-		if (cost.length < 1) {
-			return 0;
+	let detailsHref = $derived.by(() => {
+		const team = $costQuery.data?.team;
+		const environmentName = team?.environment.environment.name;
+		const workloadData = team?.environment.workload;
+
+		if (!team || !environmentName || !workloadData) {
+			return undefined;
 		}
-		const daysKnown = cost[0].date.getDate();
-		const estCostPerDay = cost[0].sum / daysKnown;
-		if (cost.length < 2) {
-			return 0;
-		}
-		const retVal = (estCostPerDay / (cost[1].sum / cost[1].date.getDate())) * 100 - 100;
-		if (retVal === Infinity || isNaN(retVal)) {
-			return 0;
-		}
-		return (estCostPerDay / (cost[1].sum / cost[1].date.getDate())) * 100 - 100;
-	}
+
+		const workloadPath = workloadData.__typename === 'Job' ? 'job' : 'app';
+		return `/team/${team.slug}/${environmentName}/${workloadPath}/${workloadData.name}/cost`;
+	});
 </script>
 
 <div class="wrapper">
 	<div class="container">
 		<Heading as="h3" size="small">Cost</Heading>
-		<HelpText title="Aggregated workload cost"
-			>Aggregated cost for workload. Current month is estimated.</HelpText
-		>
 	</div>
 
 	<GraphErrors errors={$costQuery.errors} />
 
-	{#if $costQuery.data}
-		{@const cost = $costQuery.data.team.environment.workload.cost}
-		{@const factor = getFactor(cost.monthly.series)}
-
-		{#each cost.monthly.series.slice(0, 2) as item (item)}
-			{#if item.date.getDate() === new Date(item.date.getFullYear(), item.date.getMonth() + 1, 0).getDate()}
-				<BodyShort>
-					{item.date.toLocaleString('en-GB', { month: 'long' })}:
-					{euroValueFormatter(item.sum)}
-				</BodyShort>
-			{:else}
-				<BodyShort>
-					{item.date.toLocaleString('en-GB', { month: 'long' })}: {euroValueFormatter(
-						getEstimateForMonth(item.sum, item.date)
-					)}
-					{#if cost.monthly.series.length > 1}
-						{#if factor > 1.0}
-							(<span style="color: var(--ax-bg-danger-strong);">+{factor.toFixed(2)}%</span>)
-						{:else}
-							(<span style="color: var(--ax-text-success-subtle);"
-								>-{(1.0 - factor).toFixed(2)}%</span
-							>)
-						{/if}
-					{/if}
-				</BodyShort>
-			{/if}
+	{#if $costQuery.fetching || (!$costQuery.data && !$costQuery.errors?.length)}
+		<div class="loading">
+			<Loader size="3xlarge" />
+		</div>
+	{:else if $costQuery.data}
+		{#if data.length}
+			<CostChart {data} dateField="date" valueField="sum" class="mt-3 mb-5 h-45 w-[93%] pl-[7%]" />
 		{:else}
-			<BodyShort>No cost data available</BodyShort>
-		{/each}
+			<Detail>No cost data available</Detail>
+		{/if}
 
-		<Link
-			href="/team/{$costQuery.data.team.slug}/{$costQuery.data.team.environment.environment
-				.name}/{$costQuery.data.team.environment.workload.__typename === 'Job'
-				? 'job'
-				: 'app'}/{$costQuery.data.team.environment.workload.name}/cost">View details</Link
-		>
+		{#if detailsHref}
+			<Link href={detailsHref}>View details</Link>
+		{/if}
 	{:else}
 		No cost data available
 	{/if}
@@ -135,5 +105,13 @@
 		display: flex;
 		align-items: center;
 		gap: var(--ax-space-4);
+	}
+
+	.loading {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		height: 200px;
+		width: 100%;
 	}
 </style>

--- a/src/lib/domain/cost/AggregatedCostForWorkloads.svelte
+++ b/src/lib/domain/cost/AggregatedCostForWorkloads.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
 	import CostChart from '$lib/chart/CostChart.svelte';
-	import { aggregateAndSortCostByDate } from '$lib/domain/cost/cost';
-	import { euroValueFormatter } from '$lib/utils/formatters';
+	import { aggregateAndSortCostByDate, prepareMonthlyCostSeries } from '$lib/domain/cost/cost';
 	import { Detail } from '@nais/ds-svelte-community';
-	import { CaretDownFillIcon, CaretUpFillIcon } from '@nais/ds-svelte-community/icons';
-	import { lastDayOfMonth } from 'date-fns';
 
 	interface Props {
 		readonly nodes: {
@@ -21,87 +18,13 @@
 
 	let { nodes }: Props = $props();
 
-	function getEstimateForMonth(month: { sum: number; date: Date }): number {
-		const daysKnown = month.date.getDate();
-		const daysInMonth = new Date(month.date.getFullYear(), month.date.getMonth() + 1, 0).getDate();
-		const costPerDay = month.sum / daysKnown;
-		return costPerDay * daysInMonth;
-	}
-
-	const primeData = (
-		series:
-			| {
-					readonly cost: {
-						readonly monthly: {
-							readonly series: {
-								readonly date: Date;
-								readonly sum: number;
-							}[];
-						};
-					};
-			  }[]
-			| undefined
-	): {
-		date: Date;
-		sum: number;
-	}[] => {
-		if (!series) {
-			return [];
-		}
-		let data = aggregateAndSortCostByDate(series);
-		if (data.length === 0) {
-			return [];
-		}
-		let estimateCurrentMonth = getEstimateForMonth(data.at(-1)!);
-		data.pop(); // Remove current month
-
-		data.push({
-			date: lastDayOfMonth(new Date()),
-			sum: estimateCurrentMonth
-		});
-		return data;
-	};
-
 	let data = $derived.by(() => {
-		return primeData(nodes);
+		return prepareMonthlyCostSeries(aggregateAndSortCostByDate(nodes));
 	});
 </script>
 
 {#if data.length}
-	<div class="summary">
-		<div class="estimated-cost">
-			<Detail>
-				{data.at(-1)?.date.toLocaleString('en-US', {
-					month: 'long'
-				})}: {euroValueFormatter(data.at(-1)?.sum)}
-				{#if (data.at(-1)?.sum ?? 0) > (data.at(-2)?.sum ?? 0)}
-					<CaretUpFillIcon style="color: var(--ax-bg-danger-strong);" />
-				{:else}
-					<CaretDownFillIcon style="color: var(--ax-bg-success-strong);" />
-				{/if}
-			</Detail>
-		</div>
-		<div>
-			<Detail>
-				{data.at(-2)?.date.toLocaleString('en-US', {
-					month: 'long'
-				})}: {euroValueFormatter(data.at(-2)?.sum)}
-			</Detail>
-		</div>
-	</div>
-
 	<CostChart {data} dateField="date" valueField="sum" class="mt-3 mb-5 h-45 w-[93%] pl-[7%]" />
 {:else}
 	<Detail>Insufficient data to display cost.</Detail>
 {/if}
-
-<style>
-	.summary {
-		gap: var(--ax-space-6);
-		.estimated-cost {
-			display: flex;
-			align-items: center;
-			gap: var(--ax-space-4);
-		}
-	}
-</style>

--- a/src/lib/domain/cost/cost.test.ts
+++ b/src/lib/domain/cost/cost.test.ts
@@ -1,4 +1,4 @@
-import { aggregateAndSortCostByDate } from '$lib/domain/cost/cost';
+import { aggregateAndSortCostByDate, prepareMonthlyCostSeries } from '$lib/domain/cost/cost';
 
 describe('aggregateAndSortCostByDate', () => {
 	test('data older than a year', () => {
@@ -268,6 +268,58 @@ describe('aggregateAndSortCostByDate', () => {
 			{ date: dates[2], sum: 2 },
 			{ date: dates[1], sum: 2 },
 			{ date: dates[0], sum: 2 }
+		]);
+	});
+});
+
+describe('prepareMonthlyCostSeries', () => {
+	test('returns an empty array for missing series', () => {
+		expect(prepareMonthlyCostSeries(undefined)).toEqual([]);
+	});
+
+	test('sorts newest-first input and estimates the current month', () => {
+		const aprilTwelfth = new Date(2026, 3, 12);
+		const marchThirtyFirst = new Date(2026, 2, 31);
+		const aprilThirtieth = new Date(2026, 3, 30);
+
+		expect(
+			prepareMonthlyCostSeries([
+				{
+					date: aprilTwelfth,
+					sum: 120
+				},
+				{
+					date: marchThirtyFirst,
+					sum: 240
+				}
+			])
+		).toEqual([
+			{
+				date: marchThirtyFirst,
+				sum: 240
+			},
+			{
+				date: aprilThirtieth,
+				sum: 300
+			}
+		]);
+	});
+
+	test('keeps a completed month unchanged', () => {
+		const marchThirtyFirst = new Date(2026, 2, 31);
+
+		expect(
+			prepareMonthlyCostSeries([
+				{
+					date: marchThirtyFirst,
+					sum: 240
+				}
+			])
+		).toEqual([
+			{
+				date: marchThirtyFirst,
+				sum: 240
+			}
 		]);
 	});
 });

--- a/src/lib/domain/cost/cost.test.ts
+++ b/src/lib/domain/cost/cost.test.ts
@@ -322,4 +322,31 @@ describe('prepareMonthlyCostSeries', () => {
 			}
 		]);
 	});
+
+	test('does not estimate when the newest month is already complete', () => {
+		const februaryTwentyEighth = new Date(2026, 1, 28);
+		const marchThirtyFirst = new Date(2026, 2, 31);
+
+		expect(
+			prepareMonthlyCostSeries([
+				{
+					date: marchThirtyFirst,
+					sum: 240
+				},
+				{
+					date: februaryTwentyEighth,
+					sum: 180
+				}
+			])
+		).toEqual([
+			{
+				date: februaryTwentyEighth,
+				sum: 180
+			},
+			{
+				date: marchThirtyFirst,
+				sum: 240
+			}
+		]);
+	});
 });

--- a/src/lib/domain/cost/cost.ts
+++ b/src/lib/domain/cost/cost.ts
@@ -1,16 +1,50 @@
+import { lastDayOfMonth } from 'date-fns';
+
+export interface MonthlyCostSeriesEntry {
+	readonly date: Date;
+	readonly sum: number;
+}
+
+type MonthlyCostCarrier = {
+	readonly cost: {
+		readonly monthly: {
+			readonly series: MonthlyCostSeriesEntry[];
+		};
+	};
+};
+
+export function estimateMonthCost(month: MonthlyCostSeriesEntry): number {
+	const daysKnown = month.date.getDate();
+	const daysInMonth = new Date(month.date.getFullYear(), month.date.getMonth() + 1, 0).getDate();
+	const costPerDay = month.sum / daysKnown;
+	return costPerDay * daysInMonth;
+}
+
+export function prepareMonthlyCostSeries(
+	series: MonthlyCostSeriesEntry[] | undefined
+): MonthlyCostSeriesEntry[] {
+	if (!series?.length) {
+		return [];
+	}
+
+	const sortedSeries = [...series].sort((a, b) => a.date.getTime() - b.date.getTime());
+	const currentMonth = sortedSeries.at(-1);
+
+	if (!currentMonth) {
+		return [];
+	}
+
+	const preparedSeries = sortedSeries.slice(0, -1);
+	preparedSeries.push({
+		date: lastDayOfMonth(currentMonth.date),
+		sum: estimateMonthCost(currentMonth)
+	});
+
+	return preparedSeries;
+}
+
 export function aggregateAndSortCostByDate(
-	series:
-		| {
-				readonly cost: {
-					readonly monthly: {
-						readonly series: {
-							readonly date: Date;
-							readonly sum: number;
-						}[];
-					};
-				};
-		  }[]
-		| undefined
+	series: MonthlyCostCarrier[] | undefined
 ): { date: Date; sum: number }[] {
 	const aggregated: Map<string, number> = new Map();
 	if (!series) {

--- a/src/lib/domain/cost/cost.ts
+++ b/src/lib/domain/cost/cost.ts
@@ -34,9 +34,14 @@ export function prepareMonthlyCostSeries(
 		return [];
 	}
 
+	const currentMonthEnd = lastDayOfMonth(currentMonth.date);
+	if (currentMonth.date.getDate() === currentMonthEnd.getDate()) {
+		return sortedSeries;
+	}
+
 	const preparedSeries = sortedSeries.slice(0, -1);
 	preparedSeries.push({
-		date: lastDayOfMonth(currentMonth.date),
+		date: currentMonthEnd,
 		sum: estimateMonthCost(currentMonth)
 	});
 


### PR DESCRIPTION
## Summary
- replace the text-heavy cost card summaries with the shared chart presentation for workload and workload list cards
- centralize monthly cost series preparation and add focused tests for sorting and current-month estimation
- remove help text from the small cost cards, add a loader to the workload detail card, and restore chart spacing above the graph

## Testing
- `npm run test -- --run src/lib/domain/cost/cost.test.ts src/lib/chart/CostChart.test.ts`
- `npm run check`
- `npm run lint`