### PR TITLE
fix: upgrade form-data to 4.0.6 (CVE-2026-12143)

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,7 +1,0 @@
-{
-	"servers": {
-		"svelte": {
-			"url": "https://mcp.svelte.dev/mcp"
-		}
-	}
-}

--- a/README.md
+++ b/README.md
@@ -53,20 +53,9 @@ Styles use `@layer` ordering and design tokens from `@nais/ds-svelte-community`:
 
 The project is configured with AI assistant guidelines and the Svelte MCP (Model Context Protocol) server:
 
-- **[AGENTS.md](AGENTS.md)** - Project guidelines for AI assistants (GitHub Copilot, Cursor, Claude Code, etc.)
-  - Svelte 5 runes patterns
-  - Houdini GraphQL conventions
-  - CSS variable validation rules
-  - Component library usage
-  - Code quality standards
-  - Security patterns
+- **[AGENTS.md](AGENTS.md)** — Project guidelines for AI assistants (GitHub Copilot, Cursor, Claude Code, etc.), covering Svelte 5 runes patterns, Houdini GraphQL conventions, CSS variable rules, component library usage, code quality standards, and security patterns.
 
-- **Svelte MCP Server** - Provides comprehensive Svelte 5 and SvelteKit documentation to AI assistants
-  - Configuration: `.mcp.json` (Cursor, Claude Code, Zed) and `.vscode/mcp.json` (VSCode)
-  - Remote endpoint: `https://mcp.svelte.dev/mcp`
-  - Tools: `list-sections`, `get-documentation`, `svelte-autofixer`, `playground-link`
-
-The MCP server helps AI assistants provide accurate, up-to-date Svelte 5 guidance and catch common issues before you run linters.
+- **Svelte MCP Server** — Provides Svelte 5 and SvelteKit documentation to AI assistants via the official remote endpoint at `https://mcp.svelte.dev/mcp`. In VS Code, it is available through the MCP server registry (no project config needed). For other editors (Cursor, Claude Code, Zed), it is configured in `.mcp.json`. Tools: `list-sections`, `get-documentation`, `svelte-autofixer`, `playground-link`.
 
 #### Using the nais API proxy
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"@codemirror/view": "6.43.0",
 		"@prometheus-io/codemirror-promql": "0.311.3",
 		"@slack/types": "2.21.1",
-		"@slack/web-api": "7.16.0",
+		"@slack/web-api": "7.17.0",
 		"cron-parser": "5.5.0",
 		"cronstrue": "3.14.0",
 		"d3-array": "3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@sveltejs/kit>cookie': ^0.7.0
+  form-data: ^4.0.6
 
 importers:
 
@@ -30,8 +31,8 @@ importers:
         specifier: 2.21.1
         version: 2.21.1
       '@slack/web-api':
-        specifier: 7.16.0
-        version: 7.16.0
+        specifier: 7.17.0
+        version: 7.17.0
       cron-parser:
         specifier: 5.5.0
         version: 5.5.0
@@ -924,8 +925,8 @@ packages:
     resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
-  '@slack/web-api@7.16.0':
-    resolution: {integrity: sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg==}
+  '@slack/web-api@7.17.0':
+    resolution: {integrity: sha512-jejr34a8B4L5AS713wOAx1LAqNkW16HVMDEa6sYBvFDc/llUBl8hXaiI4BwF+Al+Sug19Vn2O7iokTVIhVvZ1Q==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@standard-schema/spec@1.1.0':
@@ -1834,8 +1835,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
@@ -3564,7 +3565,7 @@ snapshots:
 
   '@slack/types@2.21.1': {}
 
-  '@slack/web-api@7.16.0':
+  '@slack/web-api@7.17.0':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.21.1
@@ -3572,7 +3573,7 @@ snapshots:
       '@types/retry': 0.12.0
       axios: 1.17.0
       eventemitter3: 5.0.4
-      form-data: 4.0.5
+      form-data: 4.0.6
       is-electron: 2.2.2
       is-stream: 2.0.1
       p-queue: 6.6.2
@@ -3978,7 +3979,7 @@ snapshots:
   axios@1.17.0:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -4515,7 +4516,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,5 +11,5 @@ minimumReleaseAgeExclude:
   - esbuild@0.28.1
   - lint-staged@17.0.7
   - "@esbuild/*"
-  - '@slack/web-api@7.17.0'
+  - "@slack/web-api@7.17.0"
   - form-data@4.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 overrides:
   "@sveltejs/kit>cookie": "^0.7.0"
+  form-data: "^4.0.6"
 
 allowBuilds:
   esbuild: true
@@ -10,3 +11,5 @@ minimumReleaseAgeExclude:
   - esbuild@0.28.1
   - lint-staged@17.0.7
   - "@esbuild/*"
+  - '@slack/web-api@7.17.0'
+  - form-data@4.0.6


### PR DESCRIPTION
Resolves [Dependabot alert #134](https://github.com/nais/console-frontend/security/dependabot/134) — CRLF injection in `form-data` via unescaped multipart field names and filenames (CVE-2026-12143, GHSA-hmw2-7cc7-3qxx).

### Changes

- **Remove `.vscode/mcp.json`** — not needed in the repo
- **Upgrade `@slack/web-api`** 7.16.0 → 7.17.0
- **Add pnpm override** for `form-data: ^4.0.6` to ensure the patched version is resolved (the transitive dependency via `axios` was pinned to 4.0.5 in the lockfile)