### PR TITLE
Fix empty-state message wording in image release selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -416,7 +416,7 @@ All of these must pass before committing. If prettier reports issues, fix them w
 When asked to address Copilot (or other) review comments on a PR:
 
 1. Fetch the review comments and implement the fixes
-2. Commit and push the changes
+2. Commit and push the changes — **do this before replying or resolving**
 3. Reply to **each** review comment thread individually with a short summary of what was done (or why no change was needed)
 4. Resolve each review thread after replying
 

--- a/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
@@ -85,7 +85,7 @@
 		</Alert>
 
 		{#if releases.length === 0}
-			<BodyLong>No previous releases were found for this application.</BodyLong>
+			<BodyLong>No releases were found for this application.</BodyLong>
 		{:else}
 			<RadioGroup legend="Releases" size="small" name="image" bind:value={selected}>
 				{#each releases as release (release.image + release.deployedAt.toISOString())}


### PR DESCRIPTION
Changes the empty-state message from "No previous releases were found for this application." to "No releases were found for this application." to match the updated UI where the radio group now includes the current image and is labeled "Releases" rather than "Previous releases".