### PR TITLE
Enable selection of current image in previous releases radio group

### DIFF
--- a/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
@@ -90,7 +90,7 @@
 			<RadioGroup legend="Previous releases" size="small" name="image" bind:value={selected}>
 				{#each releases as release (release.image + release.deployedAt.toISOString())}
 					{@const isCurrent = release.image === currentImage}
-					<Radio value={release.image} disabled={isCurrent}>
+					<Radio value={release.image}>
 						<span class="release-label">
 							<code class="release-tag">{tagFor(release.image)}</code>
 							{#if isCurrent}<span class="release-current">(current)</span>{/if}

--- a/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
@@ -87,7 +87,7 @@
 		{#if releases.length === 0}
 			<BodyLong>No previous releases were found for this application.</BodyLong>
 		{:else}
-			<RadioGroup legend="Previous releases" size="small" name="image" bind:value={selected}>
+			<RadioGroup legend="Releases" size="small" name="image" bind:value={selected}>
 				{#each releases as release (release.image + release.deployedAt.toISOString())}
 					{@const isCurrent = release.image === currentImage}
 					<Radio value={release.image}>


### PR DESCRIPTION
This pull request makes a minor update to the release selection UI. The "Previous releases" radio buttons are now always enabled, even for the currently deployed image, allowing users to re-select the current image if desired.

* The `disabled` attribute was removed from the `Radio` component for the currently deployed image in `+page.svelte`, so all release options are now selectable. ([src/routes/team/[team]/[env]/app/[app]/image/+page.svelteL93-R93](diffhunk://#diff-3c6d44d73a1ab3d09852eb8a2119494d8855e330398b60f201a3dfbaed86e026L93-R93))