### PR TITLE
fix: My Teams pagination QueryStoreCursor error

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -63,8 +63,8 @@
 					<Pagination
 						page={$UserTeams.data.me.teams.pageInfo}
 						loaders={{
-							loadPreviousPage: UserTeams.loadPreviousPage,
-							loadNextPage: UserTeams.loadNextPage
+							loadPreviousPage: () => UserTeams.loadPreviousPage(),
+							loadNextPage: () => UserTeams.loadNextPage()
 						}}
 					/>
 				{/if}


### PR DESCRIPTION
Fixes `TypeError: Receiver must be an instance of class QueryStoreCursor` when clicking next/previous page on the My Teams list on the root route.

The `loadPreviousPage` and `loadNextPage` methods were passed as bare references, which loses the `this` binding that Houdini's `QueryStoreCursor` requires. Wrapping them in arrow functions preserves the correct context.