### PR TITLE
fix: facet filter performance, ConfigFilter TS2353, and Houdini Time workaround

### DIFF
--- a/src/lib/ui/Time.svelte
+++ b/src/lib/ui/Time.svelte
@@ -83,8 +83,25 @@
 			}, 1000);
 		}
 	});
+
+	const datetime = $derived.by(() => {
+		// This is a hack to work around a bug in houdini prior to their new compiler.
+		try {
+			return time.toISOString();
+		} catch {
+			if (typeof time === 'string') {
+				try {
+					const date = new Date(time);
+					return date.toISOString();
+				} catch {
+					return undefined;
+				}
+			}
+			return undefined;
+		}
+	});
 </script>
 
-<time datetime={time.toISOString()} {title}>
+<time {datetime} {title}>
 	{text}
 </time>

--- a/src/lib/ui/Time.svelte
+++ b/src/lib/ui/Time.svelte
@@ -85,20 +85,9 @@
 	});
 
 	const datetime = $derived.by(() => {
-		// This is a hack to work around a bug in houdini prior to their new compiler.
-		try {
-			return time.toISOString();
-		} catch {
-			if (typeof time === 'string') {
-				try {
-					const date = new Date(time);
-					return date.toISOString();
-				} catch {
-					return undefined;
-				}
-			}
-			return undefined;
-		}
+		// Houdini (pre-new-compiler) may pass Date scalars as strings. Normalize to Date first.
+		const d = time instanceof Date ? time : new Date(time as string);
+		return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
 	});
 </script>
 

--- a/src/routes/team/[team]/activity-log/query.gql
+++ b/src/routes/team/[team]/activity-log/query.gql
@@ -5,7 +5,7 @@ query ActivityLog(
 	$before: Cursor
 	$after: Cursor
 	$filter: ActivityLogFilter
-) @cache(policy: CacheAndNetwork, partial: true) {
+) @cache(policy: NoCache) {
 	team(slug: $team) {
 		slug
 		activityLog(first: $first, last: $last, before: $before, after: $after, filter: $filter)

--- a/src/routes/team/[team]/applications/query.gql
+++ b/src/routes/team/[team]/applications/query.gql
@@ -6,7 +6,7 @@ query Applications(
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) @cache(policy: CacheAndNetwork, partial: true) {
+) @cache(policy: NoCache) {
 	team(slug: $team) {
 		applications(
 			first: $first

--- a/src/routes/team/[team]/bigquery/query.gql
+++ b/src/routes/team/[team]/bigquery/query.gql
@@ -6,7 +6,7 @@ query BigQuery(
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) @cache(policy: CacheAndNetwork, partial: true) {
+) @cache(policy: NoCache) {
 	team(slug: $team) {
 		slug
 

--- a/src/routes/team/[team]/buckets/query.gql
+++ b/src/routes/team/[team]/buckets/query.gql
@@ -6,7 +6,7 @@ query Buckets(
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) @cache(policy: CacheAndNetwork, partial: true) {
+) @cache(policy: NoCache) {
 	team(slug: $team) {
 		slug
 

--- a/src/routes/team/[team]/configs/+page.ts
+++ b/src/routes/team/[team]/configs/+page.ts
@@ -26,7 +26,7 @@ export async function load(event) {
 
 	const labels = parseLabelsParam(event.url.searchParams.get('labels'));
 	if (labels) {
-		filterVar = { ...filterVar, labels };
+		filterVar = { ...filterVar, labels } as ConfigFilter;
 	}
 
 	const after = event.url.searchParams.get('after') || '';

--- a/src/routes/team/[team]/configs/+page.ts
+++ b/src/routes/team/[team]/configs/+page.ts
@@ -26,7 +26,7 @@ export async function load(event) {
 
 	const labels = parseLabelsParam(event.url.searchParams.get('labels'));
 	if (labels) {
-		filterVar = { ...filterVar, labels } as ConfigFilter;
+		filterVar = { ...filterVar, labels: labels as ConfigFilter['labels'] };
 	}
 
 	const after = event.url.searchParams.get('after') || '';

--- a/src/routes/team/[team]/configs/query.gql
+++ b/src/routes/team/[team]/configs/query.gql
@@ -6,7 +6,7 @@ query Configs(
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) @cache(policy: CacheAndNetwork) {
+) @cache(policy: NoCache) {
 	me {
 		... on User {
 			isAdmin

--- a/src/routes/team/[team]/jobs/query.gql
+++ b/src/routes/team/[team]/jobs/query.gql
@@ -6,7 +6,7 @@ query Jobs(
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) @cache(policy: CacheAndNetwork, partial: true) {
+) @cache(policy: NoCache) {
 	team(slug: $team) {
 		slug
 		jobs(

--- a/src/routes/team/[team]/kafka/query.gql
+++ b/src/routes/team/[team]/kafka/query.gql
@@ -6,7 +6,7 @@ query KafkaTopics(
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) @cache(policy: CacheAndNetwork, partial: true) {
+) @cache(policy: NoCache) {
 	team(slug: $team) {
 		slug
 		kafkaTopics(

--- a/src/routes/team/[team]/opensearch/query.gql
+++ b/src/routes/team/[team]/opensearch/query.gql
@@ -6,7 +6,7 @@ query OpenSearch(
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) @cache(policy: CacheAndNetwork) {
+) @cache(policy: NoCache) {
 	team(slug: $team) {
 		slug
 

--- a/src/routes/team/[team]/postgres/query.gql
+++ b/src/routes/team/[team]/postgres/query.gql
@@ -6,7 +6,7 @@ query PostgresInstances(
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) @cache(policy: CacheAndNetwork, partial: true) {
+) @cache(policy: NoCache) {
 	team(slug: $team) {
 		slug
 		inventoryCounts {

--- a/src/routes/team/[team]/secrets/query.gql
+++ b/src/routes/team/[team]/secrets/query.gql
@@ -6,7 +6,7 @@ query Secrets(
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) @cache(policy: CacheAndNetwork) {
+) @cache(policy: NoCache) {
 	me {
 		... on User {
 			isAdmin

--- a/src/routes/team/[team]/valkey/query.gql
+++ b/src/routes/team/[team]/valkey/query.gql
@@ -6,7 +6,7 @@ query Valkeys(
 	$last: Int
 	$before: Cursor
 	$after: Cursor
-) @cache(policy: CacheAndNetwork) {
+) @cache(policy: NoCache) {
 	team(slug: $team) {
 		slug
 


### PR DESCRIPTION
## Problem

Toggling facet filters (Environments, Status, Sort By) on any workload list page caused responses to get progressively slower until Console became unresponsive.

**Root cause**: All list queries were using `@cache(policy: CacheAndNetwork, partial: true)`. Each filter toggle served stale cached results immediately while simultaneously firing a new network request. With rapid toggling, Houdini's cache accumulated entries for every filter combination, making cache lookups increasingly expensive until the UI locked up.

## Changes

### fix: switch all facet-driven list queries to `NoCache`

Affects: `applications`, `jobs`, `activity-log`, `bigquery`, `buckets`, `configs`, `kafka`, `opensearch`, `postgres`, `secrets`, `valkey`

Each filter change now always fetches fresh data from the network with no stale intermediate renders.

### fix: `Time.svelte` — Houdini pre-compiler bug workaround

Houdini (before the new compiler) may pass the `time` prop as a `string` instead of `Date`. Wraps `toISOString()` in a try/catch and falls back to constructing `new Date(time)` when the value is a string.

### fix: `configs/+page.ts` — TypeScript TS2353

Cast the merged filter object to `ConfigFilter` when adding `labels` to resolve the type error.
