### PR TITLE
fix: remove failing status display from instance group page

### DIFF
--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelte
@@ -66,12 +66,6 @@
 		return prefix && g.name.startsWith(prefix) ? g.name.slice(prefix.length) : g.name;
 	}
 
-	function groupHasFailing(g: InstanceGroup) {
-		return g.instances.some((i) => i.status.state === 'FAILING');
-	}
-
-	const hasFailing = $derived(group ? groupHasFailing(group) : false);
-
 	const baseUrl = $derived(
 		application
 			? `/team/${application.team.slug}/${application.teamEnvironment.environment.name}/app/${application.name}`
@@ -313,12 +307,6 @@
 	</div>
 {/if}
 
-{#if hasFailing}
-	<div class="status-row">
-		<Tag size="small" variant="error">Failing</Tag>
-	</div>
-{/if}
-
 <GraphErrors errors={$InstanceGroupDetail.errors} />
 
 {#if $InstanceGroupDetail.fetching}
@@ -526,12 +514,6 @@
 {/if}
 
 <style>
-	.status-row {
-		display: flex;
-		gap: var(--ax-space-8);
-		margin-bottom: var(--ax-space-4);
-	}
-
 	.group-selector {
 		margin-bottom: var(--ax-space-16);
 	}


### PR DESCRIPTION
This pull request simplifies the `+page.svelte` file for the instance group detail page by removing the logic and UI related to showing a "Failing" status tag for instance groups with failing instances. The changes focus on cleaning up both the JavaScript logic and the associated UI elements and styles.

**Removal of "Failing" status tag logic and UI:**

* Removed the `groupHasFailing` function and the `hasFailing` derived value, eliminating the logic that checked for failing instances in a group. ([src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelteL69-L74](diffhunk://#diff-e1a8ceadf9f22ef5dd20aab4d2f87357b3747871a47b370325c2fff2b2c58f7fL69-L74))
* Removed the conditional rendering of the "Failing" `<Tag>` from the template, so the UI no longer displays a "Failing" tag for instance groups with failing instances. ([src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelteL316-L321](diffhunk://#diff-e1a8ceadf9f22ef5dd20aab4d2f87357b3747871a47b370325c2fff2b2c58f7fL316-L321))
* Removed the `.status-row` CSS class, as it is no longer used after the removal of the "Failing" tag UI. ([src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelteL529-L534](diffhunk://#diff-e1a8ceadf9f22ef5dd20aab4d2f87357b3747871a47b370325c2fff2b2c58f7fL529-L534))