### PR TITLE
Invalidate cache on secret deletion and update environment facet

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -335,15 +335,6 @@ enum ActivityLogEntryResourceType {
   VULNERABILITY
 }
 
-"""A single facet item for environments."""
-type ActivityLogEnvironmentFacetItem {
-  """Number of matching entries."""
-  count: Int!
-
-  """The environment name."""
-  environmentName: String!
-}
-
 """
 Facets for activity log entries, providing distribution counts across different dimensions.
 """
@@ -354,7 +345,7 @@ type ActivityLogFacets {
   activityTypes: [ActivityLogActivityTypeFacetItem!]!
 
   """Distribution of entries by environment."""
-  environments: [ActivityLogEnvironmentFacetItem!]!
+  environments: [StringFacetItem!]!
 
   """Distribution of entries by resource type."""
   resourceTypes: [ActivityLogResourceTypeFacetItem!]!
@@ -932,21 +923,12 @@ type ApplicationEdge {
   node: Application!
 }
 
-"""A single facet item for environments."""
-type ApplicationEnvironmentFacetItem {
-  """Number of matching applications."""
-  count: Int!
-
-  """The environment name."""
-  environmentName: String!
-}
-
 """
 Facets for applications, providing distribution counts across different dimensions.
 """
 type ApplicationFacets {
   """Distribution of applications by environment."""
-  environments: [ApplicationEnvironmentFacetItem!]!
+  environments: [StringFacetItem!]!
 
   """Distribution of applications by state."""
   states: [ApplicationStateFacetItem!]!
@@ -1313,6 +1295,12 @@ enum BigQueryDatasetAccessOrderField {
 
 type BigQueryDatasetConnection {
   edges: [BigQueryDatasetEdge!]!
+
+  """
+  Facets for BigQuery datasets. Provides distribution counts to help narrow down results.
+  Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+  """
+  facets: BigQueryDatasetFacets
   nodes: [BigQueryDataset!]!
   pageInfo: PageInfo!
 }
@@ -1324,6 +1312,23 @@ type BigQueryDatasetCost {
 type BigQueryDatasetEdge {
   cursor: Cursor!
   node: BigQueryDataset!
+}
+
+"""
+Facets for BigQuery datasets, providing distribution counts across different dimensions.
+"""
+type BigQueryDatasetFacets {
+  """Distribution of datasets by environment."""
+  environments: [StringFacetItem!]!
+}
+
+"""Input for filtering BigQuery datasets."""
+input BigQueryDatasetFilter {
+  """Filter by environments."""
+  environments: [String!]
+
+  """Filter by the name of the dataset."""
+  name: String
 }
 
 input BigQueryDatasetOrder {
@@ -1341,6 +1346,17 @@ type BigQueryDatasetStatus {
   lastModifiedTime: Time
 }
 
+"""
+A shared facet item representing a boolean distribution (e.g., in-use, high availability).
+"""
+type BooleanFacetItem {
+  """Number of matching resources."""
+  count: Int!
+
+  """The boolean value."""
+  value: Boolean!
+}
+
 type Bucket implements Node & Persistence {
   cascadingDelete: Boolean!
   environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
@@ -1355,6 +1371,12 @@ type Bucket implements Node & Persistence {
 
 type BucketConnection {
   edges: [BucketEdge!]!
+
+  """
+  Facets for buckets. Provides distribution counts to help narrow down results.
+  Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+  """
+  facets: BucketFacets
   nodes: [Bucket!]!
   pageInfo: PageInfo!
 }
@@ -1362,6 +1384,23 @@ type BucketConnection {
 type BucketEdge {
   cursor: Cursor!
   node: Bucket!
+}
+
+"""
+Facets for buckets, providing distribution counts across different dimensions.
+"""
+type BucketFacets {
+  """Distribution of buckets by environment."""
+  environments: [StringFacetItem!]!
+}
+
+"""Input for filtering buckets."""
+input BucketFilter {
+  """Filter by environments."""
+  environments: [String!]
+
+  """Filter by the name of the bucket."""
+  name: String
 }
 
 input BucketOrder {
@@ -1632,6 +1671,12 @@ type ConfigConnection {
   """List of edges."""
   edges: [ConfigEdge!]!
 
+  """
+  Facets for configs. Provides distribution counts to help narrow down results.
+  Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+  """
+  facets: ConfigFacets
+
   """List of nodes."""
   nodes: [Config!]!
 
@@ -1703,8 +1748,22 @@ type ConfigEdge {
   node: Config!
 }
 
+"""
+Facets for configs, providing distribution counts across different dimensions.
+"""
+type ConfigFacets {
+  """Distribution of configs by environment."""
+  environments: [StringFacetItem!]!
+
+  """Distribution of configs by whether they are in use by any workload."""
+  inUse: [BooleanFacetItem!]!
+}
+
 """Input for filtering the configs of a team."""
 input ConfigFilter {
+  """Filter by environments."""
+  environments: [String!]
+
   """Filter by usage of the config."""
   inUse: Boolean
 
@@ -3795,21 +3854,12 @@ type JobEdge {
   node: Job!
 }
 
-"""A single facet item for environments."""
-type JobEnvironmentFacetItem {
-  """Number of matching jobs."""
-  count: Int!
-
-  """The environment name."""
-  environmentName: String!
-}
-
 """
 Facets for jobs, providing distribution counts across different dimensions.
 """
 type JobFacets {
   """Distribution of jobs by environment."""
-  environments: [JobEnvironmentFacetItem!]!
+  environments: [StringFacetItem!]!
 
   """Distribution of jobs by state."""
   states: [JobStateFacetItem!]!
@@ -4209,6 +4259,12 @@ type KafkaTopicConfiguration {
 
 type KafkaTopicConnection {
   edges: [KafkaTopicEdge!]!
+
+  """
+  Facets for Kafka topics. Provides distribution counts to help narrow down results.
+  Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+  """
+  facets: KafkaTopicFacets
   nodes: [KafkaTopic!]!
   pageInfo: PageInfo!
 }
@@ -4216,6 +4272,29 @@ type KafkaTopicConnection {
 type KafkaTopicEdge {
   cursor: Cursor!
   node: KafkaTopic!
+}
+
+"""
+Facets for Kafka topics, providing distribution counts across different dimensions.
+"""
+type KafkaTopicFacets {
+  """Distribution of topics by environment."""
+  environments: [StringFacetItem!]!
+
+  """Distribution of topics by Kafka pool."""
+  pools: [StringFacetItem!]!
+}
+
+"""Input for filtering Kafka topics."""
+input KafkaTopicFilter {
+  """Filter by environments."""
+  environments: [String!]
+
+  """Filter by the name of the topic."""
+  name: String
+
+  """Filter by Kafka pool."""
+  pools: [String!]
 }
 
 input KafkaTopicOrder {
@@ -4863,6 +4942,12 @@ enum OpenSearchAccessOrderField {
 
 type OpenSearchConnection {
   edges: [OpenSearchEdge!]!
+
+  """
+  Facets for OpenSearch instances. Provides distribution counts to help narrow down results.
+  Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+  """
+  facets: OpenSearchFacets
   nodes: [OpenSearch!]!
   pageInfo: PageInfo!
 }
@@ -4947,6 +5032,29 @@ type OpenSearchDeletedActivityLogEntry implements ActivityLogEntry & Node {
 type OpenSearchEdge {
   cursor: Cursor!
   node: OpenSearch!
+}
+
+"""
+Facets for OpenSearch instances, providing distribution counts across different dimensions.
+"""
+type OpenSearchFacets {
+  """Distribution of instances by environment."""
+  environments: [StringFacetItem!]!
+
+  """Distribution of instances by tier."""
+  tiers: [OpenSearchTierFacetItem!]!
+}
+
+"""Input for filtering OpenSearch instances."""
+input OpenSearchFilter {
+  """Filter by environments."""
+  environments: [String!]
+
+  """Filter by the name of the instance."""
+  name: String
+
+  """Filter by tier."""
+  tiers: [OpenSearchTier!]
 }
 
 type OpenSearchIssue implements Issue & Node {
@@ -5066,6 +5174,15 @@ enum OpenSearchState {
 enum OpenSearchTier {
   HIGH_AVAILABILITY
   SINGLE_NODE
+}
+
+"""A single facet item for OpenSearch tiers."""
+type OpenSearchTierFacetItem {
+  """Number of matching instances."""
+  count: Int!
+
+  """The OpenSearch tier."""
+  tier: OpenSearchTier!
 }
 
 type OpenSearchUpdatedActivityLogEntry implements ActivityLogEntry & Node {
@@ -5303,6 +5420,12 @@ type PostgresInstanceAudit {
 
 type PostgresInstanceConnection {
   edges: [PostgresInstanceEdge!]!
+
+  """
+  Facets for Postgres instances. Provides distribution counts to help narrow down results.
+  Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+  """
+  facets: PostgresInstanceFacets
   nodes: [PostgresInstance!]!
   pageInfo: PageInfo!
 }
@@ -5310,6 +5433,41 @@ type PostgresInstanceConnection {
 type PostgresInstanceEdge {
   cursor: Cursor!
   node: PostgresInstance!
+}
+
+"""
+Facets for Postgres instances, providing distribution counts across different dimensions.
+"""
+type PostgresInstanceFacets {
+  """Distribution of instances by environment."""
+  environments: [StringFacetItem!]!
+
+  """Distribution of instances by high availability."""
+  highAvailability: [BooleanFacetItem!]!
+
+  """Distribution of instances by major version."""
+  majorVersions: [StringFacetItem!]!
+
+  """Distribution of instances by state."""
+  states: [PostgresInstanceStateFacetItem!]!
+}
+
+"""Input for filtering Postgres instances."""
+input PostgresInstanceFilter {
+  """Filter by environments."""
+  environments: [String!]
+
+  """Filter by high availability."""
+  highAvailability: Boolean
+
+  """Filter by major versions."""
+  majorVersions: [String!]
+
+  """Filter by the name of the instance."""
+  name: String
+
+  """Filter by instance state."""
+  states: [PostgresInstanceState!]
 }
 
 type PostgresInstanceMaintenanceWindow {
@@ -5337,6 +5495,15 @@ enum PostgresInstanceState {
   AVAILABLE
   DEGRADED
   PROGRESSING
+}
+
+"""A single facet item for Postgres instance states."""
+type PostgresInstanceStateFacetItem {
+  """Number of matching instances."""
+  count: Int!
+
+  """The Postgres instance state."""
+  state: PostgresInstanceState!
 }
 
 type Price {
@@ -6519,6 +6686,12 @@ type SecretConnection {
   """List of edges."""
   edges: [SecretEdge!]!
 
+  """
+  Facets for secrets. Provides distribution counts to help narrow down results.
+  Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+  """
+  facets: SecretFacets
+
   """List of nodes."""
   nodes: [Secret!]!
 
@@ -6590,8 +6763,22 @@ type SecretEdge {
   node: Secret!
 }
 
+"""
+Facets for secrets, providing distribution counts across different dimensions.
+"""
+type SecretFacets {
+  """Distribution of secrets by environment."""
+  environments: [StringFacetItem!]!
+
+  """Distribution of secrets by whether they are in use by any workload."""
+  inUse: [BooleanFacetItem!]!
+}
+
 """Input for filtering the secrets of a team."""
 input SecretFilter {
+  """Filter by environments."""
+  environments: [String!]
+
   """Filter by usage of the secret."""
   inUse: Boolean
 
@@ -7635,6 +7822,17 @@ type StartValkeyMaintenancePayload {
   error: String
 }
 
+"""
+A shared facet item representing a string value distribution (e.g., pool name, version).
+"""
+type StringFacetItem {
+  """Number of matching resources."""
+  count: Int!
+
+  """The string value."""
+  value: String!
+}
+
 """The subscription root for the Nais GraphQL API."""
 type Subscription {
   """
@@ -7742,6 +7940,9 @@ type Team implements ActivityLogger & Node {
     """Get items before this cursor."""
     before: Cursor
 
+    """Filtering options for items returned from the connection."""
+    filter: BigQueryDatasetFilter
+
     """
     Get the first n items in the connection. This can be used in combination with the after parameter.
     """
@@ -7763,6 +7964,9 @@ type Team implements ActivityLogger & Node {
 
     """Get items before this cursor."""
     before: Cursor
+
+    """Filtering options for items returned from the connection."""
+    filter: BucketFilter
 
     """
     Get the first n items in the connection. This can be used in combination with the after parameter.
@@ -7909,6 +8113,9 @@ type Team implements ActivityLogger & Node {
     """Get items before this cursor."""
     before: Cursor
 
+    """Filtering options for items returned from the connection."""
+    filter: KafkaTopicFilter
+
     """
     Get the first n items in the connection. This can be used in combination with the after parameter.
     """
@@ -7959,6 +8166,9 @@ type Team implements ActivityLogger & Node {
     """Get items before this cursor."""
     before: Cursor
 
+    """Filtering options for items returned from the connection."""
+    filter: OpenSearchFilter
+
     """
     Get the first n items in the connection. This can be used in combination with the after parameter.
     """
@@ -7980,6 +8190,9 @@ type Team implements ActivityLogger & Node {
 
     """Get items before this cursor."""
     before: Cursor
+
+    """Filtering options for items returned from the connection."""
+    filter: PostgresInstanceFilter
 
     """
     Get the first n items in the connection. This can be used in combination with the after parameter.
@@ -8100,6 +8313,9 @@ type Team implements ActivityLogger & Node {
 
     """Get items before this cursor."""
     before: Cursor
+
+    """Filtering options for items returned from the connection."""
+    filter: ValkeyFilter
 
     """
     Get the first n items in the connection. This can be used in combination with the after parameter.
@@ -10100,6 +10316,12 @@ enum ValkeyAccessOrderField {
 
 type ValkeyConnection {
   edges: [ValkeyEdge!]!
+
+  """
+  Facets for Valkey instances. Provides distribution counts to help narrow down results.
+  Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+  """
+  facets: ValkeyFacets
   nodes: [Valkey!]!
   pageInfo: PageInfo!
 }
@@ -10184,6 +10406,29 @@ type ValkeyDeletedActivityLogEntry implements ActivityLogEntry & Node {
 type ValkeyEdge {
   cursor: Cursor!
   node: Valkey!
+}
+
+"""
+Facets for Valkey instances, providing distribution counts across different dimensions.
+"""
+type ValkeyFacets {
+  """Distribution of instances by environment."""
+  environments: [StringFacetItem!]!
+
+  """Distribution of instances by tier."""
+  tiers: [ValkeyTierFacetItem!]!
+}
+
+"""Input for filtering Valkey instances."""
+input ValkeyFilter {
+  """Filter by environments."""
+  environments: [String!]
+
+  """Filter by the name of the instance."""
+  name: String
+
+  """Filter by tier."""
+  tiers: [ValkeyTier!]
 }
 
 type ValkeyIssue implements Issue & Node {
@@ -10321,6 +10566,15 @@ enum ValkeyState {
 enum ValkeyTier {
   HIGH_AVAILABILITY
   SINGLE_NODE
+}
+
+"""A single facet item for Valkey tiers."""
+type ValkeyTierFacetItem {
+  """Number of matching instances."""
+  count: Int!
+
+  """The Valkey tier."""
+  tier: ValkeyTier!
 }
 
 type ValkeyUpdatedActivityLogEntry implements ActivityLogEntry & Node {

--- a/src/lib/domain/activity/ActivityLogFacets.svelte
+++ b/src/lib/domain/activity/ActivityLogFacets.svelte
@@ -13,7 +13,7 @@
 	}
 
 	interface EnvironmentFacet {
-		environmentName: string;
+		value: string;
 		count: number;
 	}
 
@@ -50,7 +50,7 @@
 	// a filtered card where some activity types have 0 entries).
 	const availableActivityTypes = $derived(new Set(activityTypes.map((f) => f.activityType)));
 	const availableResourceTypes = $derived(new Set(resourceTypes.map((f) => f.resourceType)));
-	const availableEnvironments = $derived(new Set(environments.map((f) => f.environmentName)));
+	const availableEnvironments = $derived(new Set(environments.map((f) => f.value)));
 
 	function toggleActivityType(type: ActivityLogActivityType$options) {
 		const isSelected = selectedActivityTypes.includes(type);
@@ -120,14 +120,14 @@
 		<details class="facet-section" open>
 			<summary class="facet-heading">Environments</summary>
 			<div class="facet-list">
-				{#each environments as facet (facet.environmentName)}
+				{#each environments as facet (facet.value)}
 					<label class="facet-item">
 						<input
 							type="checkbox"
-							checked={selectedEnvironments.includes(facet.environmentName)}
-							onchange={() => toggleEnvironment(facet.environmentName)}
+							checked={selectedEnvironments.includes(facet.value)}
+							onchange={() => toggleEnvironment(facet.value)}
 						/>
-						<span class="facet-label">{facet.environmentName}</span>
+						<span class="facet-label">{facet.value}</span>
 						<span class="facet-count">{facet.count}</span>
 					</label>
 				{/each}

--- a/src/lib/domain/workload/WorkloadListFilters.svelte
+++ b/src/lib/domain/workload/WorkloadListFilters.svelte
@@ -8,7 +8,7 @@
 	}
 
 	interface EnvironmentFacet {
-		environmentName: string;
+		value: string;
 		count: number;
 	}
 
@@ -60,7 +60,7 @@
 	}
 
 	const availableStates = $derived(new Set(states.map((f) => f.state)));
-	const availableEnvironments = $derived(new Set(environments.map((f) => f.environmentName)));
+	const availableEnvironments = $derived(new Set(environments.map((f) => f.value)));
 
 	function toggleState(state: string) {
 		const isSelected = selectedStates.includes(state);
@@ -114,14 +114,14 @@
 		<details class="filter-section" open>
 			<summary class="section-heading">Environments</summary>
 			<div class="facet-list">
-				{#each environments as facet (facet.environmentName)}
+				{#each environments as facet (facet.value)}
 					<label class="facet-item">
 						<input
 							type="checkbox"
-							checked={selectedEnvironments.includes(facet.environmentName)}
-							onchange={() => toggleEnvironment(facet.environmentName)}
+							checked={selectedEnvironments.includes(facet.value)}
+							onchange={() => toggleEnvironment(facet.value)}
 						/>
-						<span class="facet-label">{facet.environmentName}</span>
+						<span class="facet-label">{facet.value}</span>
 						<span class="facet-count">{facet.count}</span>
 					</label>
 				{/each}

--- a/src/routes/team/[team]/[env]/app/[app]/activity-log/query.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/activity-log/query.gql
@@ -37,7 +37,7 @@ query ApplicationActivityLog(
 							count
 						}
 						environments {
-							environmentName
+							value
 							count
 						}
 					}

--- a/src/routes/team/[team]/[env]/job/[job]/activity-log/query.gql
+++ b/src/routes/team/[team]/[env]/job/[job]/activity-log/query.gql
@@ -37,7 +37,7 @@ query JobActivityLog(
 							count
 						}
 						environments {
-							environmentName
+							value
 							count
 						}
 					}

--- a/src/routes/team/[team]/[env]/secret/[secret]/+page.svelte
+++ b/src/routes/team/[team]/[env]/secret/[secret]/+page.svelte
@@ -209,7 +209,7 @@
 			return;
 		}
 
-		await goto('/team/' + teamSlug + '/secrets');
+		await goto('/team/' + teamSlug + '/secrets', { invalidateAll: true });
 	};
 
 	const openDeleteModal = () => {

--- a/src/routes/team/[team]/activity-log/query.gql
+++ b/src/routes/team/[team]/activity-log/query.gql
@@ -34,7 +34,7 @@ query ActivityLog(
 					count
 				}
 				environments {
-					environmentName
+					value
 					count
 				}
 			}

--- a/src/routes/team/[team]/applications/query.gql
+++ b/src/routes/team/[team]/applications/query.gql
@@ -27,7 +27,7 @@ query Applications(
 			}
 			facets {
 				environments {
-					environmentName
+					value
 					count
 				}
 				states {

--- a/src/routes/team/[team]/jobs/query.gql
+++ b/src/routes/team/[team]/jobs/query.gql
@@ -29,7 +29,7 @@ query Jobs(
 
 			facets {
 				environments {
-					environmentName
+					value
 					count
 				}
 				states {


### PR DESCRIPTION
This pull request introduces a major refactor and extension of the GraphQL schema to standardize and enhance how facets and filtering are handled across multiple resource types. The changes unify environment facet types, add new facet types for boolean and string distributions, and introduce filtering and facet support to several connections. This will make it easier for clients to filter and aggregate resources by common properties such as environment, state, usage, and more.

Key changes include:

**Facets and Filtering Standardization:**

- Introduced generic facet types (`StringFacetItem`, `BooleanFacetItem`) and replaced resource-specific environment facet types with the generic `StringFacetItem` for environments across all relevant types (`ActivityLogFacets`, `ApplicationFacets`, `JobFacets`, etc.). [[1]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489L357-R348) [[2]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489L935-R931) [[3]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489L3798-R3862) [[4]](diffhunk://#diff-70c22ea0d367c9ae8f01eab13dd5d4466a7bdf1075e82920be9fd816ef1892c5L16-R16) [[5]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R7825-R7835)
- Added new facet types for resource-specific properties, such as `OpenSearchTierFacetItem`, `PostgresInstanceStateFacetItem`, and `ValkeyTierFacetItem`. [[1]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R5179-R5187) [[2]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R5500-R5508) [[3]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R10571-R10579)

**Faceted Connections and Filtering Inputs:**

- Added `facets` fields to connections for `BigQueryDataset`, `Bucket`, `Config`, `KafkaTopic`, `OpenSearch`, `PostgresInstance`, `Secret`, and `Valkey`, providing distribution counts for various properties. [[1]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R1298-R1303) [[2]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R1374-R1379) [[3]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R1674-R1679) [[4]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R4262-R4267) [[5]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R4945-R4950) [[6]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R5423-R5428) [[7]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R6689-R6694) [[8]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R10319-R10324)
- Introduced new filtering input types (e.g., `BigQueryDatasetFilter`, `BucketFilter`, `KafkaTopicFilter`, `OpenSearchFilter`, `PostgresInstanceFilter`, `ValkeyFilter`) and exposed them on the corresponding connection fields in the `Team` type. This enables clients to filter resources by environment, name, tier, state, and other properties. [[1]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R7943-R7945) [[2]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R7968-R7970) [[3]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R8116-R8118) [[4]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R8169-R8171) [[5]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R8194-R8196) [[6]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R8317-R8319) [[7]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R1317-R1333) [[8]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R1389-R1405) [[9]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R4277-R4299) [[10]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R5037-R5059) [[11]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R5438-R5472) [[12]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R6766-R6781) [[13]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489R10411-R10433)

**Deprecation and Cleanup:**

- Removed resource-specific environment facet types (`ActivityLogEnvironmentFacetItem`, `ApplicationEnvironmentFacetItem`, `JobEnvironmentFacetItem`) in favor of the new generic facet type. [[1]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489L338-L346) [[2]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489L935-R931) [[3]](diffhunk://#diff-efc1675187620595b0844197a25c35eac9b6df752f9182e5cffddee6f27a8489L3798-R3862)

These changes significantly improve the consistency and flexibility of the API for clients needing to filter and aggregate data across multiple resource types.