### PR TITLE
fix(ci): fix storybook deploy, upgrade tooling

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
         run: npm run test -- --run
       - id: node_version
         run: echo "node_version=$(mise current node)" >> $GITHUB_OUTPUT
-      - uses: nais/platform-build-push-sign@a16d89d06262f12e3468a20b9cc70f5317290bab # ratchet:nais/platform-build-push-sign@main
+      - uses: nais/platform-build-push-sign@df590279b21bc5978519685752f9eaddd546043c # ratchet:nais/platform-build-push-sign@main
         id: build-push-sign
         with:
           name: ${{ env.NAME }}
@@ -67,7 +67,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: nais/fasit-deploy@58a70a338b16dc646373c91724fc7e7522d085a4 # ratchet:nais/fasit-deploy@v4.0.1
+      - uses: nais/fasit-deploy@97187355184a7f0f4b7a36a2b49a86ce02240f7b # ratchet:nais/fasit-deploy@v4.0.0
         with:
           chart: ${{ env.IMAGE_REPOSITORY }}/${{ env.NAME }}
           version: ${{ needs.build_push.outputs.version }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # ratchet:jdx/mise-action@v4
       - id: node_version
         run: echo "node_version=$(mise current node)" >> $GITHUB_OUTPUT
-      - uses: nais/platform-build-push-sign@a16d89d06262f12e3468a20b9cc70f5317290bab # ratchet:nais/platform-build-push-sign@main
+      - uses: nais/platform-build-push-sign@df590279b21bc5978519685752f9eaddd546043c # ratchet:nais/platform-build-push-sign@main
         id: build-push-sign
         with:
           name: ${{ env.NAME }}

--- a/.github/workflows/storybook-pages.yaml
+++ b/.github/workflows/storybook-pages.yaml
@@ -19,10 +19,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.11.1
           cache: npm
       - id: build-publish
         uses: bitovi/github-actions-storybook-to-github-pages@ddd9d35f670cceedd2bfc444be681001b0709730 # ratchet:bitovi/github-actions-storybook-to-github-pages@v1.0.4

--- a/.github/workflows/storybook-pages.yaml
+++ b/.github/workflows/storybook-pages.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
         with:
           node-version: 24.11.1
           cache: npm

--- a/.github/workflows/storybook-pages.yaml
+++ b/.github/workflows/storybook-pages.yaml
@@ -19,7 +19,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
       - id: build-publish
         uses: bitovi/github-actions-storybook-to-github-pages@ddd9d35f670cceedd2bfc444be681001b0709730 # ratchet:bitovi/github-actions-storybook-to-github-pages@v1.0.4
         with:
+          checkout: false
           path: storybook-static

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,5 +2,5 @@
 pin = true
 [tools]
 node = "24.11.1"
-go = "1.25.5"
+go = "1.26.3"
 "go:github.com/sethvargo/ratchet" = "0.11.4"


### PR DESCRIPTION
`lint-staged@17.0.2` requires Node >= 22.22.1, which broke the storybook deploy workflow.

**Changes:**
- Add explicit `actions/checkout` + `actions/setup-node` (v6) to storybook workflow since the bitovi action doesn't support specifying Node version
- Pin `node-version: 24.11.1` to match `.mise.toml`
- Upgrade Go 1.25.5 → 1.26.3 in `.mise.toml`
- Run `ratchet:upgrade` to update all pinned action SHAs