### PR TITLE
Refactor form handling and update schema.graphql instructions

### DIFF
--- a/.github/instructions/schema.instructions.md
+++ b/.github/instructions/schema.instructions.md
@@ -2,4 +2,4 @@
 applyTo: 'schema.graphql'
 ---
 
-This file is auto-generated from [nais/api](https://github.com/nais/api) and must not be manually edited. Do not suggest or apply changes to `schema.graphql`.
+This file is auto-generated from [nais/api](https://github.com/nais/api) and must not be manually edited. Do not suggest or apply changes to `schema.graphql`. Also do not care if there are any changes to `schema.graphql` in the commit history.

--- a/src/routes/team/[team]/[env]/app/[app]/env/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/env/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-	import { enhance } from '$app/forms';
+	import { applyAction, enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { isPossiblyInModal } from '$lib/ui/PageModal.svelte';
 	import { Alert, BodyLong, Button, ErrorMessage, TextField } from '@nais/ds-svelte-community';
 	import { PlusIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
+	import { tick } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 
 	const form = $derived(page.form);
@@ -43,12 +44,6 @@
 			invalidateAll: true
 		});
 	};
-
-	$effect(() => {
-		if (success) {
-			queueMicrotask(() => closeButtonEl?.focus());
-		}
-	});
 </script>
 
 {#if success}
@@ -66,8 +61,9 @@
 			return async ({ result }) => {
 				if (result.type === 'redirect') {
 					success = true;
+					await tick();
+					closeButtonEl?.focus();
 				} else if (result.type === 'failure') {
-					const { applyAction } = await import('$app/forms');
 					await applyAction(result);
 				}
 			};

--- a/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { enhance } from '$app/forms';
+	import { applyAction, enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
-	import Time from '$lib/ui/Time.svelte';
 	import { isPossiblyInModal } from '$lib/ui/PageModal.svelte';
+	import Time from '$lib/ui/Time.svelte';
 	import { parseImage } from '$lib/utils/image';
 	import {
 		Alert,
@@ -13,6 +13,7 @@
 		Radio,
 		RadioGroup
 	} from '@nais/ds-svelte-community';
+	import { tick } from 'svelte';
 	import type { PageProps } from './$houdini';
 
 	let { data }: PageProps = $props();
@@ -47,12 +48,6 @@
 			invalidateAll: true
 		});
 	};
-
-	$effect(() => {
-		if (success) {
-			queueMicrotask(() => closeButtonEl?.focus());
-		}
-	});
 </script>
 
 {#if success}
@@ -71,8 +66,9 @@
 			return async ({ result }) => {
 				if (result.type === 'redirect') {
 					success = true;
+					await tick();
+					closeButtonEl?.focus();
 				} else if (result.type === 'failure') {
-					const { applyAction } = await import('$app/forms');
 					await applyAction(result);
 				}
 			};
@@ -123,12 +119,14 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--ax-space-8);
-		width: 500px;
+		max-width: 500px;
+		width: 100%;
 		align-items: flex-start;
 	}
 
 	form {
-		width: 600px;
+		max-width: 600px;
+		width: 100%;
 		display: flex;
 		flex-direction: column;
 		gap: var(--ax-space-16);
@@ -150,7 +148,7 @@
 	}
 
 	.release-time {
-		color: var(--ax-text-neutral);
+		color: var(--ax-text-subtle);
 		font-size: var(--ax-font-size-small);
 	}
 

--- a/src/routes/team/[team]/[env]/app/[app]/resize/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/resize/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { enhance } from '$app/forms';
+	import { applyAction, enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { isPossiblyInModal } from '$lib/ui/PageModal.svelte';
 	import { Alert, BodyLong, Button, ErrorMessage, TextField } from '@nais/ds-svelte-community';
+	import { tick } from 'svelte';
 	import type { PageProps } from './$houdini';
 
 	let { data }: PageProps = $props();
@@ -28,12 +29,6 @@
 			invalidateAll: true
 		});
 	};
-
-	$effect(() => {
-		if (success) {
-			queueMicrotask(() => closeButtonEl?.focus());
-		}
-	});
 </script>
 
 {#if success}
@@ -50,8 +45,9 @@
 				if (result.type === 'redirect') {
 					successMessage = `Successfully resized application to ${min} - ${max} replicas.`;
 					success = true;
+					await tick();
+					closeButtonEl?.focus();
 				} else if (result.type === 'failure') {
-					const { applyAction } = await import('$app/forms');
 					await applyAction(result);
 				}
 			};

--- a/src/routes/team/[team]/[env]/job/[job]/env/+page.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/env/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-	import { enhance } from '$app/forms';
+	import { applyAction, enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { isPossiblyInModal } from '$lib/ui/PageModal.svelte';
 	import { Alert, BodyLong, Button, ErrorMessage, TextField } from '@nais/ds-svelte-community';
 	import { PlusIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
+	import { tick } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 
 	const form = $derived(page.form);
@@ -43,12 +44,6 @@
 			invalidateAll: true
 		});
 	};
