### PR TITLE
fix: move PageModal to action components so modals work on all tabs

### DIFF
--- a/src/routes/team/[team]/[env]/app/[app]/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/+page.svelte
@@ -9,14 +9,11 @@
 	import WorkloadDeploy from '$lib/domain/workload/WorkloadDeploy.svelte';
 	import WorkloadHealth from '$lib/domain/workload/WorkloadHealth.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
-	import PageModal from '$lib/ui/PageModal.svelte';
 	import Time from '$lib/ui/Time.svelte';
 	import { Alert, Heading, Loader } from '@nais/ds-svelte-community';
 	import { onMount } from 'svelte';
 	import type { PageProps } from './$types';
 	import InstanceGroups from './InstanceGroups.svelte';
-	import EnvPage from './env/+page.svelte';
-	import ResizePage from './resize/+page.svelte';
 
 	let { data }: PageProps = $props();
 	let { App, AppInstanceGroups, teamSlug } = $derived(data);
@@ -116,11 +113,6 @@
 				{/if}
 			</div>
 		</div>
-		{#if page.state.modalHref?.includes('/resize')}
-			<PageModal content={ResizePage} header="Resize app" />
-		{:else if page.state.modalHref?.includes('/env')}
-			<PageModal content={EnvPage} header="Set environment variables" />
-		{/if}
 	</div>
 {/if}
 

--- a/src/routes/team/[team]/[env]/app/[app]/AppActions.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/AppActions.svelte
@@ -4,8 +4,10 @@
 	import Manifest from '$lib/domain/resources/Manifest.svelte';
 	import ActionConfirm from '$lib/ui/ActionConfirm.svelte';
 	import HeaderActions from '$lib/ui/HeaderActions.svelte';
-	import { pageModalClick } from '$lib/ui/PageModal.svelte';
+	import PageModal, { pageModalClick } from '$lib/ui/PageModal.svelte';
 	import { Button, Heading, Modal } from '@nais/ds-svelte-community';
+	import EnvPage from './env/+page.svelte';
+	import ResizePage from './resize/+page.svelte';
 	import {
 		ActionMenu,
 		ActionMenuDivider,
@@ -191,6 +193,12 @@
 		<Manifest workload={app} />
 	{/if}
 </Modal>
+
+{#if page.state.modalHref?.includes('/resize')}
+	<PageModal content={ResizePage} header="Resize app" />
+{:else if page.state.modalHref?.includes('/env')}
+	<PageModal content={EnvPage} header="Set environment variables" />
+{/if}
 
 <style>
 	.action-menu-button {

--- a/src/routes/team/[team]/[env]/job/[job]/+page.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/+page.svelte
@@ -12,12 +12,10 @@
 	import WorkloadHealth from '$lib/domain/workload/WorkloadHealth.svelte';
 	import Confirm from '$lib/ui/Confirm.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
-	import PageModal from '$lib/ui/PageModal.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import Time from '$lib/ui/Time.svelte';
 	import { Alert, BodyShort, Heading, Loader } from '@nais/ds-svelte-community';
 	import type { PageProps } from './$types';
-	import EnvPage from './env/+page.svelte';
 	import Runs from './Runs.svelte';
 	import Schedule from './Schedule.svelte';
 
@@ -186,7 +184,6 @@
 				Are you sure you want to delete the job run <strong>{deleteRunName}</strong>?
 			</BodyShort>
 		</Confirm>
-		<PageModal content={EnvPage} header="Set environment variables" />
 	</div>
 {/if}
 

--- a/src/routes/team/[team]/[env]/job/[job]/JobActions.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/JobActions.svelte
@@ -4,7 +4,8 @@
 	import Manifest from '$lib/domain/resources/Manifest.svelte';
 	import ActionConfirm from '$lib/ui/ActionConfirm.svelte';
 	import HeaderActions from '$lib/ui/HeaderActions.svelte';
-	import { pageModalClick } from '$lib/ui/PageModal.svelte';
+	import PageModal, { pageModalClick } from '$lib/ui/PageModal.svelte';
+	import EnvPage from './env/+page.svelte';
 	import { generateJobRunName } from '$lib/utils/jobRunName';
 	import { Button, Heading, Modal, TextField } from '@nais/ds-svelte-community';
 	import {
@@ -158,6 +159,10 @@
 		<Manifest workload={job} />
 	{/if}
 </Modal>
+
+{#if page.state.modalHref?.includes('/env')}
+	<PageModal content={EnvPage} header="Set environment variables" />
+{/if}
 
 <style>
 	.action-menu-button {


### PR DESCRIPTION
## Problem

The "Resize" and "Set environment variables" modals only opened from the Overview tab. Clicking them from any other tab (Vulnerabilities, Deployments, Logs, etc.) did nothing.

**Root cause:** `AppActions` and `JobActions` are rendered in `+layout.svelte` (always mounted on all tabs), but the `<PageModal>` components that respond to `page.state.modalHref` were in `+page.svelte` — only mounted on the Overview tab. When `pushState` set `modalHref` from a non-overview tab, no `<PageModal>` was mounted to respond.

## Fix

Move `<PageModal>` rendering from `+page.svelte` into `AppActions.svelte` and `JobActions.svelte`, which are always mounted from the layout. This co-locates the modal with the action trigger and ensures it works regardless of the active tab.

### Changes

- **`AppActions.svelte`** — Renders resize and env modals when `page.state.modalHref` matches
- **`JobActions.svelte`** — Renders env modal when `page.state.modalHref` matches
- **App `+page.svelte`** — Removed PageModal block and unused imports
- **Job `+page.svelte`** — Removed PageModal line and unused imports