### PR TITLE
fix: poll deployment status in WorkloadDeploy component

### DIFF
--- a/src/routes/team/[team]/[env]/app/[app]/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/+page.svelte
@@ -16,14 +16,15 @@
 	import InstanceGroups from './InstanceGroups.svelte';
 
 	let { data }: PageProps = $props();
-	let { App, AppInstanceGroups, teamSlug } = $derived(data);
+	let { App, AppInstanceGroups, AppDeployment, teamSlug } = $derived(data);
 
-	const refetchInstanceGroups = () => {
+	const refetchPolled = () => {
 		AppInstanceGroups.fetch({ policy: 'CacheAndNetwork' });
+		AppDeployment.fetch({ policy: 'CacheAndNetwork' });
 	};
 
 	onMount(() => {
-		const interval = setInterval(refetchInstanceGroups, 10_000);
+		const interval = setInterval(refetchPolled, 10_000);
 		return () => clearInterval(interval);
 	});
 

--- a/src/routes/team/[team]/[env]/app/[app]/+page.ts
+++ b/src/routes/team/[team]/[env]/app/[app]/+page.ts
@@ -1,4 +1,4 @@
-import { load_App, load_AppInstanceGroups } from '$houdini';
+import { load_App, load_AppDeployment, load_AppInstanceGroups } from '$houdini';
 import { addPageMeta } from '$lib/utils/pageMeta.js';
 
 export async function load(event) {
@@ -13,6 +13,14 @@ export async function load(event) {
 			}
 		})),
 		...(await load_AppInstanceGroups({
+			event,
+			variables: {
+				team: event.params.team,
+				env: event.params.env,
+				app: event.params.app
+			}
+		})),
+		...(await load_AppDeployment({
 			event,
 			variables: {
 				team: event.params.team,

--- a/src/routes/team/[team]/[env]/app/[app]/AppDeployment.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/AppDeployment.gql
@@ -1,0 +1,9 @@
+query AppDeployment($app: String!, $team: Slug!, $env: String!) {
+	team(slug: $team) {
+		environment(name: $env) {
+			application(name: $app) {
+				...WorkloadDeploy
+			}
+		}
+	}
+}

--- a/src/routes/team/[team]/[env]/app/[app]/query.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/query.gql
@@ -41,18 +41,6 @@ query App($app: String!, $team: Slug!, $env: String!) {
 				}
 
 				deletionStartedAt
-				deployments(first: 1) {
-					nodes {
-						triggerUrl
-						statuses {
-							nodes {
-								state
-								message
-								createdAt
-							}
-						}
-					}
-				}
 
 				...Persistence
 				...WorkloadDeploy

--- a/src/routes/team/[team]/[env]/job/[job]/+page.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/+page.svelte
@@ -15,12 +15,20 @@
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import Time from '$lib/ui/Time.svelte';
 	import { Alert, BodyShort, Heading, Loader } from '@nais/ds-svelte-community';
+	import { onMount } from 'svelte';
 	import type { PageProps } from './$types';
 	import Runs from './Runs.svelte';
 	import Schedule from './Schedule.svelte';
 
 	let { data }: PageProps = $props();
-	let { Job, teamSlug, viewerIsMember } = $derived(data);
+	let { Job, JobDeployment, teamSlug, viewerIsMember } = $derived(data);
+
+	onMount(() => {
+		const interval = setInterval(() => {
+			JobDeployment.fetch({ policy: 'CacheAndNetwork' });
+		}, 10_000);
+		return () => clearInterval(interval);
+	});
 
 	let runsComponent: ReturnType<typeof Runs> | undefined = $state();
 

--- a/src/routes/team/[team]/[env]/job/[job]/+page.ts
+++ b/src/routes/team/[team]/[env]/job/[job]/+page.ts
@@ -1,4 +1,4 @@
-import { load_Job } from '$houdini';
+import { load_Job, load_JobDeployment } from '$houdini';
 import { addPageMeta } from '$lib/utils/pageMeta';
 
 const rows = 6;
@@ -16,6 +16,14 @@ export async function load(event) {
 				env: event.params.env,
 				job: event.params.job,
 				...(before ? { before, last: rows } : { after, first: rows })
+			}
+		})),
+		...(await load_JobDeployment({
+			event,
+			variables: {
+				team: event.params.team,
+				env: event.params.env,
+				job: event.params.job
 			}
 		}))
 	};

--- a/src/routes/team/[team]/[env]/job/[job]/JobDeployment.gql
+++ b/src/routes/team/[team]/[env]/job/[job]/JobDeployment.gql
@@ -1,0 +1,9 @@
+query JobDeployment($job: String!, $team: Slug!, $env: String!) {
+	team(slug: $team) {
+		environment(name: $env) {
+			job(name: $job) {
+				...WorkloadDeploy
+			}
+		}
+	}
+}

--- a/src/routes/team/[team]/[env]/job/[job]/query.gql
+++ b/src/routes/team/[team]/[env]/job/[job]/query.gql
@@ -42,18 +42,6 @@ query Job($job: String!, $team: Slug!, $env: String!) @cache(policy: NetworkOnly
 						name
 					}
 				}
-				deployments(first: 1) {
-					nodes {
-						triggerUrl
-						statuses {
-							nodes {
-								state
-								message
-								createdAt
-							}
-						}
-					}
-				}
 				recentRuns: runs(first: 10) {
 					nodes {
 						status {


### PR DESCRIPTION
## Problem

The "Latest Deployment" card gets stuck showing "In progress" until the user manually refreshes the page. The deployment data was fetched once as part of the main App/Job query and never re-fetched.

## Fix

Add dedicated `AppDeployment.gql` and `JobDeployment.gql` query stores that poll every 10s — the same proven pattern as `AppInstanceGroups`.

### Key design decisions

- **Same cache path as main query** — polls through `team.environment.application(name:)` / `job(name:)`, avoiding Houdini cache normalization conflicts (using `workload(name:)` caused page blanking)
- **Removed unused inline `deployments(first: 1)`** from main App/Job queries — these had extra fields (`message`, `createdAt` on `DeploymentStatus`) that conflicted with the `WorkloadDeploy` fragment's field set, causing cache corruption on poll
- **WorkloadDeploy stays as a simple fragment consumer** — no interface change, initial data loads server-side via the main query
- **Lightweight** — only fetches `...WorkloadDeploy` fragment data per poll, doesn't trigger cascading refetches

### Changes

- `AppDeployment.gql` (new) — lightweight query fetching `...WorkloadDeploy` through `application(name:)`
- `JobDeployment.gql` (new) — same for jobs through `job(name:)`
- `App query.gql` / `Job query.gql` — removed unused inline `deployments(first: 1)` block
- `App +page.ts` / `Job +page.ts` — load the new query stores
- `App +page.svelte` — poll `AppDeployment` alongside `AppInstanceGroups` every 10s
- `Job +page.svelte` — poll `JobDeployment` every 10s