-
-	$effect(() => {
-		if (success) {
-			queueMicrotask(() => closeButtonEl?.focus());
-		}
-	});
 </script>
 
 {#if success}
@@ -66,8 +61,9 @@
 			return async ({ result }) => {
 				if (result.type === 'redirect') {
 					success = true;
+					await tick();
+					closeButtonEl?.focus();
 				} else if (result.type === 'failure') {
-					const { applyAction } = await import('$app/forms');
 					await applyAction(result);
 				}
 			};


### PR DESCRIPTION
This pull request refactors several Svelte page components to improve form handling and accessibility. The main focus is on consistently applying actions after form submissions and ensuring that the UI responds correctly (such as focusing the close button after a successful action). Additionally, there are minor UI improvements in the image page component.

**Form handling and accessibility improvements:**

* Replaced dynamic imports of `applyAction` with direct imports at the top of the file for better consistency and performance across `env`, `image`, and `resize` pages for both apps and jobs. ([src/routes/team/[team]/[env]/app/[app]/env/+page.svelteL2-R8](diffhunk://#diff-f2c194df09579ad3cd72579f4173d2147695d363d1081ca0c13453d662e78c79L2-R8), [src/routes/team/[team]/[env]/app/[app]/image/+page.svelteL2-R6](diffhunk://#diff-3c6d44d73a1ab3d09852eb8a2119494d8855e330398b60f201a3dfbaed86e026L2-R6), [src/routes/team/[team]/[env]/app/[app]/resize/+page.svelteL2-R7](diffhunk://#diff-08a565b69616c250716960455e0e1e63c2ea51001ea02cfbda3369055432fc8fL2-R7), [src/routes/team/[team]/[env]/job/[job]/env/+page.svelteL2-R8](diffhunk://#diff-61ef2cede1905a4929ad4c379b8c526aad574d89612286e26ce31d6f08caba45L2-R8))
* Removed the use of `$effect` and `queueMicrotask` for focusing the close button after successful actions, replacing them with a more reliable approach using `await tick()` and directly focusing the button after state updates. ([src/routes/team/[team]/[env]/app/[app]/env/+page.svelteL46-L51](diffhunk://#diff-f2c194df09579ad3cd72579f4173d2147695d363d1081ca0c13453d662e78c79L46-L51), [src/routes/team/[team]/[env]/app/[app]/env/+page.svelteR64-L70](diffhunk://#diff-f2c194df09579ad3cd72579f4173d2147695d363d1081ca0c13453d662e78c79R64-L70), [src/routes/team/[team]/[env]/app/[app]/image/+page.svelteL50-L55](diffhunk://#diff-3c6d44d73a1ab3d09852eb8a2119494d8855e330398b60f201a3dfbaed86e026L50-L55), [src/routes/team/[team]/[env]/app/[app]/image/+page.svelteR69-L75](diffhunk://#diff-3c6d44d73a1ab3d09852eb8a2119494d8855e330398b60f201a3dfbaed86e026R69-L75), [src/routes/team/[team]/[env]/app/[app]/resize/+page.svelteL31-L36](diffhunk://#diff-08a565b69616c250716960455e0e1e63c2ea51001ea02cfbda3369055432fc8fL31-L36), [src/routes/team/[team]/[env]/app/[app]/resize/+page.svelteR48-L54](diffhunk://#diff-08a565b69616c250716960455e0e1e63c2ea51001ea02cfbda3369055432fc8fR48-L54), [src/routes/team/[team]/[env]/job/[job]/env/+page.svelteL46-L51](diffhunk://#diff-61ef2cede1905a4929ad4c379b8c526aad574d89612286e26ce31d6f08caba45L46-L51), [src/routes/team/[team]/[env]/job/[job]/env/+page.svelteR64-L70](diffhunk://#diff-61ef2cede1905a4929ad4c379b8c526aad574d89612286e26ce31d6f08caba45R64-L70))

**UI and style improvements in image page:**

* Changed fixed widths on forms and containers to use `max-width` and `width: 100%` for better responsiveness. ([src/routes/team/[team]/[env]/app/[app]/image/+page.svelteL126-R129](diffhunk://#diff-3c6d44d73a1ab3d09852eb8a2119494d8855e330398b60f201a3dfbaed86e026L126-R129))
* Updated the color of `.release-time` to use a more subtle text color variable for improved visual hierarchy. ([src/routes/team/[team]/[env]/app/[app]/image/+page.svelteL153-R151](diffhunk://#diff-3c6d44d73a1ab3d09852eb8a2119494d8855e330398b60f201a3dfbaed86e026L153-R151))

**Documentation update:**

* Clarified in the schema instructions file that changes to `schema.graphql` in commit history should be ignored.