### PR TITLE
Implement retry logic for secret load

### DIFF
--- a/src/routes/team/[team]/[env]/secret/[secret]/+page.ts
+++ b/src/routes/team/[team]/[env]/secret/[secret]/+page.ts
@@ -1,19 +1,31 @@
 import { load_Secret } from '$houdini';
 import { addPageMeta } from '$lib/utils/pageMeta';
+import { get } from 'svelte/store';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export async function load(event) {
-	return {
-		...(await addPageMeta(event, {
-			title: event.params.secret,
-			docPath: '/services/secrets/'
-		})),
-		...(await load_Secret({
-			event,
-			variables: {
-				team: event.params.team,
-				env: event.params.env,
-				secret: event.params.secret
-			}
-		}))
+	const MAX_RETRIES = 5;
+	const RETRY_DELAY = 1500;
+
+	const meta = await addPageMeta(event, {
+		title: event.params.secret,
+		docPath: '/services/secrets/'
+	});
+
+	const variables = {
+		team: event.params.team,
+		env: event.params.env,
+		secret: event.params.secret
 	};
+
+	for (let i = 0; i < MAX_RETRIES; i++) {
+		const result = await load_Secret({ event, variables });
+		const { errors } = get(result.Secret);
+		const isNotFound = errors?.some((e) => e.message.toLowerCase().includes('not found'));
+		if (!isNotFound || i === MAX_RETRIES - 1) {
+			return { ...meta, ...result };
+		}
+		await sleep(RETRY_DELAY);
+	}
 }

--- a/src/routes/team/[team]/[env]/secret/[secret]/+page.ts
+++ b/src/routes/team/[team]/[env]/secret/[secret]/+page.ts
@@ -19,11 +19,16 @@ export async function load(event) {
 		secret: event.params.secret
 	};
 
+	const secretName = event.params.secret.toLowerCase();
 	for (let i = 0; i < MAX_RETRIES; i++) {
-		const result = await load_Secret({ event, variables });
+		const result = await load_Secret({ event, variables, blocking: true });
 		const { errors } = get(result.Secret);
-		const isNotFound = errors?.some((e) => e.message.toLowerCase().includes('not found'));
-		if (!isNotFound || i === MAX_RETRIES - 1) {
+		const isSecretNotFound = errors?.some(
+			(e) =>
+				e.message.toLowerCase().includes('not found') &&
+				e.message.toLowerCase().includes(secretName)
+		);
+		if (!isSecretNotFound || i === MAX_RETRIES - 1) {
 			return { ...meta, ...result };
 		}
 		await sleep(RETRY_DELAY);


### PR DESCRIPTION
This pull request updates the `load` function in `+page.ts` to improve how secret data is fetched and handled when not immediately available. The main change is the addition of a retry mechanism to handle cases where a secret might not be found on the first attempt, making the page more robust to eventual consistency issues.

**Enhancements to secret loading logic:**

* Added a retry loop to the `load` function that attempts to fetch the secret up to five times, with a delay between attempts, in case the secret is not found initially. This helps handle situations where the secret may become available shortly after the request is made. ([src/routes/team/[team]/[env]/secret/[secret]/+page.tsR3-R30](diffhunk://#diff-ce5ea006ae70f6b1456211984fc9a7b3485974aeeb818f7b9945f2fa26342aa1R3-R30))
* Introduced a `sleep` utility function to provide a delay between retry attempts. ([src/routes/team/[team]/[env]/secret/[secret]/+page.tsR3-R30](diffhunk://#diff-ce5ea006ae70f6b1456211984fc9a7b3485974aeeb818f7b9945f2fa26342aa1R3-R30))
* Refactored the code to separate the loading of page metadata from the secret fetching logic, improving readability and maintainability. ([src/routes/team/[team]/[env]/secret/[secret]/+page.tsR3-R30](diffhunk://#diff-ce5ea006ae70f6b1456211984fc9a7b3485974aeeb818f7b9945f2fa26342aa1R3-R30))