### PR TITLE
Remove labels.nais.io prefix handling from labels flow

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -6404,8 +6404,6 @@ A user-defined label attached to a resource.
 Labels are key-value pairs that teams can use to organize and filter their
 resources. Both the key and the value may contain letters, numbers, hyphens,
 underscores and dots, and may be at most 63 characters long.
-
-Keys must be prefixed with labels.nais.io/.
 """
 type ResourceLabel {
   """The label key."""

--- a/src/lib/domain/labels/LabelFacets.svelte
+++ b/src/lib/domain/labels/LabelFacets.svelte
@@ -33,7 +33,7 @@
 	<summary class="section-heading">Labels</summary>
 	<div class="facet-list">
 		{#each labels as facet (labelId(facet))}
-			{@const display = `${facet.key.replace(/^labels\.nais\.io\//, '')}=${facet.value}`}
+			{@const display = `${facet.key}=${facet.value}`}
 			<label class="facet-item">
 				<input
 					type="checkbox"

--- a/src/lib/domain/labels/LabelFacets.svelte
+++ b/src/lib/domain/labels/LabelFacets.svelte
@@ -30,7 +30,7 @@
 </script>
 
 <details class="filter-section" open>
-	<summary class="section-heading">Labels (labels.nais.io)</summary>
+	<summary class="section-heading">Labels</summary>
 	<div class="facet-list">
 		{#each labels as facet (labelId(facet))}
 			{@const display = `${facet.key.replace(/^labels\.nais\.io\//, '')}=${facet.value}`}

--- a/src/lib/domain/labels/LabelRows.svelte
+++ b/src/lib/domain/labels/LabelRows.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
 	import { Button, TextField } from '@nais/ds-svelte-community';
 	import { PlusIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
-	import {
-		LABEL_PREFIX,
-		duplicateLabelKeys,
-		rowKeyError,
-		rowValueError,
-		type LabelRow
-	} from './labels';
+	import { duplicateLabelKeys, rowKeyError, rowValueError, type LabelRow } from './labels';
 
 	let { rows = $bindable() }: { rows: LabelRow[] } = $props();
 
 	let duplicates = $derived(duplicateLabelKeys(rows));
 
-	const keyInputStyle = `font-family: monospace; font-size: var(--ax-font-size-small); padding-left: calc(${LABEL_PREFIX.length}ch + var(--ax-space-12));`;
+	const keyInputStyle = `font-family: monospace; font-size: var(--ax-font-size-small); padding-left: var(--ax-space-12);`;
 
 	function addRow() {
 		rows.push({ key: '', value: '' });
@@ -31,7 +25,6 @@
 	{#each rows as row, i (i)}
 		<div class="label-row">
 			<div class="key-field">
-				<span class="prefix" aria-hidden="true">{LABEL_PREFIX}</span>
 				<TextField
 					size="small"
 					label="Label key"
@@ -95,19 +88,6 @@
 
 	.key-field {
 		position: relative;
-	}
-
-	.prefix {
-		position: absolute;
-		top: 0;
-		left: var(--ax-space-8);
-		height: 2rem;
-		display: flex;
-		align-items: center;
-		font-family: monospace;
-		font-size: var(--ax-font-size-small);
-		color: var(--ax-text-neutral-subtle);
-		pointer-events: none;
 	}
 
 	@media (max-width: 600px) {

--- a/src/lib/domain/labels/LabelsEditorModal.svelte
+++ b/src/lib/domain/labels/LabelsEditorModal.svelte
@@ -48,10 +48,7 @@
 		<Heading as="h2" size="large">{title}</Heading>
 	{/snippet}
 
-	<BodyShort size="small" spacing>
-		Labels are key-value pairs used to organize resources. The <code>labels.nais.io/</code> prefix is
-		added automatically.
-	</BodyShort>
+	<BodyShort size="small" spacing>Labels are key-value pairs used to organize resources.</BodyShort>
 
 	<LabelRows bind:rows />
 
@@ -64,10 +61,3 @@
 		<Button variant="secondary" size="small" type="button" onclick={onclose}>Cancel</Button>
 	{/snippet}
 </Modal>
-
-<style>
-	code {
-		font-family: monospace;
-		font-size: var(--ax-font-size-small);
-	}
-</style>

--- a/src/lib/domain/labels/labels.test.ts
+++ b/src/lib/domain/labels/labels.test.ts
@@ -1,5 +1,4 @@
 import {
-	LABEL_PREFIX,
 	duplicateLabelKeys,
 	labelKeyError,
 	labelRowsHaveErrors,
@@ -7,35 +6,9 @@ import {
 	rowKeyError,
 	rowValueError,
 	rowsFromArrays,
-	stripLabelPrefix,
 	toLabelInput,
-	toLabelRows,
-	withLabelPrefix
+	toLabelRows
 } from './labels';
-
-describe('stripLabelPrefix', () => {
-	test('removes the prefix when present', () => {
-		expect(stripLabelPrefix(`${LABEL_PREFIX}team`)).toBe('team');
-	});
-
-	test('leaves keys without the prefix untouched', () => {
-		expect(stripLabelPrefix('team')).toBe('team');
-	});
-});
-
-describe('withLabelPrefix', () => {
-	test('adds the prefix to a bare suffix', () => {
-		expect(withLabelPrefix('team')).toBe(`${LABEL_PREFIX}team`);
-	});
-
-	test('does not double-prefix an already prefixed key', () => {
-		expect(withLabelPrefix(`${LABEL_PREFIX}team`)).toBe(`${LABEL_PREFIX}team`);
-	});
-
-	test('trims surrounding whitespace', () => {
-		expect(withLabelPrefix('  team  ')).toBe(`${LABEL_PREFIX}team`);
-	});
-});
 
 describe('labelKeyError', () => {
 	test.each([
@@ -48,7 +21,7 @@ describe('labelKeyError', () => {
 		},
 		{
 			key: 'has/slash',
-			expected: 'Must consist of letters, numbers, hyphens, underscores, or dots'
+			expected: ''
 		},
 		{ key: 'valid', expected: '' },
 		{ key: 'valid.key_1-2', expected: '' },
@@ -171,8 +144,8 @@ describe('toLabelInput', () => {
 				{ key: 'env', value: '' }
 			])
 		).toEqual([
-			{ key: `${LABEL_PREFIX}team`, value: 'platform' },
-			{ key: `${LABEL_PREFIX}env`, value: '' }
+			{ key: `team`, value: 'platform' },
+			{ key: `env`, value: '' }
 		]);
 	});
 
@@ -185,8 +158,8 @@ describe('toLabelRows', () => {
 	test('strips the prefix from existing labels', () => {
 		expect(
 			toLabelRows([
-				{ key: `${LABEL_PREFIX}team`, value: 'platform' },
-				{ key: `${LABEL_PREFIX}env`, value: 'prod' }
+				{ key: `team`, value: 'platform' },
+				{ key: `env`, value: 'prod' }
 			])
 		).toEqual([
 			{ key: 'team', value: 'platform' },

--- a/src/lib/domain/labels/labels.test.ts
+++ b/src/lib/domain/labels/labels.test.ts
@@ -136,7 +136,7 @@ describe('rowsFromArrays', () => {
 });
 
 describe('toLabelInput', () => {
-	test('drops empty rows, trims, and reattaches the prefix', () => {
+	test('drops empty rows and trims', () => {
 		expect(
 			toLabelInput([
 				{ key: '  team  ', value: '  platform  ' },
@@ -155,7 +155,7 @@ describe('toLabelInput', () => {
 });
 
 describe('toLabelRows', () => {
-	test('strips the prefix from existing labels', () => {
+	test('maps existing labels to editor rows', () => {
 		expect(
 			toLabelRows([
 				{ key: `team`, value: 'platform' },

--- a/src/lib/domain/labels/labels.test.ts
+++ b/src/lib/domain/labels/labels.test.ts
@@ -17,7 +17,7 @@ describe('labelKeyError', () => {
 		{ key: 'a'.repeat(64), expected: 'Must be at most 63 characters' },
 		{
 			key: 'has space',
-			expected: 'Must consist of letters, numbers, hyphens, underscores, or dots'
+			expected: 'Must consist of letters, numbers, hyphens, underscores, slash or dots'
 		},
 		{
 			key: 'has/slash',
@@ -81,7 +81,7 @@ describe('rowKeyError', () => {
 
 	test('validates the key charset', () => {
 		expect(rowKeyError({ key: 'bad key', value: 'v' }, new Set())).toBe(
-			'Must consist of letters, numbers, hyphens, underscores, or dots'
+			'Must consist of letters, numbers, hyphens, underscores, slash or dots'
 		);
 	});
 });

--- a/src/lib/domain/labels/labels.test.ts
+++ b/src/lib/domain/labels/labels.test.ts
@@ -17,7 +17,7 @@ describe('labelKeyError', () => {
 		{ key: 'a'.repeat(64), expected: 'Must be at most 63 characters' },
 		{
 			key: 'has space',
-			expected: 'Must consist of letters, numbers, hyphens, underscores, slash or dots'
+			expected: 'Must consist of letters, numbers, hyphens, underscores, slashes or dots'
 		},
 		{
 			key: 'has/slash',
@@ -81,7 +81,7 @@ describe('rowKeyError', () => {
 
 	test('validates the key charset', () => {
 		expect(rowKeyError({ key: 'bad key', value: 'v' }, new Set())).toBe(
-			'Must consist of letters, numbers, hyphens, underscores, slash or dots'
+			'Must consist of letters, numbers, hyphens, underscores, slashes or dots'
 		);
 	});
 });

--- a/src/lib/domain/labels/labels.ts
+++ b/src/lib/domain/labels/labels.ts
@@ -1,7 +1,9 @@
 export const LABEL_MAX_LENGTH = 63;
 
-const CHARSET = /^[a-zA-Z0-9._/-]+$/;
-const CHARSET_MESSAGE = 'Must consist of letters, numbers, hyphens, underscores, or dots';
+const KEY_CHARSET = /^[a-zA-Z0-9._/-]+$/;
+const KEY_CHARSET_MESSAGE = 'Must consist of letters, numbers, hyphens, underscores, slash or dots';
+const VALUE_CHARSET = /^[a-zA-Z0-9._-]+$/;
+const VALUE_CHARSET_MESSAGE = 'Must consist of letters, numbers, hyphens, underscores, or dots';
 
 export interface Label {
 	key: string;
@@ -21,8 +23,8 @@ export function labelKeyError(suffix: string): string {
 	if (key.length > LABEL_MAX_LENGTH) {
 		return `Must be at most ${LABEL_MAX_LENGTH} characters`;
 	}
-	if (!CHARSET.test(key)) {
-		return CHARSET_MESSAGE;
+	if (!KEY_CHARSET.test(key)) {
+		return KEY_CHARSET_MESSAGE;
 	}
 	return '';
 }
@@ -35,8 +37,8 @@ export function labelValueError(value: string): string {
 	if (v.length > LABEL_MAX_LENGTH) {
 		return `Must be at most ${LABEL_MAX_LENGTH} characters`;
 	}
-	if (!CHARSET.test(v)) {
-		return CHARSET_MESSAGE;
+	if (!VALUE_CHARSET.test(v)) {
+		return VALUE_CHARSET_MESSAGE;
 	}
 	return '';
 }

--- a/src/lib/domain/labels/labels.ts
+++ b/src/lib/domain/labels/labels.ts
@@ -1,7 +1,6 @@
-export const LABEL_PREFIX = 'labels.nais.io/';
 export const LABEL_MAX_LENGTH = 63;
 
-const CHARSET = /^[a-zA-Z0-9._-]+$/;
+const CHARSET = /^[a-zA-Z0-9._/-]+$/;
 const CHARSET_MESSAGE = 'Must consist of letters, numbers, hyphens, underscores, or dots';
 
 export interface Label {
@@ -12,15 +11,6 @@ export interface Label {
 export interface LabelRow {
 	key: string;
 	value: string;
-}
-
-export function stripLabelPrefix(key: string): string {
-	return key.startsWith(LABEL_PREFIX) ? key.slice(LABEL_PREFIX.length) : key;
-}
-
-export function withLabelPrefix(suffix: string): string {
-	const trimmed = suffix.trim();
-	return trimmed.startsWith(LABEL_PREFIX) ? trimmed : LABEL_PREFIX + trimmed;
 }
 
 export function labelKeyError(suffix: string): string {
@@ -101,13 +91,12 @@ export function rowsFromArrays(keys: string[], values: string[]): LabelRow[] {
 export function toLabelInput(rows: readonly LabelRow[]): Label[] {
 	return rows
 		.map((row) => ({ key: row.key.trim(), value: row.value.trim() }))
-		.filter((row) => row.key.length > 0)
-		.map((row) => ({ key: withLabelPrefix(row.key), value: row.value }));
+		.filter((row) => row.key.length > 0);
 }
 
 export function toLabelRows(labels: readonly Label[]): LabelRow[] {
 	return labels.map((label) => ({
-		key: stripLabelPrefix(label.key),
+		key: label.key,
 		value: label.value
 	}));
 }

--- a/src/lib/domain/labels/labels.ts
+++ b/src/lib/domain/labels/labels.ts
@@ -1,7 +1,8 @@
 export const LABEL_MAX_LENGTH = 63;
 
 const KEY_CHARSET = /^[a-zA-Z0-9._/-]+$/;
-const KEY_CHARSET_MESSAGE = 'Must consist of letters, numbers, hyphens, underscores, slash or dots';
+const KEY_CHARSET_MESSAGE =
+	'Must consist of letters, numbers, hyphens, underscores, slashes or dots';
 const VALUE_CHARSET = /^[a-zA-Z0-9._-]+$/;
 const VALUE_CHARSET_MESSAGE = 'Must consist of letters, numbers, hyphens, underscores, or dots';
 

--- a/src/lib/domain/workload/WorkloadListFilters.svelte
+++ b/src/lib/domain/workload/WorkloadListFilters.svelte
@@ -171,7 +171,7 @@
 
 	{#if labels.length > 0}
 		<details class="filter-section" open>
-			<summary class="section-heading">Labels (labels.nais.io)</summary>
+			<summary class="section-heading">Labels</summary>
 			<div class="facet-list">
 				{#each labels as facet (labelId(facet))}
 					{@const display = `${facet.key}=${facet.value}`}

--- a/src/lib/domain/workload/WorkloadListFilters.svelte
+++ b/src/lib/domain/workload/WorkloadListFilters.svelte
@@ -2,6 +2,7 @@
 	import ListFilters from '$lib/ui/ListFilters.svelte';
 	import { capitalizeFirstLetter } from '$lib/utils/formatters';
 	import type { Snippet } from 'svelte';
+	import LabelFacets from '../labels/LabelFacets.svelte';
 
 	interface StateFacet {
 		state: string;
@@ -74,10 +75,6 @@
 		return capitalizeFirstLetter(state.split('_').join(' ').toLowerCase());
 	}
 
-	function labelId(label: LabelFacet): string {
-		return `${label.key}:${label.value}`;
-	}
-
 	const displayStates = $derived([
 		...states,
 		...selectedStates
@@ -90,8 +87,6 @@
 			.filter((e) => !environments.some((f) => f.value === e))
 			.map((e) => ({ value: e, count: 0 }))
 	]);
-
-	const availableLabels = $derived(new Set(labels.map((f) => labelId(f))));
 
 	function toggleState(state: string) {
 		const isSelected = selectedStates.includes(state);
@@ -107,15 +102,6 @@
 			? selectedEnvironments.filter((e) => e !== env)
 			: [...selectedEnvironments, env];
 		onEnvironmentsChange(next);
-	}
-
-	function toggleLabel(label: LabelFacet) {
-		const id = labelId(label);
-		const isSelected = selectedLabels.includes(id);
-		const next = isSelected
-			? selectedLabels.filter((l) => l !== id && availableLabels.has(l))
-			: [...selectedLabels.filter((l) => availableLabels.has(l)), id];
-		onLabelsChange(next);
 	}
 </script>
 
@@ -170,7 +156,8 @@
 	{/if}
 
 	{#if labels.length > 0}
-		<details class="filter-section" open>
+		<LabelFacets {labels} {onLabelsChange} {selectedLabels} />
+		<!-- <details class="filter-section" open>
 			<summary class="section-heading">Labels</summary>
 			<div class="facet-list">
 				{#each labels as facet (labelId(facet))}
@@ -181,14 +168,12 @@
 							checked={selectedLabels.includes(labelId(facet))}
 							onchange={() => toggleLabel(facet)}
 						/>
-						<span title={display} class="facet-label"
-							>{display.replace(/^labels\.nais\.io\//, '')}</span
-						>
+						<span title={display} class="facet-label">{display}</span>
 						<span class="facet-count">{facet.count}</span>
 					</label>
 				{/each}
 			</div>
-		</details>
+		</details> -->
 	{/if}
 
 	{@render children?.()}

--- a/src/lib/domain/workload/WorkloadListFilters.svelte
+++ b/src/lib/domain/workload/WorkloadListFilters.svelte
@@ -157,23 +157,6 @@
 
 	{#if labels.length > 0}
 		<LabelFacets {labels} {onLabelsChange} {selectedLabels} />
-		<!-- <details class="filter-section" open>
-			<summary class="section-heading">Labels</summary>
-			<div class="facet-list">
-				{#each labels as facet (labelId(facet))}
-					{@const display = `${facet.key}=${facet.value}`}
-					<label class="facet-item">
-						<input
-							type="checkbox"
-							checked={selectedLabels.includes(labelId(facet))}
-							onchange={() => toggleLabel(facet)}
-						/>
-						<span title={display} class="facet-label">{display}</span>
-						<span class="facet-count">{facet.count}</span>
-					</label>
-				{/each}
-			</div>
-		</details> -->
 	{/if}
 
 	{@render children?.()}


### PR DESCRIPTION
Accept slash in label keys and stop auto-adding or stripping a labels.nais.io prefix in label conversion helpers.

Update label UI copy and headings to remove prefix references, and drop the key-field prefix decoration in the editor rows.

Adjust tests to match raw key behavior and new key validation rules.

Requires https://github.com/nais/api/pull/463