### PR TITLE
Increase default rows for improved data display

### DIFF
--- a/src/routes/team/[team]/vulnerabilities/[cve]/+page.svelte
+++ b/src/routes/team/[team]/vulnerabilities/[cve]/+page.svelte
@@ -34,7 +34,7 @@
 
 	const rowKey = (node: { id: string }) => node.id;
 
-	const rows = 5;
+	const rows = 50;
 
 	const teamRoles = graphql(`
 		query TeamCVEPageTeamRoles($team: Slug!) @cache(policy: CacheAndNetwork) {

--- a/src/routes/team/[team]/vulnerabilities/[cve]/+page.svelte
+++ b/src/routes/team/[team]/vulnerabilities/[cve]/+page.svelte
@@ -34,7 +34,7 @@
 
 	const rowKey = (node: { id: string }) => node.id;
 
-	const rows = 50;
+	const rows = 25;
 
 	const teamRoles = graphql(`
 		query TeamCVEPageTeamRoles($team: Slug!) @cache(policy: CacheAndNetwork) {


### PR DESCRIPTION
This pull request makes a minor adjustment to the vulnerabilities page by increasing the number of rows displayed in the table from 5 to 25.

* Increased the default number of rows shown in the vulnerabilities table from 5 to 25 in `src/routes/team/[team]/vulnerabilities/[cve]/+page.svelte`. ([src/routes/team/[team]/vulnerabilities/[cve]/+page.svelteL37-R37](diffhunk://#diff-25e675a091eb4ebf8d6ce68a40992457c3bd314d684af6b2e39d46a17e555a8bL37-R37))