### PR TITLE
feat: add facet filters for resource list pages

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,7 +65,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: nais/fasit-deploy@97187355184a7f0f4b7a36a2b49a86ce02240f7b # ratchet:nais/fasit-deploy@v4.0.0
+      - uses: nais/fasit-deploy@9f870e05e92cde6cfd827b13384ec09e80be65fd # ratchet:nais/fasit-deploy@v4.1.0
         with:
           chart: ${{ env.IMAGE_REPOSITORY }}/${{ env.NAME }}
           version: ${{ needs.build_push.outputs.version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,8 +19,8 @@ jobs:
     name: Build and push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # ratchet:jdx/mise-action@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # ratchet:jdx/mise-action@v4
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -34,7 +34,7 @@ jobs:
         run: pnpm run test -- --run
       - id: node_version
         run: echo "node_version=$(mise current node)" >> $GITHUB_OUTPUT
-      - uses: nais/platform-build-push-sign@df590279b21bc5978519685752f9eaddd546043c # ratchet:nais/platform-build-push-sign@main
+      - uses: nais/platform-build-push-sign@31014e4bcac554cb52525fe2364244c5166b84d2 # ratchet:nais/platform-build-push-sign@main
         id: build-push-sign
         with:
           name: ${{ env.NAME }}
@@ -65,7 +65,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: nais/fasit-deploy@58a70a338b16dc646373c91724fc7e7522d085a4 # ratchet:nais/fasit-deploy@v4.0.1
+      - uses: nais/fasit-deploy@97187355184a7f0f4b7a36a2b49a86ce02240f7b # ratchet:nais/fasit-deploy@v4.0.0
         with:
           chart: ${{ env.IMAGE_REPOSITORY }}/${{ env.NAME }}
           version: ${{ needs.build_push.outputs.version }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,8 +12,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # ratchet:jdx/mise-action@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # ratchet:jdx/mise-action@v4
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Sync SvelteKit
@@ -35,11 +35,11 @@ jobs:
     name: Build and push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # ratchet:jdx/mise-action@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # ratchet:jdx/mise-action@v4
       - id: node_version
         run: echo "node_version=$(mise current node)" >> $GITHUB_OUTPUT
-      - uses: nais/platform-build-push-sign@df590279b21bc5978519685752f9eaddd546043c # ratchet:nais/platform-build-push-sign@main
+      - uses: nais/platform-build-push-sign@31014e4bcac554cb52525fe2364244c5166b84d2 # ratchet:nais/platform-build-push-sign@main
         id: build-push-sign
         with:
           name: ${{ env.NAME }}

--- a/schema.graphql
+++ b/schema.graphql
@@ -2836,6 +2836,11 @@ type Environment implements Node {
   """Unique name of the environment."""
   name: String!
 
+  """
+  The OIDC issuer URL for workload identity tokens in the environment. Null for environments that do not support workload identity.
+  """
+  oidcIssuerURL: String
+
   """Nais workloads in the environment."""
   workloads(
     """Get items after this cursor."""

--- a/src/lib/domain/workload/WorkloadListFilters.svelte
+++ b/src/lib/domain/workload/WorkloadListFilters.svelte
@@ -62,22 +62,19 @@
 		return capitalizeFirstLetter(state.split('_').join(' ').toLowerCase());
 	}
 
-	const availableStates = $derived(new Set(states.map((f) => f.state)));
-	const availableEnvironments = $derived(new Set(environments.map((f) => f.value)));
-
 	function toggleState(state: string) {
 		const isSelected = selectedStates.includes(state);
 		const next = isSelected
-			? selectedStates.filter((s) => s !== state && availableStates.has(s))
-			: [...selectedStates.filter((s) => availableStates.has(s)), state];
+			? selectedStates.filter((s) => s !== state)
+			: [...selectedStates, state];
 		onStatesChange(next);
 	}
 
 	function toggleEnvironment(env: string) {
 		const isSelected = selectedEnvironments.includes(env);
 		const next = isSelected
-			? selectedEnvironments.filter((e) => e !== env && availableEnvironments.has(e))
-			: [...selectedEnvironments.filter((e) => availableEnvironments.has(e)), env];
+			? selectedEnvironments.filter((e) => e !== env)
+			: [...selectedEnvironments, env];
 		onEnvironmentsChange(next);
 	}
 </script>

--- a/src/lib/domain/workload/WorkloadListFilters.svelte
+++ b/src/lib/domain/workload/WorkloadListFilters.svelte
@@ -62,6 +62,19 @@
 		return capitalizeFirstLetter(state.split('_').join(' ').toLowerCase());
 	}
 
+	const displayStates = $derived([
+		...states,
+		...selectedStates
+			.filter((s) => !states.some((f) => f.state === s))
+			.map((s) => ({ state: s, count: 0 }))
+	]);
+	const displayEnvironments = $derived([
+		...environments,
+		...selectedEnvironments
+			.filter((e) => !environments.some((f) => f.value === e))
+			.map((e) => ({ value: e, count: 0 }))
+	]);
+
 	function toggleState(state: string) {
 		const isSelected = selectedStates.includes(state);
 		const next = isSelected
@@ -91,11 +104,11 @@
 	{onFilterClear}
 	{onSort}
 >
-	{#if states.length > 0}
+	{#if displayStates.length > 0}
 		<details class="filter-section" open>
 			<summary class="section-heading">Status</summary>
 			<div class="facet-list">
-				{#each states as facet (facet.state)}
+				{#each displayStates as facet (facet.state)}
 					<label class="facet-item">
 						<input
 							type="checkbox"
@@ -110,11 +123,11 @@
 		</details>
 	{/if}
 
-	{#if environments.length > 0}
+	{#if displayEnvironments.length > 0}
 		<details class="filter-section" open>
 			<summary class="section-heading">Environments</summary>
 			<div class="facet-list">
-				{#each environments as facet (facet.value)}
+				{#each displayEnvironments as facet (facet.value)}
 					<label class="facet-item">
 						<input
 							type="checkbox"

--- a/src/lib/domain/workload/WorkloadListFilters.svelte
+++ b/src/lib/domain/workload/WorkloadListFilters.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ListFilters from '$lib/ui/ListFilters.svelte';
 	import { capitalizeFirstLetter } from '$lib/utils/formatters';
+	import type { Snippet } from 'svelte';
 
 	interface StateFacet {
 		state: string;
@@ -18,22 +19,23 @@
 	}
 
 	interface Props {
-		filter: string;
-		searchPlaceholder: string;
-		searchLabel: string;
+		filter?: string;
+		searchPlaceholder?: string;
+		searchLabel?: string;
 		sortFields: SortField[];
 		currentSortField: string;
 		currentSortDirection: string;
 		states?: StateFacet[];
 		environments?: EnvironmentFacet[];
-		selectedStates: string[];
-		selectedEnvironments: string[];
-		onFilterInput: (value: string) => void;
-		onFilterSubmit: () => void;
-		onFilterClear: () => void;
+		selectedStates?: string[];
+		selectedEnvironments?: string[];
+		onFilterInput?: (value: string) => void;
+		onFilterSubmit?: () => void;
+		onFilterClear?: () => void;
 		onSort: (field: string) => void;
-		onStatesChange: (selected: string[]) => void;
-		onEnvironmentsChange: (selected: string[]) => void;
+		onStatesChange?: (selected: string[]) => void;
+		onEnvironmentsChange?: (selected: string[]) => void;
+		children?: Snippet;
 	}
 
 	let {
@@ -45,14 +47,15 @@
 		currentSortDirection,
 		states = [],
 		environments = [],
-		selectedStates,
-		selectedEnvironments,
+		selectedStates = [],
+		selectedEnvironments = [],
 		onFilterInput,
 		onFilterSubmit,
 		onFilterClear,
 		onSort,
-		onStatesChange,
-		onEnvironmentsChange
+		onStatesChange = () => {},
+		onEnvironmentsChange = () => {},
+		children
 	}: Props = $props();
 
 	function stateLabel(state: string): string {
@@ -128,87 +131,9 @@
 			</div>
 		</details>
 	{/if}
+
+	{@render children?.()}
 </ListFilters>
 
 <style>
-	.filter-section {
-		display: flex;
-		flex-direction: column;
-		gap: var(--ax-space-8);
-	}
-
-	.section-heading {
-		font-size: var(--ax-font-size-small);
-		font-weight: 500;
-		color: var(--ax-text-neutral-subtle);
-		margin: 0;
-		letter-spacing: 0.01em;
-		border-bottom: 1px solid var(--ax-border-neutral-subtleA);
-		padding-bottom: var(--ax-space-6);
-		cursor: pointer;
-		list-style: none;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-	}
-
-	.section-heading::-webkit-details-marker {
-		display: none;
-	}
-
-	.section-heading::after {
-		content: '';
-		width: 0.4em;
-		height: 0.4em;
-		border-right: 2px solid currentColor;
-		border-bottom: 2px solid currentColor;
-		transform: rotate(45deg);
-		transition: transform 150ms ease;
-		flex-shrink: 0;
-	}
-
-	.filter-section[open] > .section-heading::after {
-		transform: rotate(-135deg);
-	}
-
-	.facet-list {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.facet-item {
-		display: flex;
-		align-items: center;
-		gap: var(--ax-space-8);
-		padding: var(--ax-space-6) 0;
-		font-size: var(--ax-font-size-small);
-		cursor: pointer;
-	}
-
-	.facet-item:hover {
-		color: var(--ax-text-neutral);
-	}
-
-	.facet-item input[type='checkbox'] {
-		width: 1rem;
-		height: 1rem;
-		margin: 0;
-		flex-shrink: 0;
-		cursor: pointer;
-		accent-color: var(--ax-text-accent);
-	}
-
-	.facet-label {
-		flex: 1;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-		min-width: 0;
-	}
-
-	.facet-count {
-		flex-shrink: 0;
-		font-size: 0.6875rem;
-		color: var(--ax-text-neutral-subtle);
-	}
 </style>

--- a/src/lib/domain/workload/WorkloadListFilters.svelte
+++ b/src/lib/domain/workload/WorkloadListFilters.svelte
@@ -144,6 +144,3 @@
 
 	{@render children?.()}
 </ListFilters>
-
-<style>
-</style>

--- a/src/routes/team/[team]/bigquery/+page.svelte
+++ b/src/routes/team/[team]/bigquery/+page.svelte
@@ -3,12 +3,12 @@
 	import { BigQueryDatasetOrderField, OrderDirection } from '$houdini';
 	import { docURL } from '$lib/doc';
 	import WorkloadLink from '$lib/domain/workload/WorkloadLink.svelte';
+	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
 	import BigQueryIcon from '$lib/icons/BigQueryIcon.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
-	import ListFilters from '$lib/ui/ListFilters.svelte';
 	import ListItem from '$lib/ui/ListItem.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
@@ -48,6 +48,14 @@
 					: OrderDirection.ASC
 				: OrderDirection.ASC;
 		changeParams({ sort: `${field}-${direction}`, after: '', before: '' });
+	}
+
+	const selectedEnvironments: string[] = $derived(
+		page.url.searchParams.get('environments')?.split(',').filter(Boolean) ?? []
+	);
+
+	function handleEnvironmentsChange(selected: string[]) {
+		changeParams({ environments: selected.join(','), after: '', before: '' }, { noScroll: true });
 	}
 </script>
 
@@ -116,11 +124,14 @@
 		</div>
 		<div class="layout-sidebar">
 			<SurfaceCard title="Filters">
-				<ListFilters
+				<WorkloadListFilters
 					{sortFields}
 					{currentSortField}
 					{currentSortDirection}
+					environments={$BigQuery.data?.team.bigQueryDatasets.facets?.environments ?? []}
+					{selectedEnvironments}
 					onSort={(field) => setSort(field as BigQueryOrderFieldOptions)}
+					onEnvironmentsChange={handleEnvironmentsChange}
 				/>
 			</SurfaceCard>
 		</div>

--- a/src/routes/team/[team]/bigquery/+page.ts
+++ b/src/routes/team/[team]/bigquery/+page.ts
@@ -7,8 +7,8 @@ const rows = 25;
 export async function load(event) {
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
-	const environments: string[] | undefined =
-		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
+	const envParam = event.url.searchParams.get('environments')?.split(',').filter(Boolean);
+	const environments = envParam?.length ? envParam : undefined;
 
 	return {
 		...(await addPageMeta(event, {

--- a/src/routes/team/[team]/bigquery/+page.ts
+++ b/src/routes/team/[team]/bigquery/+page.ts
@@ -1,4 +1,4 @@
-import { BigQueryDatasetOrderField, load_BigQuery } from '$houdini';
+import { BigQueryDatasetOrderField, load_BigQuery, type BigQueryDatasetFilter } from '$houdini';
 import { urlToOrderDirection, urlToOrderField } from '$lib/ui/OrderByMenu.svelte';
 import { addPageMeta } from '$lib/utils/pageMeta';
 
@@ -7,6 +7,8 @@ const rows = 25;
 export async function load(event) {
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
+	const environments: string[] | undefined =
+		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
 
 	return {
 		...(await addPageMeta(event, {
@@ -18,6 +20,7 @@ export async function load(event) {
 			event,
 			variables: {
 				team: event.params.team,
+				filter: { environments } as BigQueryDatasetFilter,
 				orderBy: {
 					field: urlToOrderField(
 						BigQueryDatasetOrderField,

--- a/src/routes/team/[team]/bigquery/query.gql
+++ b/src/routes/team/[team]/bigquery/query.gql
@@ -1,16 +1,23 @@
 query BigQuery(
 	$team: Slug!
 	$orderBy: BigQueryDatasetOrder
+	$filter: BigQueryDatasetFilter
 	$first: Int
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) {
+) @cache(policy: CacheAndNetwork, partial: true) {
 	team(slug: $team) {
 		slug
 
-		bigQueryDatasets(first: $first, last: $last, orderBy: $orderBy, before: $before, after: $after)
-			@paginate(mode: SinglePage) {
+		bigQueryDatasets(
+			first: $first
+			last: $last
+			orderBy: $orderBy
+			filter: $filter
+			before: $before
+			after: $after
+		) @paginate(mode: SinglePage) {
 			pageInfo {
 				hasNextPage
 				hasPreviousPage
@@ -19,6 +26,12 @@ query BigQuery(
 				totalCount
 				startCursor
 				endCursor
+			}
+			facets {
+				environments {
+					value
+					count
+				}
 			}
 			nodes {
 				id

--- a/src/routes/team/[team]/buckets/+page.svelte
+++ b/src/routes/team/[team]/buckets/+page.svelte
@@ -3,11 +3,11 @@
 	import { BucketOrderField, OrderDirection } from '$houdini';
 	import { docURL } from '$lib/doc';
 	import WorkloadLink from '$lib/domain/workload/WorkloadLink.svelte';
+	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
-	import ListFilters from '$lib/ui/ListFilters.svelte';
 	import ListItem from '$lib/ui/ListItem.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
@@ -47,6 +47,14 @@
 					: OrderDirection.ASC
 				: OrderDirection.ASC;
 		changeParams({ sort: `${field}-${direction}`, after: '', before: '' });
+	}
+
+	const selectedEnvironments: string[] = $derived(
+		page.url.searchParams.get('environments')?.split(',').filter(Boolean) ?? []
+	);
+
+	function handleEnvironmentsChange(selected: string[]) {
+		changeParams({ environments: selected.join(','), after: '', before: '' }, { noScroll: true });
 	}
 </script>
 
@@ -112,11 +120,14 @@
 		</div>
 		<div class="layout-sidebar">
 			<SurfaceCard title="Filters">
-				<ListFilters
+				<WorkloadListFilters
 					{sortFields}
 					{currentSortField}
 					{currentSortDirection}
+					environments={$Buckets.data?.team.buckets.facets?.environments ?? []}
+					{selectedEnvironments}
 					onSort={(field) => setSort(field as BucketOrderFieldOptions)}
+					onEnvironmentsChange={handleEnvironmentsChange}
 				/>
 			</SurfaceCard>
 		</div>

--- a/src/routes/team/[team]/buckets/+page.ts
+++ b/src/routes/team/[team]/buckets/+page.ts
@@ -7,8 +7,8 @@ const rows = 25;
 export async function load(event) {
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
-	const environments: string[] | undefined =
-		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
+	const envParam = event.url.searchParams.get('environments')?.split(',').filter(Boolean);
+	const environments = envParam?.length ? envParam : undefined;
 
 	return {
 		...(await addPageMeta(event, {

--- a/src/routes/team/[team]/buckets/+page.ts
+++ b/src/routes/team/[team]/buckets/+page.ts
@@ -1,4 +1,4 @@
-import { BucketOrderField, load_Buckets } from '$houdini';
+import { BucketOrderField, load_Buckets, type BucketFilter } from '$houdini';
 import { urlToOrderDirection, urlToOrderField } from '$lib/ui/OrderByMenu.svelte';
 import { addPageMeta } from '$lib/utils/pageMeta';
 
@@ -7,6 +7,8 @@ const rows = 25;
 export async function load(event) {
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
+	const environments: string[] | undefined =
+		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
 
 	return {
 		...(await addPageMeta(event, {
@@ -18,6 +20,7 @@ export async function load(event) {
 			event,
 			variables: {
 				team: event.params.team,
+				filter: { environments } as BucketFilter,
 				orderBy: {
 					field: urlToOrderField(BucketOrderField, BucketOrderField.NAME, event.url),
 					direction: urlToOrderDirection(event.url)

--- a/src/routes/team/[team]/buckets/query.gql
+++ b/src/routes/team/[team]/buckets/query.gql
@@ -1,16 +1,23 @@
 query Buckets(
 	$team: Slug!
 	$orderBy: BucketOrder
+	$filter: BucketFilter
 	$first: Int
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) {
+) @cache(policy: CacheAndNetwork, partial: true) {
 	team(slug: $team) {
 		slug
 
-		buckets(first: $first, last: $last, orderBy: $orderBy, before: $before, after: $after)
-			@paginate(mode: SinglePage) {
+		buckets(
+			first: $first
+			last: $last
+			orderBy: $orderBy
+			filter: $filter
+			before: $before
+			after: $after
+		) @paginate(mode: SinglePage) {
 			pageInfo {
 				hasNextPage
 				hasPreviousPage
@@ -19,6 +26,12 @@ query Buckets(
 				totalCount
 				startCursor
 				endCursor
+			}
+			facets {
+				environments {
+					value
+					count
+				}
 			}
 			nodes {
 				id

--- a/src/routes/team/[team]/configs/+page.svelte
+++ b/src/routes/team/[team]/configs/+page.svelte
@@ -43,6 +43,12 @@
 
 	const inUseFacets = $derived($Configs.data?.team.configs.facets?.inUse ?? []);
 	const environmentFacets = $derived($Configs.data?.team.configs.facets?.environments ?? []);
+	const displayEnvironmentFacets = $derived([
+		...environmentFacets,
+		...selectedEnvironments
+			.filter((e) => !environmentFacets.some((f) => f.value === e))
+			.map((e) => ({ value: e, count: 0 }))
+	]);
 
 	function toggleInUse(value: string) {
 		const next = inUseFilter === value ? '' : value;
@@ -222,11 +228,11 @@
 					}}
 					onSort={(field) => setSort(field as ConfigOrderFieldOptions)}
 				>
-					{#if environmentFacets.length > 0}
+					{#if displayEnvironmentFacets.length > 0}
 						<details class="filter-section" open>
 							<summary class="section-heading">Environments</summary>
 							<div class="facet-list">
-								{#each environmentFacets as facet (facet.value)}
+								{#each displayEnvironmentFacets as facet (facet.value)}
 									<label class="facet-item">
 										<input
 											type="checkbox"
@@ -240,19 +246,20 @@
 							</div>
 						</details>
 					{/if}
-					{#if inUseFacets.length > 0}
+					{#if inUseFacets.length > 0 || inUseFilter !== null}
 						<details class="filter-section" open>
 							<summary class="section-heading">Usage</summary>
 							<div class="facet-list">
-								{#each inUseFacets as facet (String(facet.value))}
+								{#each ['true', 'false'] as value (value)}
+									{@const count = inUseFacets.find((f) => String(f.value) === value)?.count ?? 0}
 									<label class="facet-item">
 										<input
 											type="checkbox"
-											checked={inUseFilter === String(facet.value)}
-											onchange={() => toggleInUse(String(facet.value))}
+											checked={inUseFilter === value}
+											onchange={() => toggleInUse(value)}
 										/>
-										<span class="facet-label">{facet.value ? 'In use' : 'Not in use'}</span>
-										<span class="facet-count">{facet.count}</span>
+										<span class="facet-label">{value === 'true' ? 'In use' : 'Not in use'}</span>
+										<span class="facet-count">{count}</span>
 									</label>
 								{/each}
 							</div>

--- a/src/routes/team/[team]/configs/+page.svelte
+++ b/src/routes/team/[team]/configs/+page.svelte
@@ -43,7 +43,6 @@
 
 	const inUseFacets = $derived($Configs.data?.team.configs.facets?.inUse ?? []);
 	const environmentFacets = $derived($Configs.data?.team.configs.facets?.environments ?? []);
-	const availableEnvironments = $derived(new Set(environmentFacets.map((f) => f.value)));
 
 	function toggleInUse(value: string) {
 		const next = inUseFilter === value ? '' : value;
@@ -53,8 +52,8 @@
 	function toggleEnvironment(env: string) {
 		const isSelected = selectedEnvironments.includes(env);
 		const next = isSelected
-			? selectedEnvironments.filter((e) => e !== env && availableEnvironments.has(e))
-			: [...selectedEnvironments.filter((e) => availableEnvironments.has(e)), env];
+			? selectedEnvironments.filter((e) => e !== env)
+			: [...selectedEnvironments, env];
 		changeParams({ environments: next.join(','), after: '', before: '' }, { noScroll: true });
 	}
 

--- a/src/routes/team/[team]/configs/+page.svelte
+++ b/src/routes/team/[team]/configs/+page.svelte
@@ -36,22 +36,27 @@
 	let after: string = $derived($Configs.variables?.after ?? '');
 	let before: string = $derived($Configs.variables?.before ?? '');
 
-	const allUsages = ['inUse', 'notInUse'];
-	let activeUsages: string[] = $derived.by(() => {
-		const param = page.url.searchParams.get('filter');
-		if (param === 'inUse') return ['inUse'];
-		if (param === 'notInUse') return ['notInUse'];
-		return allUsages;
-	});
+	const inUseFilter = $derived(page.url.searchParams.get('inUse'));
+	const selectedEnvironments: string[] = $derived(
+		page.url.searchParams.get('environments')?.split(',').filter(Boolean) ?? []
+	);
 
-	const toggleUsage = (key: string) => {
-		const next = activeUsages.includes(key)
-			? activeUsages.filter((s) => s !== key)
-			: [...activeUsages, key];
-		if (next.length === 0) return;
-		const filter = next.length === allUsages.length ? '' : next[0];
-		changeParams({ filter, after: '', before: '' });
-	};
+	const inUseFacets = $derived($Configs.data?.team.configs.facets?.inUse ?? []);
+	const environmentFacets = $derived($Configs.data?.team.configs.facets?.environments ?? []);
+	const availableEnvironments = $derived(new Set(environmentFacets.map((f) => f.value)));
+
+	function toggleInUse(value: string) {
+		const next = inUseFilter === value ? '' : value;
+		changeParams({ inUse: next, after: '', before: '' }, { noScroll: true });
+	}
+
+	function toggleEnvironment(env: string) {
+		const isSelected = selectedEnvironments.includes(env);
+		const next = isSelected
+			? selectedEnvironments.filter((e) => e !== env && availableEnvironments.has(e))
+			: [...selectedEnvironments.filter((e) => availableEnvironments.has(e)), env];
+		changeParams({ environments: next.join(','), after: '', before: '' }, { noScroll: true });
+	}
 
 	const changeQuery = (
 		params: {
@@ -63,7 +68,8 @@
 		changeParams({
 			before: params.before ?? before,
 			after: params.after ?? after,
-			nameFilter: params.newFilter ?? filter
+			nameFilter: params.newFilter ?? filter,
+			environments: selectedEnvironments.join(',')
 		});
 	};
 
@@ -217,27 +223,42 @@
 					}}
 					onSort={(field) => setSort(field as ConfigOrderFieldOptions)}
 				>
-					<details class="usage-section" open>
-						<summary class="usage-heading">Usage</summary>
-						<div class="facet-list">
-							<label class="facet-item">
-								<input
-									type="checkbox"
-									checked={activeUsages.includes('inUse')}
-									onchange={() => toggleUsage('inUse')}
-								/>
-								<span class="facet-label">In use</span>
-							</label>
-							<label class="facet-item">
-								<input
-									type="checkbox"
-									checked={activeUsages.includes('notInUse')}
-									onchange={() => toggleUsage('notInUse')}
-								/>
-								<span class="facet-label">Not in use</span>
-							</label>
-						</div>
-					</details>
+					{#if environmentFacets.length > 0}
+						<details class="filter-section" open>
+							<summary class="section-heading">Environments</summary>
+							<div class="facet-list">
+								{#each environmentFacets as facet (facet.value)}
+									<label class="facet-item">
+										<input
+											type="checkbox"
+											checked={selectedEnvironments.includes(facet.value)}
+											onchange={() => toggleEnvironment(facet.value)}
+										/>
+										<span class="facet-label">{facet.value}</span>
+										<span class="facet-count">{facet.count}</span>
+									</label>
+								{/each}
+							</div>
+						</details>
+					{/if}
+					{#if inUseFacets.length > 0}
+						<details class="filter-section" open>
+							<summary class="section-heading">Usage</summary>
+							<div class="facet-list">
+								{#each inUseFacets as facet (String(facet.value))}
+									<label class="facet-item">
+										<input
+											type="checkbox"
+											checked={inUseFilter === String(facet.value)}
+											onchange={() => toggleInUse(String(facet.value))}
+										/>
+										<span class="facet-label">{facet.value ? 'In use' : 'Not in use'}</span>
+										<span class="facet-count">{facet.count}</span>
+									</label>
+								{/each}
+							</div>
+						</details>
+					{/if}
 				</ListFilters>
 			</SurfaceCard>
 			<TeamActivityCard
@@ -264,72 +285,6 @@
 		flex-direction: column;
 		align-items: end;
 		gap: var(--ax-space-2);
-	}
-
-	.usage-section {
-		display: flex;
-		flex-direction: column;
-		gap: var(--ax-space-8);
-	}
-
-	.usage-heading {
-		font-size: var(--ax-font-size-small);
-		font-weight: 500;
-		color: var(--ax-text-neutral-subtle);
-		letter-spacing: 0.01em;
-		border-bottom: 1px solid var(--ax-border-neutral-subtleA);
-		padding-bottom: var(--ax-space-6);
-		cursor: pointer;
-		list-style: none;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-	}
-
-	.usage-heading::-webkit-details-marker {
-		display: none;
-	}
-
-	.usage-heading::after {
-		content: '';
-		width: 0.4em;
-		height: 0.4em;
-		border-right: 2px solid currentColor;
-		border-bottom: 2px solid currentColor;
-		transform: rotate(45deg);
-		transition: transform 150ms ease;
-		flex-shrink: 0;
-	}
-
-	.usage-section[open] > .usage-heading::after {
-		transform: rotate(-135deg);
-	}
-
-	.facet-list {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.facet-item {
-		display: flex;
-		align-items: center;
-		gap: var(--ax-space-8);
-		padding: var(--ax-space-6) 0;
-		font-size: var(--ax-font-size-medium);
-		cursor: pointer;
-	}
-
-	.facet-item:hover {
-		color: var(--ax-text-neutral);
-	}
-
-	.facet-item input[type='checkbox'] {
-		width: 1rem;
-		height: 1rem;
-		margin: 0;
-		flex-shrink: 0;
-		cursor: pointer;
-		accent-color: var(--ax-text-accent);
 	}
 
 	.name-group {

--- a/src/routes/team/[team]/configs/+page.ts
+++ b/src/routes/team/[team]/configs/+page.ts
@@ -4,13 +4,19 @@ import { addPageMeta } from '$lib/utils/pageMeta';
 
 const rows = 25;
 export async function load(event) {
-	const filter = event.url.searchParams.get('filter') || '';
 	const nameFilter = event.url.searchParams.get('nameFilter') || '';
+	const inUse = event.url.searchParams.get('inUse');
+	const environments: string[] | undefined =
+		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
 
 	let filterVar: ConfigFilter | undefined = undefined;
 
-	if (filter === 'inUse' || filter === 'notInUse') {
-		filterVar = { inUse: filter === 'inUse' ? true : false };
+	if (inUse === 'true' || inUse === 'false') {
+		filterVar = { inUse: inUse === 'true' };
+	}
+
+	if (environments?.length) {
+		filterVar = { ...filterVar, environments };
 	}
 
 	if (nameFilter) {

--- a/src/routes/team/[team]/configs/query.gql
+++ b/src/routes/team/[team]/configs/query.gql
@@ -31,6 +31,16 @@ query Configs(
 				startCursor
 				endCursor
 			}
+			facets {
+				environments {
+					value
+					count
+				}
+				inUse {
+					value
+					count
+				}
+			}
 			nodes {
 				id
 				name

--- a/src/routes/team/[team]/kafka/+page.svelte
+++ b/src/routes/team/[team]/kafka/+page.svelte
@@ -2,12 +2,12 @@
 	import { page } from '$app/state';
 	import { KafkaTopicOrderField, OrderDirection } from '$houdini';
 	import { docURL } from '$lib/doc';
+	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
 	import KafkaIcon from '$lib/icons/KafkaIcon.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
-	import ListFilters from '$lib/ui/ListFilters.svelte';
 	import ListItem from '$lib/ui/ListItem.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
@@ -47,6 +47,28 @@
 					: OrderDirection.ASC
 				: OrderDirection.ASC;
 		changeParams({ sort: `${field}-${direction}`, after: '', before: '' });
+	}
+
+	const selectedEnvironments: string[] = $derived(
+		page.url.searchParams.get('environments')?.split(',').filter(Boolean) ?? []
+	);
+	const selectedPools: string[] = $derived(
+		page.url.searchParams.get('pools')?.split(',').filter(Boolean) ?? []
+	);
+
+	function handleEnvironmentsChange(selected: string[]) {
+		changeParams({ environments: selected.join(','), after: '', before: '' }, { noScroll: true });
+	}
+
+	const poolFacets = $derived($KafkaTopics.data?.team.kafkaTopics.facets?.pools ?? []);
+	const availablePools = $derived(new Set(poolFacets.map((f) => f.value)));
+
+	function togglePool(pool: string) {
+		const isSelected = selectedPools.includes(pool);
+		const next = isSelected
+			? selectedPools.filter((p) => p !== pool && availablePools.has(p))
+			: [...selectedPools.filter((p) => availablePools.has(p)), pool];
+		changeParams({ pools: next.join(','), after: '', before: '' }, { noScroll: true });
 	}
 </script>
 
@@ -107,12 +129,34 @@
 		</div>
 		<div class="layout-sidebar">
 			<SurfaceCard title="Filters">
-				<ListFilters
+				<WorkloadListFilters
 					{sortFields}
 					{currentSortField}
 					{currentSortDirection}
+					environments={$KafkaTopics.data?.team.kafkaTopics.facets?.environments ?? []}
+					{selectedEnvironments}
 					onSort={(field) => setSort(field as KafkaTopicOrderFieldOptions)}
-				/>
+					onEnvironmentsChange={handleEnvironmentsChange}
+				>
+					{#if poolFacets.length > 0}
+						<details class="filter-section" open>
+							<summary class="section-heading">Pools</summary>
+							<div class="facet-list">
+								{#each poolFacets as facet (facet.value)}
+									<label class="facet-item">
+										<input
+											type="checkbox"
+											checked={selectedPools.includes(facet.value)}
+											onchange={() => togglePool(facet.value)}
+										/>
+										<span class="facet-label">{facet.value}</span>
+										<span class="facet-count">{facet.count}</span>
+									</label>
+								{/each}
+							</div>
+						</details>
+					{/if}
+				</WorkloadListFilters>
 			</SurfaceCard>
 		</div>
 	</div>

--- a/src/routes/team/[team]/kafka/+page.svelte
+++ b/src/routes/team/[team]/kafka/+page.svelte
@@ -61,6 +61,12 @@
 	}
 
 	const poolFacets = $derived($KafkaTopics.data?.team.kafkaTopics.facets?.pools ?? []);
+	const displayPoolFacets = $derived([
+		...poolFacets,
+		...selectedPools
+			.filter((p) => !poolFacets.some((f) => f.value === p))
+			.map((p) => ({ value: p, count: 0 }))
+	]);
 
 	function togglePool(pool: string) {
 		const isSelected = selectedPools.includes(pool);
@@ -135,11 +141,11 @@
 					onSort={(field) => setSort(field as KafkaTopicOrderFieldOptions)}
 					onEnvironmentsChange={handleEnvironmentsChange}
 				>
-					{#if poolFacets.length > 0}
+					{#if displayPoolFacets.length > 0}
 						<details class="filter-section" open>
 							<summary class="section-heading">Pools</summary>
 							<div class="facet-list">
-								{#each poolFacets as facet (facet.value)}
+								{#each displayPoolFacets as facet (facet.value)}
 									<label class="facet-item">
 										<input
 											type="checkbox"

--- a/src/routes/team/[team]/kafka/+page.svelte
+++ b/src/routes/team/[team]/kafka/+page.svelte
@@ -61,13 +61,10 @@
 	}
 
 	const poolFacets = $derived($KafkaTopics.data?.team.kafkaTopics.facets?.pools ?? []);
-	const availablePools = $derived(new Set(poolFacets.map((f) => f.value)));
 
 	function togglePool(pool: string) {
 		const isSelected = selectedPools.includes(pool);
-		const next = isSelected
-			? selectedPools.filter((p) => p !== pool && availablePools.has(p))
-			: [...selectedPools.filter((p) => availablePools.has(p)), pool];
+		const next = isSelected ? selectedPools.filter((p) => p !== pool) : [...selectedPools, pool];
 		changeParams({ pools: next.join(','), after: '', before: '' }, { noScroll: true });
 	}
 </script>

--- a/src/routes/team/[team]/kafka/+page.ts
+++ b/src/routes/team/[team]/kafka/+page.ts
@@ -7,10 +7,10 @@ const rows = 25;
 export async function load(event) {
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
-	const environments: string[] | undefined =
-		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
-	const pools: string[] | undefined =
-		event.url.searchParams.get('pools')?.split(',').filter(Boolean) || undefined;
+	const envParam = event.url.searchParams.get('environments')?.split(',').filter(Boolean);
+	const environments = envParam?.length ? envParam : undefined;
+	const poolsParam = event.url.searchParams.get('pools')?.split(',').filter(Boolean);
+	const pools = poolsParam?.length ? poolsParam : undefined;
 
 	return {
 		...(await addPageMeta(event, {

--- a/src/routes/team/[team]/kafka/+page.ts
+++ b/src/routes/team/[team]/kafka/+page.ts
@@ -1,4 +1,4 @@
-import { KafkaTopicOrderField, load_KafkaTopics } from '$houdini';
+import { KafkaTopicOrderField, load_KafkaTopics, type KafkaTopicFilter } from '$houdini';
 import { urlToOrderDirection, urlToOrderField } from '$lib/ui/OrderByMenu.svelte';
 import { addPageMeta } from '$lib/utils/pageMeta';
 
@@ -7,6 +7,10 @@ const rows = 25;
 export async function load(event) {
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
+	const environments: string[] | undefined =
+		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
+	const pools: string[] | undefined =
+		event.url.searchParams.get('pools')?.split(',').filter(Boolean) || undefined;
 
 	return {
 		...(await addPageMeta(event, {
@@ -18,6 +22,7 @@ export async function load(event) {
 			event,
 			variables: {
 				team: event.params.team,
+				filter: { environments, pools } as KafkaTopicFilter,
 				orderBy: {
 					field: urlToOrderField(KafkaTopicOrderField, KafkaTopicOrderField.NAME, event.url),
 					direction: urlToOrderDirection(event.url)

--- a/src/routes/team/[team]/kafka/query.gql
+++ b/src/routes/team/[team]/kafka/query.gql
@@ -1,15 +1,22 @@
 query KafkaTopics(
 	$team: Slug!
 	$orderBy: KafkaTopicOrder
+	$filter: KafkaTopicFilter
 	$first: Int
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) {
+) @cache(policy: CacheAndNetwork, partial: true) {
 	team(slug: $team) {
 		slug
-		kafkaTopics(first: $first, last: $last, orderBy: $orderBy, before: $before, after: $after)
-			@paginate(mode: SinglePage) {
+		kafkaTopics(
+			first: $first
+			last: $last
+			orderBy: $orderBy
+			filter: $filter
+			before: $before
+			after: $after
+		) @paginate(mode: SinglePage) {
 			pageInfo {
 				hasNextPage
 				hasPreviousPage
@@ -18,6 +25,16 @@ query KafkaTopics(
 				totalCount
 				startCursor
 				endCursor
+			}
+			facets {
+				environments {
+					value
+					count
+				}
+				pools {
+					value
+					count
+				}
 			}
 
 			nodes {

--- a/src/routes/team/[team]/opensearch/+page.svelte
+++ b/src/routes/team/[team]/opensearch/+page.svelte
@@ -82,6 +82,12 @@
 	}
 
 	const tierFacets = $derived($OpenSearch.data?.team.openSearches.facets?.tiers ?? []);
+	const displayTierFacets = $derived([
+		...tierFacets,
+		...selectedTiers
+			.filter((t) => !tierFacets.some((f) => f.tier === t))
+			.map((t) => ({ tier: t, count: 0 }))
+	]);
 
 	function toggleTier(tier: string) {
 		const isSelected = selectedTiers.includes(tier);
@@ -209,11 +215,11 @@
 					onSort={(field) => setSort(field as OpenSearchOrderFieldOptions)}
 					onEnvironmentsChange={handleEnvironmentsChange}
 				>
-					{#if tierFacets.length > 0}
+					{#if displayTierFacets.length > 0}
 						<details class="filter-section" open>
 							<summary class="section-heading">Tier</summary>
 							<div class="facet-list">
-								{#each tierFacets as facet (facet.tier)}
+								{#each displayTierFacets as facet (facet.tier)}
 									<label class="facet-item">
 										<input
 											type="checkbox"

--- a/src/routes/team/[team]/opensearch/+page.svelte
+++ b/src/routes/team/[team]/opensearch/+page.svelte
@@ -3,17 +3,18 @@
 	import { OpenSearchOrderField, OrderDirection } from '$houdini';
 	import { docURL } from '$lib/doc';
 	import IssueSeverityTags from '$lib/domain/issues/IssueSeverityTags.svelte';
+	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
-	import ListFilters from '$lib/ui/ListFilters.svelte';
 	import ListItem from '$lib/ui/ListItem.svelte';
 	import PageModal, { pageModalClick } from '$lib/ui/PageModal.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import RunningIndicator from '$lib/ui/RunningIndicator.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import TooltipAlignHack from '$lib/ui/TooltipAlignHack.svelte';
+	import { capitalizeFirstLetter } from '$lib/utils/formatters';
 	import { countIssuesBySeverity } from '$lib/utils/issueCounts';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Button, Tag } from '@nais/ds-svelte-community';
@@ -68,6 +69,28 @@
 		header: 'Create OpenSearch',
 		viewerIsMember: viewerIsMember
 	});
+
+	const selectedEnvironments: string[] = $derived(
+		page.url.searchParams.get('environments')?.split(',').filter(Boolean) ?? []
+	);
+	const selectedTiers: string[] = $derived(
+		page.url.searchParams.get('tiers')?.split(',').filter(Boolean) ?? []
+	);
+
+	function handleEnvironmentsChange(selected: string[]) {
+		changeParams({ environments: selected.join(','), after: '', before: '' }, { noScroll: true });
+	}
+
+	const tierFacets = $derived($OpenSearch.data?.team.openSearches.facets?.tiers ?? []);
+	const availableTiers = $derived(new Set<string>(tierFacets.map((f) => f.tier)));
+
+	function toggleTier(tier: string) {
+		const isSelected = selectedTiers.includes(tier);
+		const next = isSelected
+			? selectedTiers.filter((t) => t !== tier && availableTiers.has(t))
+			: [...selectedTiers.filter((t) => availableTiers.has(t)), tier];
+		changeParams({ tiers: next.join(','), after: '', before: '' }, { noScroll: true });
+	}
 </script>
 
 <GraphErrors errors={$OpenSearch.errors} />
@@ -180,12 +203,36 @@
 		</div>
 		<div class="layout-sidebar">
 			<SurfaceCard title="Filters">
-				<ListFilters
+				<WorkloadListFilters
 					{sortFields}
 					{currentSortField}
 					{currentSortDirection}
+					environments={$OpenSearch.data?.team.openSearches.facets?.environments ?? []}
+					{selectedEnvironments}
 					onSort={(field) => setSort(field as OpenSearchOrderFieldOptions)}
-				/>
+					onEnvironmentsChange={handleEnvironmentsChange}
+				>
+					{#if tierFacets.length > 0}
+						<details class="filter-section" open>
+							<summary class="section-heading">Tier</summary>
+							<div class="facet-list">
+								{#each tierFacets as facet (facet.tier)}
+									<label class="facet-item">
+										<input
+											type="checkbox"
+											checked={selectedTiers.includes(facet.tier)}
+											onchange={() => toggleTier(facet.tier)}
+										/>
+										<span class="facet-label"
+											>{capitalizeFirstLetter(facet.tier.split('_').join(' ').toLowerCase())}</span
+										>
+										<span class="facet-count">{facet.count}</span>
+									</label>
+								{/each}
+							</div>
+						</details>
+					{/if}
+				</WorkloadListFilters>
 			</SurfaceCard>
 		</div>
 	</div>

--- a/src/routes/team/[team]/opensearch/+page.svelte
+++ b/src/routes/team/[team]/opensearch/+page.svelte
@@ -82,13 +82,10 @@
 	}
 
 	const tierFacets = $derived($OpenSearch.data?.team.openSearches.facets?.tiers ?? []);
-	const availableTiers = $derived(new Set<string>(tierFacets.map((f) => f.tier)));
 
 	function toggleTier(tier: string) {
 		const isSelected = selectedTiers.includes(tier);
-		const next = isSelected
-			? selectedTiers.filter((t) => t !== tier && availableTiers.has(t))
-			: [...selectedTiers.filter((t) => availableTiers.has(t)), tier];
+		const next = isSelected ? selectedTiers.filter((t) => t !== tier) : [...selectedTiers, tier];
 		changeParams({ tiers: next.join(','), after: '', before: '' }, { noScroll: true });
 	}
 </script>

--- a/src/routes/team/[team]/opensearch/+page.ts
+++ b/src/routes/team/[team]/opensearch/+page.ts
@@ -1,6 +1,7 @@
 import {
 	load_OpenSearch,
 	OpenSearchOrderField,
+	OpenSearchTier,
 	OrderDirection,
 	type OpenSearchFilter
 } from '$houdini';
@@ -33,8 +34,12 @@ export async function load(event) {
 	const before = url.searchParams.get('before') || '';
 	const environments: string[] | undefined =
 		url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
-	const tiers: string[] | undefined =
-		url.searchParams.get('tiers')?.split(',').filter(Boolean) || undefined;
+	const validOpenSearchTiers = new Set<string>(Object.values(OpenSearchTier));
+	const tiers =
+		url.searchParams
+			.get('tiers')
+			?.split(',')
+			.filter((t) => validOpenSearchTiers.has(t)) || undefined;
 
 	return {
 		...(await addPageMeta(event, {

--- a/src/routes/team/[team]/opensearch/+page.ts
+++ b/src/routes/team/[team]/opensearch/+page.ts
@@ -32,14 +32,14 @@ export async function load(event) {
 
 	const after = url.searchParams.get('after') || '';
 	const before = url.searchParams.get('before') || '';
-	const environments: string[] | undefined =
-		url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
+	const envParam = url.searchParams.get('environments')?.split(',').filter(Boolean);
+	const environments = envParam?.length ? envParam : undefined;
 	const validOpenSearchTiers = new Set<string>(Object.values(OpenSearchTier));
-	const tiers =
-		url.searchParams
-			.get('tiers')
-			?.split(',')
-			.filter((t) => validOpenSearchTiers.has(t)) || undefined;
+	const tiersParam = url.searchParams
+		.get('tiers')
+		?.split(',')
+		.filter((t) => validOpenSearchTiers.has(t));
+	const tiers = tiersParam?.length ? tiersParam : undefined;
 
 	return {
 		...(await addPageMeta(event, {

--- a/src/routes/team/[team]/opensearch/+page.ts
+++ b/src/routes/team/[team]/opensearch/+page.ts
@@ -1,4 +1,9 @@
-import { load_OpenSearch, OpenSearchOrderField, OrderDirection } from '$houdini';
+import {
+	load_OpenSearch,
+	OpenSearchOrderField,
+	OrderDirection,
+	type OpenSearchFilter
+} from '$houdini';
 import { urlToOrderDirection, urlToOrderField } from '$lib/ui/OrderByMenu.svelte';
 import { addPageMeta } from '$lib/utils/pageMeta';
 import { error } from '@sveltejs/kit';
@@ -26,6 +31,10 @@ export async function load(event) {
 
 	const after = url.searchParams.get('after') || '';
 	const before = url.searchParams.get('before') || '';
+	const environments: string[] | undefined =
+		url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
+	const tiers: string[] | undefined =
+		url.searchParams.get('tiers')?.split(',').filter(Boolean) || undefined;
 
 	return {
 		...(await addPageMeta(event, {
@@ -37,6 +46,7 @@ export async function load(event) {
 			event,
 			variables: {
 				team: event.params.team,
+				filter: { environments, tiers } as OpenSearchFilter,
 				orderBy: {
 					field: urlToOrderField(OpenSearchOrderField, OpenSearchOrderField.ISSUES, event.url),
 					direction: urlToOrderDirection(event.url, OrderDirection.DESC)

--- a/src/routes/team/[team]/opensearch/query.gql
+++ b/src/routes/team/[team]/opensearch/query.gql
@@ -1,6 +1,7 @@
 query OpenSearch(
 	$team: Slug!
 	$orderBy: OpenSearchOrder
+	$filter: OpenSearchFilter
 	$first: Int
 	$last: Int
 	$before: Cursor
@@ -9,8 +10,14 @@ query OpenSearch(
 	team(slug: $team) {
 		slug
 
-		openSearches(first: $first, last: $last, orderBy: $orderBy, before: $before, after: $after)
-			@paginate(mode: SinglePage) {
+		openSearches(
+			first: $first
+			last: $last
+			orderBy: $orderBy
+			filter: $filter
+			before: $before
+			after: $after
+		) @paginate(mode: SinglePage) {
 			pageInfo {
 				hasNextPage
 				hasPreviousPage
@@ -19,6 +26,16 @@ query OpenSearch(
 				pageEnd
 				startCursor
 				endCursor
+			}
+			facets {
+				environments {
+					value
+					count
+				}
+				tiers {
+					tier
+					count
+				}
 			}
 			nodes {
 				id

--- a/src/routes/team/[team]/postgres/+page.svelte
+++ b/src/routes/team/[team]/postgres/+page.svelte
@@ -2,15 +2,16 @@
 	import { page } from '$app/state';
 	import { OrderDirection, PostgresInstanceOrderField } from '$houdini';
 	import { docURL } from '$lib/doc';
+	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
-	import ListFilters from '$lib/ui/ListFilters.svelte';
 	import ListItem from '$lib/ui/ListItem.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import TooltipAlignHack from '$lib/ui/TooltipAlignHack.svelte';
+	import { capitalizeFirstLetter } from '$lib/utils/formatters';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Alert, Loader, Tag } from '@nais/ds-svelte-community';
 	import { CircleFillIcon } from '@nais/ds-svelte-community/icons';
@@ -54,6 +55,48 @@
 		($PostgresInstances.data?.team.inventoryCounts.sqlInstances.total ?? 0) > 0
 	);
 	let cloudSqlTeamSlug = $derived($PostgresInstances.data?.team.slug ?? data.teamSlug);
+
+	const selectedEnvironments: string[] = $derived(
+		page.url.searchParams.get('environments')?.split(',').filter(Boolean) ?? []
+	);
+	const selectedStates: string[] = $derived(
+		page.url.searchParams.get('states')?.split(',').filter(Boolean) ?? []
+	);
+	const selectedMajorVersions: string[] = $derived(
+		page.url.searchParams.get('majorVersions')?.split(',').filter(Boolean) ?? []
+	);
+	const selectedHighAvailability: string = $derived(
+		page.url.searchParams.get('highAvailability') ?? ''
+	);
+
+	function handleEnvironmentsChange(selected: string[]) {
+		changeParams({ environments: selected.join(','), after: '', before: '' }, { noScroll: true });
+	}
+	function handleStatesChange(selected: string[]) {
+		changeParams({ states: selected.join(','), after: '', before: '' }, { noScroll: true });
+	}
+
+	const majorVersionFacets = $derived(
+		$PostgresInstances.data?.team.postgresInstances.facets?.majorVersions ?? []
+	);
+	const availableMajorVersions = $derived(new Set(majorVersionFacets.map((f) => f.value)));
+
+	function toggleMajorVersion(version: string) {
+		const isSelected = selectedMajorVersions.includes(version);
+		const next = isSelected
+			? selectedMajorVersions.filter((v) => v !== version && availableMajorVersions.has(v))
+			: [...selectedMajorVersions.filter((v) => availableMajorVersions.has(v)), version];
+		changeParams({ majorVersions: next.join(','), after: '', before: '' }, { noScroll: true });
+	}
+
+	const highAvailabilityFacets = $derived(
+		$PostgresInstances.data?.team.postgresInstances.facets?.highAvailability ?? []
+	);
+
+	function toggleHighAvailability(value: string) {
+		const next = selectedHighAvailability === value ? '' : value;
+		changeParams({ highAvailability: next, after: '', before: '' }, { noScroll: true });
+	}
 </script>
 
 <GraphErrors errors={$PostgresInstances.errors} />
@@ -140,12 +183,57 @@
 		</div>
 		<div class="layout-sidebar">
 			<SurfaceCard title="Filters">
-				<ListFilters
+				<WorkloadListFilters
 					{sortFields}
 					{currentSortField}
 					{currentSortDirection}
+					states={$PostgresInstances.data?.team.postgresInstances.facets?.states ?? []}
+					{selectedStates}
+					environments={$PostgresInstances.data?.team.postgresInstances.facets?.environments ?? []}
+					{selectedEnvironments}
 					onSort={(field) => setSort(field as PostgresOrderFieldOptions)}
-				/>
+					onStatesChange={handleStatesChange}
+					onEnvironmentsChange={handleEnvironmentsChange}
+				>
+					{#if majorVersionFacets.length > 0}
+						<details class="filter-section" open>
+							<summary class="section-heading">Major version</summary>
+							<div class="facet-list">
+								{#each majorVersionFacets as facet (facet.value)}
+									<label class="facet-item">
+										<input
+											type="checkbox"
+											checked={selectedMajorVersions.includes(facet.value)}
+											onchange={() => toggleMajorVersion(facet.value)}
+										/>
+										<span class="facet-label">{facet.value}</span>
+										<span class="facet-count">{facet.count}</span>
+									</label>
+								{/each}
+							</div>
+						</details>
+					{/if}
+					{#if highAvailabilityFacets.length > 0}
+						<details class="filter-section" open>
+							<summary class="section-heading">High availability</summary>
+							<div class="facet-list">
+								{#each highAvailabilityFacets as facet (String(facet.value))}
+									<label class="facet-item">
+										<input
+											type="checkbox"
+											checked={selectedHighAvailability === String(facet.value)}
+											onchange={() => toggleHighAvailability(String(facet.value))}
+										/>
+										<span class="facet-label"
+											>{capitalizeFirstLetter(facet.value ? 'high availability' : 'standard')}</span
+										>
+										<span class="facet-count">{facet.count}</span>
+									</label>
+								{/each}
+							</div>
+						</details>
+					{/if}
+				</WorkloadListFilters>
 			</SurfaceCard>
 		</div>
 	</div>

--- a/src/routes/team/[team]/postgres/+page.svelte
+++ b/src/routes/team/[team]/postgres/+page.svelte
@@ -79,13 +79,12 @@
 	const majorVersionFacets = $derived(
 		$PostgresInstances.data?.team.postgresInstances.facets?.majorVersions ?? []
 	);
-	const availableMajorVersions = $derived(new Set(majorVersionFacets.map((f) => f.value)));
 
 	function toggleMajorVersion(version: string) {
 		const isSelected = selectedMajorVersions.includes(version);
 		const next = isSelected
-			? selectedMajorVersions.filter((v) => v !== version && availableMajorVersions.has(v))
-			: [...selectedMajorVersions.filter((v) => availableMajorVersions.has(v)), version];
+			? selectedMajorVersions.filter((v) => v !== version)
+			: [...selectedMajorVersions, version];
 		changeParams({ majorVersions: next.join(','), after: '', before: '' }, { noScroll: true });
 	}
 

--- a/src/routes/team/[team]/postgres/+page.svelte
+++ b/src/routes/team/[team]/postgres/+page.svelte
@@ -79,6 +79,12 @@
 	const majorVersionFacets = $derived(
 		$PostgresInstances.data?.team.postgresInstances.facets?.majorVersions ?? []
 	);
+	const displayMajorVersionFacets = $derived([
+		...majorVersionFacets,
+		...selectedMajorVersions
+			.filter((v) => !majorVersionFacets.some((f) => f.value === v))
+			.map((v) => ({ value: v, count: 0 }))
+	]);
 
 	function toggleMajorVersion(version: string) {
 		const isSelected = selectedMajorVersions.includes(version);
@@ -194,11 +200,11 @@
 					onStatesChange={handleStatesChange}
 					onEnvironmentsChange={handleEnvironmentsChange}
 				>
-					{#if majorVersionFacets.length > 0}
+					{#if displayMajorVersionFacets.length > 0}
 						<details class="filter-section" open>
 							<summary class="section-heading">Major version</summary>
 							<div class="facet-list">
-								{#each majorVersionFacets as facet (facet.value)}
+								{#each displayMajorVersionFacets as facet (facet.value)}
 									<label class="facet-item">
 										<input
 											type="checkbox"
@@ -212,21 +218,23 @@
 							</div>
 						</details>
 					{/if}
-					{#if highAvailabilityFacets.length > 0}
+					{#if highAvailabilityFacets.length > 0 || selectedHighAvailability !== ''}
 						<details class="filter-section" open>
 							<summary class="section-heading">High availability</summary>
 							<div class="facet-list">
-								{#each highAvailabilityFacets as facet (String(facet.value))}
+								{#each [true, false] as haValue (String(haValue))}
+									{@const count =
+										highAvailabilityFacets.find((f) => f.value === haValue)?.count ?? 0}
 									<label class="facet-item">
 										<input
 											type="checkbox"
-											checked={selectedHighAvailability === String(facet.value)}
-											onchange={() => toggleHighAvailability(String(facet.value))}
+											checked={selectedHighAvailability === String(haValue)}
+											onchange={() => toggleHighAvailability(String(haValue))}
 										/>
 										<span class="facet-label"
-											>{capitalizeFirstLetter(facet.value ? 'high availability' : 'standard')}</span
+											>{capitalizeFirstLetter(haValue ? 'high availability' : 'standard')}</span
 										>
-										<span class="facet-count">{facet.count}</span>
+										<span class="facet-count">{count}</span>
 									</label>
 								{/each}
 							</div>

--- a/src/routes/team/[team]/postgres/+page.ts
+++ b/src/routes/team/[team]/postgres/+page.ts
@@ -13,16 +13,19 @@ const rows = 25;
 export async function load(event) {
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
-	const environments: string[] | undefined =
-		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
+	const envParam = event.url.searchParams.get('environments')?.split(',').filter(Boolean);
+	const environments = envParam?.length ? envParam : undefined;
 	const validStates = new Set<string>(Object.values(PostgresInstanceState));
-	const states =
-		event.url.searchParams
-			.get('states')
-			?.split(',')
-			.filter((s) => validStates.has(s)) || undefined;
-	const majorVersions: string[] | undefined =
-		event.url.searchParams.get('majorVersions')?.split(',').filter(Boolean) || undefined;
+	const statesParam = event.url.searchParams
+		.get('states')
+		?.split(',')
+		.filter((s) => validStates.has(s));
+	const states = statesParam?.length ? statesParam : undefined;
+	const majorVersionsParam = event.url.searchParams
+		.get('majorVersions')
+		?.split(',')
+		.filter(Boolean);
+	const majorVersions = majorVersionsParam?.length ? majorVersionsParam : undefined;
 	const highAvailabilityParam = event.url.searchParams.get('highAvailability');
 	const highAvailability =
 		highAvailabilityParam === 'true' ? true : highAvailabilityParam === 'false' ? false : undefined;

--- a/src/routes/team/[team]/postgres/+page.ts
+++ b/src/routes/team/[team]/postgres/+page.ts
@@ -2,6 +2,7 @@ import {
 	load_PostgresInstances,
 	OrderDirection,
 	PostgresInstanceOrderField,
+	PostgresInstanceState,
 	type PostgresInstanceFilter
 } from '$houdini';
 import { urlToOrderDirection, urlToOrderField } from '$lib/ui/OrderByMenu.svelte';
@@ -14,8 +15,12 @@ export async function load(event) {
 	const before = event.url.searchParams.get('before') || '';
 	const environments: string[] | undefined =
 		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
-	const states: string[] | undefined =
-		event.url.searchParams.get('states')?.split(',').filter(Boolean) || undefined;
+	const validStates = new Set<string>(Object.values(PostgresInstanceState));
+	const states =
+		event.url.searchParams
+			.get('states')
+			?.split(',')
+			.filter((s) => validStates.has(s)) || undefined;
 	const majorVersions: string[] | undefined =
 		event.url.searchParams.get('majorVersions')?.split(',').filter(Boolean) || undefined;
 	const highAvailabilityParam = event.url.searchParams.get('highAvailability');

--- a/src/routes/team/[team]/postgres/+page.ts
+++ b/src/routes/team/[team]/postgres/+page.ts
@@ -1,4 +1,9 @@
-import { load_PostgresInstances, OrderDirection, PostgresInstanceOrderField } from '$houdini';
+import {
+	load_PostgresInstances,
+	OrderDirection,
+	PostgresInstanceOrderField,
+	type PostgresInstanceFilter
+} from '$houdini';
 import { urlToOrderDirection, urlToOrderField } from '$lib/ui/OrderByMenu.svelte';
 import { addPageMeta } from '$lib/utils/pageMeta';
 
@@ -7,6 +12,15 @@ const rows = 25;
 export async function load(event) {
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
+	const environments: string[] | undefined =
+		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
+	const states: string[] | undefined =
+		event.url.searchParams.get('states')?.split(',').filter(Boolean) || undefined;
+	const majorVersions: string[] | undefined =
+		event.url.searchParams.get('majorVersions')?.split(',').filter(Boolean) || undefined;
+	const highAvailabilityParam = event.url.searchParams.get('highAvailability');
+	const highAvailability =
+		highAvailabilityParam === 'true' ? true : highAvailabilityParam === 'false' ? false : undefined;
 
 	return {
 		...(await addPageMeta(event, {
@@ -18,6 +32,7 @@ export async function load(event) {
 			event,
 			variables: {
 				team: event.params.team,
+				filter: { environments, states, majorVersions, highAvailability } as PostgresInstanceFilter,
 				orderBy: {
 					field: urlToOrderField(
 						PostgresInstanceOrderField,

--- a/src/routes/team/[team]/postgres/query.gql
+++ b/src/routes/team/[team]/postgres/query.gql
@@ -1,11 +1,12 @@
 query PostgresInstances(
 	$team: Slug!
 	$orderBy: PostgresInstanceOrder
+	$filter: PostgresInstanceFilter
 	$first: Int
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) {
+) @cache(policy: CacheAndNetwork, partial: true) {
 	team(slug: $team) {
 		slug
 		inventoryCounts {
@@ -18,6 +19,7 @@ query PostgresInstances(
 			first: $first
 			last: $last
 			orderBy: $orderBy
+			filter: $filter
 			before: $before
 			after: $after
 		) @paginate(mode: SinglePage) {
@@ -29,6 +31,24 @@ query PostgresInstances(
 				totalCount
 				startCursor
 				endCursor
+			}
+			facets {
+				environments {
+					value
+					count
+				}
+				states {
+					state
+					count
+				}
+				majorVersions {
+					value
+					count
+				}
+				highAvailability {
+					value
+					count
+				}
 			}
 			nodes {
 				id

--- a/src/routes/team/[team]/secrets/+page.svelte
+++ b/src/routes/team/[team]/secrets/+page.svelte
@@ -43,7 +43,6 @@
 
 	const inUseFacets = $derived($Secrets.data?.team.secrets.facets?.inUse ?? []);
 	const environmentFacets = $derived($Secrets.data?.team.secrets.facets?.environments ?? []);
-	const availableEnvironments = $derived(new Set(environmentFacets.map((f) => f.value)));
 
 	function toggleInUse(value: string) {
 		const next = inUseFilter === value ? '' : value;
@@ -53,8 +52,8 @@
 	function toggleEnvironment(env: string) {
 		const isSelected = selectedEnvironments.includes(env);
 		const next = isSelected
-			? selectedEnvironments.filter((e) => e !== env && availableEnvironments.has(e))
-			: [...selectedEnvironments.filter((e) => availableEnvironments.has(e)), env];
+			? selectedEnvironments.filter((e) => e !== env)
+			: [...selectedEnvironments, env];
 		changeParams({ environments: next.join(','), after: '', before: '' }, { noScroll: true });
 	}
 

--- a/src/routes/team/[team]/secrets/+page.svelte
+++ b/src/routes/team/[team]/secrets/+page.svelte
@@ -43,6 +43,12 @@
 
 	const inUseFacets = $derived($Secrets.data?.team.secrets.facets?.inUse ?? []);
 	const environmentFacets = $derived($Secrets.data?.team.secrets.facets?.environments ?? []);
+	const displayEnvironmentFacets = $derived([
+		...environmentFacets,
+		...selectedEnvironments
+			.filter((e) => !environmentFacets.some((f) => f.value === e))
+			.map((e) => ({ value: e, count: 0 }))
+	]);
 
 	function toggleInUse(value: string) {
 		const next = inUseFilter === value ? '' : value;
@@ -222,11 +228,11 @@
 					}}
 					onSort={(field) => setSort(field as SecretOrderFieldOptions)}
 				>
-					{#if environmentFacets.length > 0}
+					{#if displayEnvironmentFacets.length > 0}
 						<details class="filter-section" open>
 							<summary class="section-heading">Environments</summary>
 							<div class="facet-list">
-								{#each environmentFacets as facet (facet.value)}
+								{#each displayEnvironmentFacets as facet (facet.value)}
 									<label class="facet-item">
 										<input
 											type="checkbox"
@@ -240,19 +246,20 @@
 							</div>
 						</details>
 					{/if}
-					{#if inUseFacets.length > 0}
+					{#if inUseFacets.length > 0 || inUseFilter !== null}
 						<details class="filter-section" open>
 							<summary class="section-heading">Usage</summary>
 							<div class="facet-list">
-								{#each inUseFacets as facet (String(facet.value))}
+								{#each ['true', 'false'] as value (value)}
+									{@const count = inUseFacets.find((f) => String(f.value) === value)?.count ?? 0}
 									<label class="facet-item">
 										<input
 											type="checkbox"
-											checked={inUseFilter === String(facet.value)}
-											onchange={() => toggleInUse(String(facet.value))}
+											checked={inUseFilter === value}
+											onchange={() => toggleInUse(value)}
 										/>
-										<span class="facet-label">{facet.value ? 'In use' : 'Not in use'}</span>
-										<span class="facet-count">{facet.count}</span>
+										<span class="facet-label">{value === 'true' ? 'In use' : 'Not in use'}</span>
+										<span class="facet-count">{count}</span>
 									</label>
 								{/each}
 							</div>

--- a/src/routes/team/[team]/secrets/+page.svelte
+++ b/src/routes/team/[team]/secrets/+page.svelte
@@ -36,22 +36,27 @@
 	let after: string = $derived($Secrets.variables?.after ?? '');
 	let before: string = $derived($Secrets.variables?.before ?? '');
 
-	const allUsages = ['inUse', 'notInUse'];
-	let activeUsages: string[] = $derived.by(() => {
-		const param = page.url.searchParams.get('filter');
-		if (param === 'inUse') return ['inUse'];
-		if (param === 'notInUse') return ['notInUse'];
-		return allUsages;
-	});
+	const inUseFilter = $derived(page.url.searchParams.get('inUse'));
+	const selectedEnvironments: string[] = $derived(
+		page.url.searchParams.get('environments')?.split(',').filter(Boolean) ?? []
+	);
 
-	const toggleUsage = (key: string) => {
-		const next = activeUsages.includes(key)
-			? activeUsages.filter((s) => s !== key)
-			: [...activeUsages, key];
-		if (next.length === 0) return;
-		const filter = next.length === allUsages.length ? '' : next[0];
-		changeParams({ filter, after: '', before: '' });
-	};
+	const inUseFacets = $derived($Secrets.data?.team.secrets.facets?.inUse ?? []);
+	const environmentFacets = $derived($Secrets.data?.team.secrets.facets?.environments ?? []);
+	const availableEnvironments = $derived(new Set(environmentFacets.map((f) => f.value)));
+
+	function toggleInUse(value: string) {
+		const next = inUseFilter === value ? '' : value;
+		changeParams({ inUse: next, after: '', before: '' }, { noScroll: true });
+	}
+
+	function toggleEnvironment(env: string) {
+		const isSelected = selectedEnvironments.includes(env);
+		const next = isSelected
+			? selectedEnvironments.filter((e) => e !== env && availableEnvironments.has(e))
+			: [...selectedEnvironments.filter((e) => availableEnvironments.has(e)), env];
+		changeParams({ environments: next.join(','), after: '', before: '' }, { noScroll: true });
+	}
 
 	const changeQuery = (
 		params: {
@@ -63,7 +68,8 @@
 		changeParams({
 			before: params.before ?? before,
 			after: params.after ?? after,
-			nameFilter: params.newFilter ?? filter
+			nameFilter: params.newFilter ?? filter,
+			environments: selectedEnvironments.join(',')
 		});
 	};
 
@@ -217,27 +223,42 @@
 					}}
 					onSort={(field) => setSort(field as SecretOrderFieldOptions)}
 				>
-					<details class="usage-section" open>
-						<summary class="usage-heading">Usage</summary>
-						<div class="facet-list">
-							<label class="facet-item">
-								<input
-									type="checkbox"
-									checked={activeUsages.includes('inUse')}
-									onchange={() => toggleUsage('inUse')}
-								/>
-								<span class="facet-label">In use</span>
-							</label>
-							<label class="facet-item">
-								<input
-									type="checkbox"
-									checked={activeUsages.includes('notInUse')}
-									onchange={() => toggleUsage('notInUse')}
-								/>
-								<span class="facet-label">Not in use</span>
-							</label>
-						</div>
-					</details>
+					{#if environmentFacets.length > 0}
+						<details class="filter-section" open>
+							<summary class="section-heading">Environments</summary>
+							<div class="facet-list">
+								{#each environmentFacets as facet (facet.value)}
+									<label class="facet-item">
+										<input
+											type="checkbox"
+											checked={selectedEnvironments.includes(facet.value)}
+											onchange={() => toggleEnvironment(facet.value)}
+										/>
+										<span class="facet-label">{facet.value}</span>
+										<span class="facet-count">{facet.count}</span>
+									</label>
+								{/each}
+							</div>
+						</details>
+					{/if}
+					{#if inUseFacets.length > 0}
+						<details class="filter-section" open>
+							<summary class="section-heading">Usage</summary>
+							<div class="facet-list">
+								{#each inUseFacets as facet (String(facet.value))}
+									<label class="facet-item">
+										<input
+											type="checkbox"
+											checked={inUseFilter === String(facet.value)}
+											onchange={() => toggleInUse(String(facet.value))}
+										/>
+										<span class="facet-label">{facet.value ? 'In use' : 'Not in use'}</span>
+										<span class="facet-count">{facet.count}</span>
+									</label>
+								{/each}
+							</div>
+						</details>
+					{/if}
 				</ListFilters>
 			</SurfaceCard>
 			<TeamActivityCard
@@ -267,72 +288,6 @@
 		flex-direction: column;
 		align-items: end;
 		gap: var(--ax-space-2);
-	}
-
-	.usage-section {
-		display: flex;
-		flex-direction: column;
-		gap: var(--ax-space-8);
-	}
-
-	.usage-heading {
-		font-size: var(--ax-font-size-small);
-		font-weight: 500;
-		color: var(--ax-text-neutral-subtle);
-		letter-spacing: 0.01em;
-		border-bottom: 1px solid var(--ax-border-neutral-subtleA);
-		padding-bottom: var(--ax-space-6);
-		cursor: pointer;
-		list-style: none;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-	}
-
-	.usage-heading::-webkit-details-marker {
-		display: none;
-	}
-
-	.usage-heading::after {
-		content: '';
-		width: 0.4em;
-		height: 0.4em;
-		border-right: 2px solid currentColor;
-		border-bottom: 2px solid currentColor;
-		transform: rotate(45deg);
-		transition: transform 150ms ease;
-		flex-shrink: 0;
-	}
-
-	.usage-section[open] > .usage-heading::after {
-		transform: rotate(-135deg);
-	}
-
-	.facet-list {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.facet-item {
-		display: flex;
-		align-items: center;
-		gap: var(--ax-space-8);
-		padding: var(--ax-space-6) 0;
-		font-size: var(--ax-font-size-medium);
-		cursor: pointer;
-	}
-
-	.facet-item:hover {
-		color: var(--ax-text-neutral);
-	}
-
-	.facet-item input[type='checkbox'] {
-		width: 1rem;
-		height: 1rem;
-		margin: 0;
-		flex-shrink: 0;
-		cursor: pointer;
-		accent-color: var(--ax-text-accent);
 	}
 
 	@media (max-width: 767px), (max-height: 500px) {

--- a/src/routes/team/[team]/secrets/+page.ts
+++ b/src/routes/team/[team]/secrets/+page.ts
@@ -4,13 +4,19 @@ import { addPageMeta } from '$lib/utils/pageMeta';
 
 const rows = 25;
 export async function load(event) {
-	const filter = event.url.searchParams.get('filter') || '';
 	const nameFilter = event.url.searchParams.get('nameFilter') || '';
+	const inUse = event.url.searchParams.get('inUse');
+	const environments: string[] | undefined =
+		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
 
 	let filterVar: SecretFilter | undefined = undefined;
 
-	if (filter === 'inUse' || filter === 'notInUse') {
-		filterVar = { inUse: filter === 'inUse' ? true : false };
+	if (inUse === 'true' || inUse === 'false') {
+		filterVar = { inUse: inUse === 'true' };
+	}
+
+	if (environments?.length) {
+		filterVar = { ...filterVar, environments };
 	}
 
 	if (nameFilter) {

--- a/src/routes/team/[team]/secrets/query.gql
+++ b/src/routes/team/[team]/secrets/query.gql
@@ -31,6 +31,16 @@ query Secrets(
 				startCursor
 				endCursor
 			}
+			facets {
+				environments {
+					value
+					count
+				}
+				inUse {
+					value
+					count
+				}
+			}
 			nodes {
 				id
 				name

--- a/src/routes/team/[team]/valkey/+page.svelte
+++ b/src/routes/team/[team]/valkey/+page.svelte
@@ -3,17 +3,18 @@
 	import { OrderDirection, ValkeyOrderField } from '$houdini';
 	import { docURL } from '$lib/doc';
 	import IssueSeverityTags from '$lib/domain/issues/IssueSeverityTags.svelte';
+	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
-	import ListFilters from '$lib/ui/ListFilters.svelte';
 	import ListItem from '$lib/ui/ListItem.svelte';
 	import PageModal, { pageModalClick } from '$lib/ui/PageModal.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import RunningIndicator from '$lib/ui/RunningIndicator.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import TooltipAlignHack from '$lib/ui/TooltipAlignHack.svelte';
+	import { capitalizeFirstLetter } from '$lib/utils/formatters';
 	import { countIssuesBySeverity } from '$lib/utils/issueCounts';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Button, Tag } from '@nais/ds-svelte-community';
@@ -67,6 +68,28 @@
 		header: 'Create Valkey',
 		viewerIsMember: viewerIsMember
 	});
+
+	const selectedEnvironments: string[] = $derived(
+		page.url.searchParams.get('environments')?.split(',').filter(Boolean) ?? []
+	);
+	const selectedTiers: string[] = $derived(
+		page.url.searchParams.get('tiers')?.split(',').filter(Boolean) ?? []
+	);
+
+	function handleEnvironmentsChange(selected: string[]) {
+		changeParams({ environments: selected.join(','), after: '', before: '' }, { noScroll: true });
+	}
+
+	const tierFacets = $derived($Valkeys.data?.team.valkeys.facets?.tiers ?? []);
+	const availableTiers = $derived(new Set<string>(tierFacets.map((f) => f.tier)));
+
+	function toggleTier(tier: string) {
+		const isSelected = selectedTiers.includes(tier);
+		const next = isSelected
+			? selectedTiers.filter((t) => t !== tier && availableTiers.has(t))
+			: [...selectedTiers.filter((t) => availableTiers.has(t)), tier];
+		changeParams({ tiers: next.join(','), after: '', before: '' }, { noScroll: true });
+	}
 </script>
 
 <GraphErrors errors={$Valkeys.errors} />
@@ -180,12 +203,36 @@
 		</div>
 		<div class="layout-sidebar">
 			<SurfaceCard title="Filters">
-				<ListFilters
+				<WorkloadListFilters
 					{sortFields}
 					{currentSortField}
 					{currentSortDirection}
+					environments={$Valkeys.data?.team.valkeys.facets?.environments ?? []}
+					{selectedEnvironments}
 					onSort={(field) => setSort(field as ValkeyOrderFieldOptions)}
-				/>
+					onEnvironmentsChange={handleEnvironmentsChange}
+				>
+					{#if tierFacets.length > 0}
+						<details class="filter-section" open>
+							<summary class="section-heading">Tier</summary>
+							<div class="facet-list">
+								{#each tierFacets as facet (facet.tier)}
+									<label class="facet-item">
+										<input
+											type="checkbox"
+											checked={selectedTiers.includes(facet.tier)}
+											onchange={() => toggleTier(facet.tier)}
+										/>
+										<span class="facet-label"
+											>{capitalizeFirstLetter(facet.tier.split('_').join(' ').toLowerCase())}</span
+										>
+										<span class="facet-count">{facet.count}</span>
+									</label>
+								{/each}
+							</div>
+						</details>
+					{/if}
+				</WorkloadListFilters>
 			</SurfaceCard>
 		</div>
 	</div>

--- a/src/routes/team/[team]/valkey/+page.svelte
+++ b/src/routes/team/[team]/valkey/+page.svelte
@@ -81,6 +81,12 @@
 	}
 
 	const tierFacets = $derived($Valkeys.data?.team.valkeys.facets?.tiers ?? []);
+	const displayTierFacets = $derived([
+		...tierFacets,
+		...selectedTiers
+			.filter((t) => !tierFacets.some((f) => f.tier === t))
+			.map((t) => ({ tier: t, count: 0 }))
+	]);
 
 	function toggleTier(tier: string) {
 		const isSelected = selectedTiers.includes(tier);
@@ -209,11 +215,11 @@
 					onSort={(field) => setSort(field as ValkeyOrderFieldOptions)}
 					onEnvironmentsChange={handleEnvironmentsChange}
 				>
-					{#if tierFacets.length > 0}
+					{#if displayTierFacets.length > 0}
 						<details class="filter-section" open>
 							<summary class="section-heading">Tier</summary>
 							<div class="facet-list">
-								{#each tierFacets as facet (facet.tier)}
+								{#each displayTierFacets as facet (facet.tier)}
 									<label class="facet-item">
 										<input
 											type="checkbox"

--- a/src/routes/team/[team]/valkey/+page.svelte
+++ b/src/routes/team/[team]/valkey/+page.svelte
@@ -81,13 +81,10 @@
 	}
 
 	const tierFacets = $derived($Valkeys.data?.team.valkeys.facets?.tiers ?? []);
-	const availableTiers = $derived(new Set<string>(tierFacets.map((f) => f.tier)));
 
 	function toggleTier(tier: string) {
 		const isSelected = selectedTiers.includes(tier);
-		const next = isSelected
-			? selectedTiers.filter((t) => t !== tier && availableTiers.has(t))
-			: [...selectedTiers.filter((t) => availableTiers.has(t)), tier];
+		const next = isSelected ? selectedTiers.filter((t) => t !== tier) : [...selectedTiers, tier];
 		changeParams({ tiers: next.join(','), after: '', before: '' }, { noScroll: true });
 	}
 </script>

--- a/src/routes/team/[team]/valkey/+page.ts
+++ b/src/routes/team/[team]/valkey/+page.ts
@@ -1,4 +1,10 @@
-import { load_Valkeys, OrderDirection, ValkeyOrderField, type ValkeyFilter } from '$houdini';
+import {
+	load_Valkeys,
+	OrderDirection,
+	ValkeyOrderField,
+	ValkeyTier,
+	type ValkeyFilter
+} from '$houdini';
 import { urlToOrderDirection, urlToOrderField } from '$lib/ui/OrderByMenu.svelte';
 import { addPageMeta } from '$lib/utils/pageMeta';
 import { error } from '@sveltejs/kit';
@@ -27,8 +33,12 @@ export async function load(event) {
 	const before = event.url.searchParams.get('before') || '';
 	const environments: string[] | undefined =
 		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
-	const tiers: string[] | undefined =
-		event.url.searchParams.get('tiers')?.split(',').filter(Boolean) || undefined;
+	const validValkeyTiers = new Set<string>(Object.values(ValkeyTier));
+	const tiers =
+		event.url.searchParams
+			.get('tiers')
+			?.split(',')
+			.filter((t) => validValkeyTiers.has(t)) || undefined;
 
 	return {
 		...(await addPageMeta(event, {

--- a/src/routes/team/[team]/valkey/+page.ts
+++ b/src/routes/team/[team]/valkey/+page.ts
@@ -31,14 +31,14 @@ export async function load(event) {
 
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
-	const environments: string[] | undefined =
-		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
+	const envParam = event.url.searchParams.get('environments')?.split(',').filter(Boolean);
+	const environments = envParam?.length ? envParam : undefined;
 	const validValkeyTiers = new Set<string>(Object.values(ValkeyTier));
-	const tiers =
-		event.url.searchParams
-			.get('tiers')
-			?.split(',')
-			.filter((t) => validValkeyTiers.has(t)) || undefined;
+	const tiersParam = event.url.searchParams
+		.get('tiers')
+		?.split(',')
+		.filter((t) => validValkeyTiers.has(t));
+	const tiers = tiersParam?.length ? tiersParam : undefined;
 
 	return {
 		...(await addPageMeta(event, {

--- a/src/routes/team/[team]/valkey/+page.ts
+++ b/src/routes/team/[team]/valkey/+page.ts
@@ -1,4 +1,4 @@
-import { load_Valkeys, OrderDirection, ValkeyOrderField } from '$houdini';
+import { load_Valkeys, OrderDirection, ValkeyOrderField, type ValkeyFilter } from '$houdini';
 import { urlToOrderDirection, urlToOrderField } from '$lib/ui/OrderByMenu.svelte';
 import { addPageMeta } from '$lib/utils/pageMeta';
 import { error } from '@sveltejs/kit';
@@ -25,6 +25,10 @@ export async function load(event) {
 
 	const after = event.url.searchParams.get('after') || '';
 	const before = event.url.searchParams.get('before') || '';
+	const environments: string[] | undefined =
+		event.url.searchParams.get('environments')?.split(',').filter(Boolean) || undefined;
+	const tiers: string[] | undefined =
+		event.url.searchParams.get('tiers')?.split(',').filter(Boolean) || undefined;
 
 	return {
 		...(await addPageMeta(event, {
@@ -36,6 +40,7 @@ export async function load(event) {
 			event,
 			variables: {
 				team: event.params.team,
+				filter: { environments, tiers } as ValkeyFilter,
 				orderBy: {
 					field: urlToOrderField(ValkeyOrderField, ValkeyOrderField.ISSUES, event.url),
 					direction: urlToOrderDirection(event.url, OrderDirection.DESC)

--- a/src/routes/team/[team]/valkey/query.gql
+++ b/src/routes/team/[team]/valkey/query.gql
@@ -1,6 +1,7 @@
 query Valkeys(
 	$team: Slug!
 	$orderBy: ValkeyOrder
+	$filter: ValkeyFilter
 	$first: Int
 	$last: Int
 	$before: Cursor
@@ -9,8 +10,14 @@ query Valkeys(
 	team(slug: $team) {
 		slug
 
-		valkeys(first: $first, last: $last, orderBy: $orderBy, before: $before, after: $after)
-			@paginate(mode: SinglePage) {
+		valkeys(
+			first: $first
+			last: $last
+			orderBy: $orderBy
+			filter: $filter
+			before: $before
+			after: $after
+		) @paginate(mode: SinglePage) {
 			pageInfo {
 				hasNextPage
 				hasPreviousPage
@@ -19,6 +26,16 @@ query Valkeys(
 				pageEnd
 				startCursor
 				endCursor
+			}
+			facets {
+				environments {
+					value
+					count
+				}
+				tiers {
+					tier
+					count
+				}
 			}
 			nodes {
 				id

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -153,6 +153,87 @@ html {
 	align-items: start;
 }
 
+.filter-section {
+	display: flex;
+	flex-direction: column;
+	gap: var(--ax-space-8);
+}
+
+.section-heading {
+	font-size: var(--ax-font-size-small);
+	font-weight: 500;
+	color: var(--ax-text-neutral-subtle);
+	margin: 0;
+	letter-spacing: 0.01em;
+	border-bottom: 1px solid var(--ax-border-neutral-subtleA);
+	padding-bottom: var(--ax-space-6);
+	cursor: pointer;
+	list-style: none;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.section-heading::-webkit-details-marker {
+	display: none;
+}
+
+.section-heading::after {
+	content: '';
+	width: 0.4em;
+	height: 0.4em;
+	border-right: 2px solid currentColor;
+	border-bottom: 2px solid currentColor;
+	transform: rotate(45deg);
+	transition: transform 150ms ease;
+	flex-shrink: 0;
+}
+
+.filter-section[open] > .section-heading::after {
+	transform: rotate(-135deg);
+}
+
+.facet-list {
+	display: flex;
+	flex-direction: column;
+}
+
+.facet-item {
+	display: flex;
+	align-items: center;
+	gap: var(--ax-space-8);
+	padding: var(--ax-space-6) 0;
+	font-size: var(--ax-font-size-small);
+	cursor: pointer;
+}
+
+.facet-item:hover {
+	color: var(--ax-text-neutral);
+}
+
+.facet-item input[type='checkbox'] {
+	width: 1rem;
+	height: 1rem;
+	margin: 0;
+	flex-shrink: 0;
+	cursor: pointer;
+	accent-color: var(--ax-text-accent);
+}
+
+.facet-label {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+}
+
+.facet-count {
+	flex-shrink: 0;
+	font-size: 0.6875rem;
+	color: var(--ax-text-neutral-subtle);
+}
+
 .layout-sidebar {
 	display: grid;
 	gap: var(--spacing-sidebar);


### PR DESCRIPTION
Adds environment and resource-specific facet filters to all 8 resource list pages, using the new facet API from nais/api#475.

## Changes

### Infrastructure
- Updated `schema.graphql` with new facet types
- Updated GitHub Actions workflows

### UI — `WorkloadListFilters.svelte`
- All props except sort-related are now optional
- Added `children` snippet slot for page-specific filter sections

### Global CSS (`app.css`)
- Added utility classes: `.filter-section`, `.section-heading`, `.facet-list`, `.facet-item`, `.facet-label`, `.facet-count`

### Per-page changes

| Page | Filters |
|------|---------|
| BigQuery | Environments |
| Buckets | Environments |
| Kafka | Environments, Pools |
| OpenSearch | Environments, Tier |
| Valkey | Environments, Tier |
| Postgres | Environments, States, Major version, High availability |
| Configs | Environments, Usage — migrated from `?filter=inUse/notInUse` to `?inUse=true/false` |
| Secrets | Environments, Usage — migrated from `?filter=inUse/notInUse` to `?inUse=true/false` |

## Known issue

When a facet filter is selected, the API returns facets computed from the already-filtered result set, causing other options to disappear. This is a backend issue in nais/api — facets should be computed independently of the active filter dimension. No frontend workaround applied.