### PR TITLE
fix: use id as each-key for instance group environment variables

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -3083,7 +3083,10 @@ type InstanceGroup implements Node {
 }
 
 """An environment variable configured for an instance group."""
-type InstanceGroupEnvironmentVariable {
+type InstanceGroupEnvironmentVariable implements Node {
+  """The globally unique ID of the environment variable."""
+  id: ID!
+
   """The name of the environment variable."""
   name: String!
 

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/EnvironmentVariables.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/EnvironmentVariables.svelte
@@ -50,7 +50,7 @@
 					</Tr>
 				</Thead>
 				<Tbody>
-					{#each envVars as env (env.name)}
+					{#each envVars as env (env.id)}
 						<Tr>
 							<Td class="name-cell"><code>{env.name}</code></Td>
 							<Td class="value-cell">

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/query.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/query.gql
@@ -61,6 +61,7 @@ query InstanceGroupDetail($app: String!, $team: Slug!, $env: String!) @cache(pol
 					readyInstances
 					desiredInstances
 					environmentVariables {
+						id
 						name
 						value
 						source {


### PR DESCRIPTION
## Summary

- Fixes `each_key_duplicate` error on instancegroup page by using the new `id` field as each-key instead of `env.name` (which can be duplicated across sources)
- Updates schema and query to include `id` on `InstanceGroupEnvironmentVariable`