### PR TITLE
Improve secret deletion handling and update GraphQL query

### DIFF
--- a/houdini.config.js
+++ b/houdini.config.js
@@ -13,6 +13,9 @@ const config = {
 		}
 	},
 	defaultCachePolicy: 'CacheAndNetwork',
+	features: {
+		imperativeCache: true
+	},
 	plugins: {
 		'houdini-svelte': {
 			forceRunesMode: true

--- a/src/routes/team/[team]/[env]/secret/[secret]/+page.svelte
+++ b/src/routes/team/[team]/[env]/secret/[secret]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
-	import { ValueEncoding, graphql, type ValueEncoding$options } from '$houdini';
+	import { ValueEncoding, cache, graphql, type ValueEncoding$options } from '$houdini';
 	import Confirm from '$lib/ui/Confirm.svelte';
 	import {
 		Alert,
@@ -199,6 +199,7 @@
 	`);
 
 	const deleteSecret = async () => {
+		const secretId = secret?.id;
 		await deleteMutation.mutate({
 			name: secretName,
 			team: teamSlug,
@@ -209,7 +210,11 @@
 			return;
 		}
 
-		await goto('/team/' + teamSlug + '/secrets', { invalidateAll: true });
+		if (secretId) {
+			cache.get('Secret', { id: secretId }).delete();
+		}
+
+		await goto('/team/' + teamSlug + '/secrets');
 	};
 
 	const openDeleteModal = () => {

--- a/src/routes/team/[team]/[env]/secret/[secret]/query.gql
+++ b/src/routes/team/[team]/[env]/secret/[secret]/query.gql
@@ -8,6 +8,7 @@ query Secret($secret: String!, $team: Slug!, $env: String!) @cache(policy: Netwo
 		viewerIsMember
 		environment(name: $env) {
 			secret(name: $secret) {
+				id
 				name
 				teamEnvironment {
 					environment {


### PR DESCRIPTION
This pull request improves the handling of secret deletion in the team environment secret page. The main changes ensure that the deleted secret is properly removed from the cache, and the necessary secret ID is now available in the query and client code. Additionally, a Houdini configuration update enables a new imperative cache feature.

**Secret Deletion and Cache Management:**

* The `id` field is now included in the `secret` query, making the secret's unique identifier available in the client. ([src/routes/team/[team]/[env]/secret/[secret]/query.gqlR11](diffhunk://#diff-92a06479bde153e7d8daa1c9297ead0a5f8468e3c622e2469492756331ea0af2R11))
* The secret's `id` is extracted and stored before deletion, allowing cache operations to target the correct entity. ([src/routes/team/[team]/[env]/secret/[secret]/+page.svelteR202](diffhunk://#diff-64e1598679b0a1ea7fd1c1172a0546acda86d35e6a494be52db2ffb97c1c35c9R202))
* After a secret is deleted, the corresponding cache entry is explicitly removed using `cache.get('Secret', { id: secretId }).delete()`, ensuring the UI stays in sync with the backend. ([src/routes/team/[team]/[env]/secret/[secret]/+page.svelteL212-R217](diffhunk://#diff-64e1598679b0a1ea7fd1c1172a0546acda86d35e6a494be52db2ffb97c1c35c9L212-R217))

**Houdini Configuration:**

* The Houdini config (`houdini.config.js`) now enables the `imperativeCache` feature, allowing for direct cache manipulation in the app.
* The Houdini cache object is imported in the Svelte page to support imperative cache operations. ([src/routes/team/[team]/[env]/secret/[secret]/+page.svelteL4-R4](diffhunk://#diff-64e1598679b0a1ea7fd1c1172a0546acda86d35e6a494be52db2ffb97c1c35c9L4-R4))