### PR TITLE
feat: GitHub-style Time component with accessible Tooltip

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,6 @@
 pin = true
 [tools]
 node = "24.11.1"
-pnpm = "11.7.0"
+pnpm = "11.8.0"
 go = "1.26.3"
 "go:github.com/sethvargo/ratchet" = "0.11.4"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "console-frontend",
 	"version": "0.0.1",
 	"private": true,
-	"packageManager": "pnpm@11.7.0",
+	"packageManager": "pnpm@11.8.0",
 	"scripts": {
 		"build": "vite build",
 		"check-outdated": "pnpm outdated",
@@ -47,7 +47,7 @@
 		"prettier": "3.8.3",
 		"prettier-plugin-svelte": "4.1.0",
 		"prettier-plugin-tailwindcss": "0.8.0",
-		"svelte": "5.56.1",
+		"svelte": "5.56.2",
 		"svelte-check": "4.6.0",
 		"tailwindcss": "4.3.0",
 		"typescript": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 2.6.0(graphql@16.14.1)
       layerchart:
         specifier: 2.0.0-next.64
-        version: 2.0.0-next.64(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))
+        version: 2.0.0-next.64(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))
       luxon:
         specifier: 3.7.2
         version: 3.7.2
@@ -84,16 +84,16 @@ importers:
         version: 2.0.0-next.18
       '@nais/ds-svelte-community':
         specifier: 2.0.0-next.8
-        version: 2.0.0-next.8(@navikt/ds-css@8.9.1)(@navikt/ds-tokens@8.9.1)(svelte@5.56.1(@typescript-eslint/types@8.60.1))
+        version: 2.0.0-next.8(@navikt/ds-css@8.9.1)(@navikt/ds-tokens@8.9.1)(svelte@5.56.2(@typescript-eslint/types@8.60.1))
       '@sveltejs/adapter-node':
         specifier: 5.5.4
-        version: 5.5.4(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 5.5.4(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))
       '@sveltejs/kit':
         specifier: 2.63.0
-        version: 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: 7.1.2
-        version: 7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: 4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -123,7 +123,7 @@ importers:
         version: 10.1.8(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-svelte:
         specifier: 3.19.0
-        version: 3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.56.1(@typescript-eslint/types@8.60.1))
+        version: 3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.56.2(@typescript-eslint/types@8.60.1))
       eslint-plugin-unicorn:
         specifier: 64.0.0
         version: 64.0.0(eslint@10.4.1(jiti@2.7.0))
@@ -135,7 +135,7 @@ importers:
         version: 2.0.0-next.12(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       houdini-svelte:
         specifier: 3.0.0-next.14
-        version: 3.0.0-next.14(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 3.0.0-next.14(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -150,16 +150,16 @@ importers:
         version: 3.8.3
       prettier-plugin-svelte:
         specifier: 4.1.0
-        version: 4.1.0(prettier@3.8.3)(svelte@5.56.1(@typescript-eslint/types@8.60.1))
+        version: 4.1.0(prettier@3.8.3)(svelte@5.56.2(@typescript-eslint/types@8.60.1))
       prettier-plugin-tailwindcss:
         specifier: 0.8.0
-        version: 0.8.0(prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.1(@typescript-eslint/types@8.60.1)))(prettier@3.8.3)
+        version: 0.8.0(prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.2(@typescript-eslint/types@8.60.1)))(prettier@3.8.3)
       svelte:
-        specifier: 5.56.1
-        version: 5.56.1(@typescript-eslint/types@8.60.1)
+        specifier: 5.56.2
+        version: 5.56.2(@typescript-eslint/types@8.60.1)
       svelte-check:
         specifier: 4.6.0
-        version: 4.6.0(picomatch@4.0.4)(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)
+        version: 4.6.0(picomatch@4.0.4)(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)
       tailwindcss:
         specifier: 4.3.0
         version: 4.3.0
@@ -2722,8 +2722,8 @@ packages:
   svelte-highlight@7.10.1:
     resolution: {integrity: sha512-7nwxAzbWUXTh6i/sqkDIaZpIv2EhuGyJqJrK8R+VbuMCW3/XnxRk6Bfgn5AQb6wIGZRoLeyUtJQrmj1OxLZ+FQ==}
 
-  svelte@5.56.1:
-    resolution: {integrity: sha512-eArsJmvl3xZVuTYD852PzIEdg2wgDdIZ1NEsIPbzAukHwi284B18No4nK2rCO9AwsWUDza4Cjvmoa4HaojTl5g==}
+  svelte@5.56.2:
+    resolution: {integrity: sha512-1lDf8TLqpxyAt3xgybfytWPJQbaUD6TiDgpiCLH0BKrKEwzecB9pjuNVnEJMpzH018xUzo6oxheK2HT0oa2RoQ==}
     engines: {node: '>=18'}
 
   tailwind-merge@3.6.0:
@@ -3351,11 +3351,11 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@nais/ds-svelte-community@2.0.0-next.8(@navikt/ds-css@8.9.1)(@navikt/ds-tokens@8.9.1)(svelte@5.56.1(@typescript-eslint/types@8.60.1))':
+  '@nais/ds-svelte-community@2.0.0-next.8(@navikt/ds-css@8.9.1)(@navikt/ds-tokens@8.9.1)(svelte@5.56.2(@typescript-eslint/types@8.60.1))':
     dependencies:
       '@navikt/ds-css': 8.9.1
       '@navikt/ds-tokens': 8.9.1
-      svelte: 5.56.1(@typescript-eslint/types@8.60.1)
+      svelte: 5.56.2(@typescript-eslint/types@8.60.1)
     optionalDependencies:
       svelte-floating-ui: 1.6.2
 
@@ -3589,19 +3589,19 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.3(rollup@4.61.1)
       '@rollup/plugin-json': 6.1.0(rollup@4.61.1)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.61.1)
-      '@sveltejs/kit': 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       rollup: 4.61.1
 
-  '@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.7.2
@@ -3612,19 +3612,19 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
-      svelte: 5.56.1(@typescript-eslint/types@8.60.1)
+      svelte: 5.56.2(@typescript-eslint/types@8.60.1)
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
       typescript: 6.0.3
 
   '@sveltejs/load-config@0.1.1': {}
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.56.1(@typescript-eslint/types@8.60.1)
+      svelte: 5.56.2(@typescript-eslint/types@8.60.1)
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
@@ -4309,7 +4309,7 @@ snapshots:
     dependencies:
       eslint: 10.4.1(jiti@2.7.0)
 
-  eslint-plugin-svelte@3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.56.1(@typescript-eslint/types@8.60.1)):
+  eslint-plugin-svelte@3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.56.2(@typescript-eslint/types@8.60.1)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4321,9 +4321,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.15)
       postcss-safe-parser: 7.0.1(postcss@8.5.15)
       semver: 7.8.1
-      svelte-eslint-parser: 1.8.0(svelte@5.56.1(@typescript-eslint/types@8.60.1))
+      svelte-eslint-parser: 1.8.0(svelte@5.56.2(@typescript-eslint/types@8.60.1))
     optionalDependencies:
-      svelte: 5.56.1(@typescript-eslint/types@8.60.1)
+      svelte: 5.56.2(@typescript-eslint/types@8.60.1)
     transitivePeerDependencies:
       - ts-node
 
@@ -4619,17 +4619,17 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  houdini-svelte@3.0.0-next.14(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+  houdini-svelte@3.0.0-next.14(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@kitql/helpers': 0.8.15
-      '@sveltejs/kit': 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       ast-types: 0.16.1
       estree-walker: 3.0.3
       graphql: 16.14.1
       houdini: 2.0.0-next.12(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       recast: 0.23.8
       rollup: 4.61.1
-      svelte: 5.56.1(@typescript-eslint/types@8.60.1)
+      svelte: 5.56.2(@typescript-eslint/types@8.60.1)
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
   houdini@2.0.0-next.12(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
@@ -4755,7 +4755,7 @@ snapshots:
 
   known-css-properties@0.37.0: {}
 
-  layerchart@2.0.0-next.64(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1)):
+  layerchart@2.0.0-next.64(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1)):
     dependencies:
       '@dagrejs/dagre': 2.0.4
       '@layerstack/svelte-actions': 1.0.1-next.18
@@ -4785,8 +4785,8 @@ snapshots:
       d3-tile: 1.0.0
       d3-time: 3.1.0
       memoize: 10.2.0
-      runed: 0.37.1(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))
-      svelte: 5.56.1(@typescript-eslint/types@8.60.1)
+      runed: 0.37.1(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))
+      svelte: 5.56.2(@typescript-eslint/types@8.60.1)
     transitivePeerDependencies:
       - '@sveltejs/kit'
       - zod
@@ -5100,16 +5100,16 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.1(@typescript-eslint/types@8.60.1)):
+  prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.2(@typescript-eslint/types@8.60.1)):
     dependencies:
       prettier: 3.8.3
-      svelte: 5.56.1(@typescript-eslint/types@8.60.1)
+      svelte: 5.56.2(@typescript-eslint/types@8.60.1)
 
-  prettier-plugin-tailwindcss@0.8.0(prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.1(@typescript-eslint/types@8.60.1)))(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.8.0(prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.2(@typescript-eslint/types@8.60.1)))(prettier@3.8.3):
     dependencies:
       prettier: 3.8.3
     optionalDependencies:
-      prettier-plugin-svelte: 4.1.0(prettier@3.8.3)(svelte@5.56.1(@typescript-eslint/types@8.60.1))
+      prettier-plugin-svelte: 4.1.0(prettier@3.8.3)(svelte@5.56.2(@typescript-eslint/types@8.60.1))
 
   prettier@3.8.3: {}
 
@@ -5218,14 +5218,14 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
-  runed@0.37.1(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1)):
+  runed@0.37.1(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1)):
     dependencies:
       dequal: 2.0.3
       esm-env: 1.2.2
       lz-string: 1.5.0
-      svelte: 5.56.1(@typescript-eslint/types@8.60.1)
+      svelte: 5.56.2(@typescript-eslint/types@8.60.1)
     optionalDependencies:
-      '@sveltejs/kit': 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2(@typescript-eslint/types@8.60.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
   rw@1.3.3: {}
 
@@ -5318,7 +5318,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.6.0(picomatch@4.0.4)(svelte@5.56.1(@typescript-eslint/types@8.60.1))(typescript@6.0.3):
+  svelte-check@4.6.0(picomatch@4.0.4)(svelte@5.56.2(@typescript-eslint/types@8.60.1))(typescript@6.0.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       '@sveltejs/load-config': 0.1.1
@@ -5326,12 +5326,12 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.56.1(@typescript-eslint/types@8.60.1)
+      svelte: 5.56.2(@typescript-eslint/types@8.60.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.8.0(svelte@5.56.1(@typescript-eslint/types@8.60.1)):
+  svelte-eslint-parser@1.8.0(svelte@5.56.2(@typescript-eslint/types@8.60.1)):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -5341,7 +5341,7 @@ snapshots:
       postcss-selector-parser: 7.1.1
       semver: 7.8.1
     optionalDependencies:
-      svelte: 5.56.1(@typescript-eslint/types@8.60.1)
+      svelte: 5.56.2(@typescript-eslint/types@8.60.1)
 
   svelte-floating-ui@1.6.2:
     dependencies:
@@ -5352,7 +5352,7 @@ snapshots:
     dependencies:
       highlight.js: 11.11.1
 
-  svelte@5.56.1(@typescript-eslint/types@8.60.1):
+  svelte@5.56.2(@typescript-eslint/types@8.60.1):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5

--- a/src/lib/domain/activity/shared/texts/PostgresGrantAccessActivityLogEntryText.svelte
+++ b/src/lib/domain/activity/shared/texts/PostgresGrantAccessActivityLogEntryText.svelte
@@ -16,7 +16,7 @@
 <div>
 	Granted access to {data.postgresGrantAccessData.grantee} on {data.resourceType.toLocaleLowerCase()}
 	<strong>{data.resourceName}</strong>
-	until <Time time={data.postgresGrantAccessData.until} dateFormat="dd/MM/yyyy HH:mm" />
+	until <Time time={data.postgresGrantAccessData.until} dateFormat="d MMM yyyy, HH:mm" />
 	{#if data.environmentName}
 		in {data.environmentName}
 	{/if}

--- a/src/lib/domain/list-items/AppListItem.svelte
+++ b/src/lib/domain/list-items/AppListItem.svelte
@@ -7,8 +7,6 @@
 	import { countIssuesBySeverity } from '$lib/utils/issueCounts';
 	import { Tag, Tooltip } from '@nais/ds-svelte-community';
 	import { RocketIcon } from '@nais/ds-svelte-community/icons';
-	import { format } from 'date-fns';
-	import { enGB } from 'date-fns/locale';
 
 	const {
 		app
@@ -78,16 +76,10 @@
 		<div class="meta-cell">
 			{#if app.deployments.nodes.length > 0}
 				{@const timestamp = app.deployments.nodes[0].createdAt}
-				<Tooltip
-					content="Last deploy — {format(timestamp, 'PPPP', {
-						locale: enGB
-					})}"
-				>
-					<span class="meta-item">
-						<RocketIcon style="font-size: 14px" />
-						<Time time={timestamp} distance={true} />
-					</span>
-				</Tooltip>
+				<span class="meta-item">
+					<RocketIcon style="font-size: 14px" />
+					<Time time={timestamp} distance={true} />
+				</span>
 			{/if}
 			<span class="meta-item">
 				{#if app.instances.pageInfo.totalCount === 0}

--- a/src/lib/domain/list-items/AppListItem.svelte
+++ b/src/lib/domain/list-items/AppListItem.svelte
@@ -76,8 +76,9 @@
 		<div class="meta-cell">
 			{#if app.deployments.nodes.length > 0}
 				{@const timestamp = app.deployments.nodes[0].createdAt}
-				<span class="meta-item" aria-label="Last deploy">
+				<span class="meta-item">
 					<RocketIcon style="font-size: 14px" aria-hidden="true" />
+					<span class="aksel-sr-only">Last deploy</span>
 					<Time time={timestamp} distance={true} />
 				</span>
 			{/if}

--- a/src/lib/domain/list-items/AppListItem.svelte
+++ b/src/lib/domain/list-items/AppListItem.svelte
@@ -76,8 +76,8 @@
 		<div class="meta-cell">
 			{#if app.deployments.nodes.length > 0}
 				{@const timestamp = app.deployments.nodes[0].createdAt}
-				<span class="meta-item">
-					<RocketIcon style="font-size: 14px" />
+				<span class="meta-item" aria-label="Last deploy">
+					<RocketIcon style="font-size: 14px" aria-hidden="true" />
 					<Time time={timestamp} distance={true} />
 				</span>
 			{/if}

--- a/src/lib/domain/list-items/DeploymentWithTeamListItem.svelte
+++ b/src/lib/domain/list-items/DeploymentWithTeamListItem.svelte
@@ -60,7 +60,7 @@
 				</ExternalLink>
 				by {deployment.deployerUsername}
 				{#if deployment.triggerUrl}
-					· <Time time={deployment.createdAt} dateFormat="dd/MM/yyyy HH:mm" /> ·
+					· <Time time={deployment.createdAt} dateFormat="d MMM yyyy, HH:mm" /> ·
 					<ExternalLink href={deployment.triggerUrl}>GitHub action</ExternalLink>
 					to deploy to
 					<Tag size="small" variant={envTagVariant(deployment.environmentName)}>
@@ -89,7 +89,7 @@
 					</ul>
 				{/if}
 			{:else}
-				<Time time={deployment.createdAt} dateFormat="dd/MM/yyyy HH:mm" /> · Deploy to
+				<Time time={deployment.createdAt} dateFormat="d MMM yyyy, HH:mm" /> · Deploy to
 				<Tag size="small" variant={envTagVariant(deployment.environmentName)}>
 					{deployment.environmentName}
 				</Tag>:

--- a/src/lib/domain/list-items/JobListItem.svelte
+++ b/src/lib/domain/list-items/JobListItem.svelte
@@ -85,13 +85,16 @@
 
 		<div class="meta-cell">
 			{#if lastRun}
-				<span class="meta-item run-status">
+				<span
+					class="meta-item run-status"
+					aria-label="Last run {lastRun.status.state.toLowerCase()}"
+				>
 					{#if lastRun.status.state === 'RUNNING' || lastRun.status.state === 'PENDING'}
-						<Loader size="xsmall" variant="interaction" />
+						<Loader size="xsmall" variant="interaction" aria-hidden="true" />
 					{:else if lastRun.status.state === 'SUCCEEDED'}
-						<SuccessIcon />
+						<SuccessIcon aria-hidden="true" />
 					{:else if lastRun.status.state === 'FAILED'}
-						<ErrorIcon />
+						<ErrorIcon aria-hidden="true" />
 					{/if}
 					{#if lastRun.startTime}
 						<Time time={lastRun.startTime} distance={true} />
@@ -99,15 +102,15 @@
 				</span>
 			{/if}
 			{#if job.schedule?.nextRun}
-				<span class="meta-item">
-					<CalendarIcon style="font-size: 14px" />
+				<span class="meta-item" aria-label="Next run">
+					<CalendarIcon style="font-size: 14px" aria-hidden="true" />
 					<Time time={job.schedule.nextRun} distance={true} />
 				</span>
 			{/if}
 			{#if job.deployments.nodes.length > 0}
 				{@const timestamp = job.deployments.nodes[0].createdAt}
-				<span class="meta-item">
-					<RocketIcon style="font-size: 14px" />
+				<span class="meta-item" aria-label="Last deploy">
+					<RocketIcon style="font-size: 14px" aria-hidden="true" />
 					<Time time={timestamp} distance={true} />
 				</span>
 			{/if}

--- a/src/lib/domain/list-items/JobListItem.svelte
+++ b/src/lib/domain/list-items/JobListItem.svelte
@@ -85,10 +85,8 @@
 
 		<div class="meta-cell">
 			{#if lastRun}
-				<span
-					class="meta-item run-status"
-					aria-label="Last run {lastRun.status.state.toLowerCase()}"
-				>
+				<span class="meta-item run-status">
+					<span class="aksel-sr-only">Last run {lastRun.status.state.toLowerCase()}</span>
 					{#if lastRun.status.state === 'RUNNING' || lastRun.status.state === 'PENDING'}
 						<Loader size="xsmall" variant="interaction" aria-hidden="true" />
 					{:else if lastRun.status.state === 'SUCCEEDED'}
@@ -102,15 +100,17 @@
 				</span>
 			{/if}
 			{#if job.schedule?.nextRun}
-				<span class="meta-item" aria-label="Next run">
+				<span class="meta-item">
 					<CalendarIcon style="font-size: 14px" aria-hidden="true" />
+					<span class="aksel-sr-only">Next run</span>
 					<Time time={job.schedule.nextRun} distance={true} />
 				</span>
 			{/if}
 			{#if job.deployments.nodes.length > 0}
 				{@const timestamp = job.deployments.nodes[0].createdAt}
-				<span class="meta-item" aria-label="Last deploy">
+				<span class="meta-item">
 					<RocketIcon style="font-size: 14px" aria-hidden="true" />
+					<span class="aksel-sr-only">Last deploy</span>
 					<Time time={timestamp} distance={true} />
 				</span>
 			{/if}

--- a/src/lib/domain/list-items/JobListItem.svelte
+++ b/src/lib/domain/list-items/JobListItem.svelte
@@ -10,8 +10,6 @@
 	import { countIssuesBySeverity } from '$lib/utils/issueCounts';
 	import { Loader, Tag, Tooltip } from '@nais/ds-svelte-community';
 	import { CalendarIcon, RocketIcon } from '@nais/ds-svelte-community/icons';
-	import { format } from 'date-fns';
-	import { enGB } from 'date-fns/locale';
 
 	const {
 		job
@@ -87,41 +85,31 @@
 
 		<div class="meta-cell">
 			{#if lastRun}
-				<Tooltip
-					content="Last run {lastRun.status.state.toLowerCase()} — {lastRun.startTime
-						? format(lastRun.startTime, 'PPPp', { locale: enGB })
-						: 'unknown'}"
-				>
-					<span class="meta-item run-status">
-						{#if lastRun.status.state === 'RUNNING' || lastRun.status.state === 'PENDING'}
-							<Loader size="xsmall" variant="interaction" />
-						{:else if lastRun.status.state === 'SUCCEEDED'}
-							<SuccessIcon />
-						{:else if lastRun.status.state === 'FAILED'}
-							<ErrorIcon />
-						{/if}
-						{#if lastRun.startTime}
-							<Time time={lastRun.startTime} distance={true} />
-						{/if}
-					</span>
-				</Tooltip>
+				<span class="meta-item run-status">
+					{#if lastRun.status.state === 'RUNNING' || lastRun.status.state === 'PENDING'}
+						<Loader size="xsmall" variant="interaction" />
+					{:else if lastRun.status.state === 'SUCCEEDED'}
+						<SuccessIcon />
+					{:else if lastRun.status.state === 'FAILED'}
+						<ErrorIcon />
+					{/if}
+					{#if lastRun.startTime}
+						<Time time={lastRun.startTime} distance={true} />
+					{/if}
+				</span>
 			{/if}
 			{#if job.schedule?.nextRun}
-				<Tooltip content="Next run — {format(job.schedule.nextRun, 'PPPp', { locale: enGB })}">
-					<span class="meta-item">
-						<CalendarIcon style="font-size: 14px" />
-						<Time time={job.schedule.nextRun} distance={true} />
-					</span>
-				</Tooltip>
+				<span class="meta-item">
+					<CalendarIcon style="font-size: 14px" />
+					<Time time={job.schedule.nextRun} distance={true} />
+				</span>
 			{/if}
 			{#if job.deployments.nodes.length > 0}
 				{@const timestamp = job.deployments.nodes[0].createdAt}
-				<Tooltip content="Last deploy — {format(timestamp, 'PPPP', { locale: enGB })}">
-					<span class="meta-item">
-						<RocketIcon style="font-size: 14px" />
-						<Time time={timestamp} distance={true} />
-					</span>
-				</Tooltip>
+				<span class="meta-item">
+					<RocketIcon style="font-size: 14px" />
+					<Time time={timestamp} distance={true} />
+				</span>
 			{/if}
 		</div>
 	</div>

--- a/src/lib/domain/list-items/ServiceAccountListItem.svelte
+++ b/src/lib/domain/list-items/ServiceAccountListItem.svelte
@@ -2,10 +2,8 @@
 	import IconLabel from '$lib/ui/IconLabel.svelte';
 	import ListItem from '$lib/ui/ListItem.svelte';
 	import Time from '$lib/ui/Time.svelte';
-	import { Detail, Tooltip } from '@nais/ds-svelte-community';
+	import { Detail } from '@nais/ds-svelte-community';
 	import { RobotIcon } from '@nais/ds-svelte-community/icons';
-	import { format } from 'date-fns';
-	import { enGB } from 'date-fns/locale';
 
 	const {
 		serviceAccount,
@@ -33,27 +31,15 @@
 
 	<div class="right">
 		{#if serviceAccount.lastUsedAt}
-			<Tooltip
-				content="Last used - {format(serviceAccount.lastUsedAt, 'PPPP', {
-					locale: enGB
-				})}"
-			>
-				<Detail>
-					Last used <Time time={serviceAccount.lastUsedAt} distance={true} />
-				</Detail>
-			</Tooltip>
+			<Detail>
+				Last used <Time time={serviceAccount.lastUsedAt} distance={true} />
+			</Detail>
 		{:else}
 			<Detail>Never used</Detail>
 		{/if}
-		<Tooltip
-			content="Created - {format(serviceAccount.createdAt, 'PPPP', {
-				locale: enGB
-			})}"
-		>
-			<Detail>
-				Created <Time time={serviceAccount.createdAt} distance={true} />
-			</Detail>
-		</Tooltip>
+		<Detail>
+			Created <Time time={serviceAccount.createdAt} distance={true} />
+		</Detail>
 	</div>
 </ListItem>
 

--- a/src/lib/domain/service-accounts/ServiceAccountAuthentications.svelte
+++ b/src/lib/domain/service-accounts/ServiceAccountAuthentications.svelte
@@ -9,10 +9,8 @@
 	import ListItem from '$lib/ui/ListItem.svelte';
 	import { pageModalClick } from '$lib/ui/PageModal.svelte';
 	import Time from '$lib/ui/Time.svelte';
-	import { Button, Detail, Heading, Tooltip } from '@nais/ds-svelte-community';
+	import { Button, Detail, Heading } from '@nais/ds-svelte-community';
 	import { BranchingIcon, TokenIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
-	import { format } from 'date-fns';
-	import { enGB } from 'date-fns/locale';
 
 	interface Props {
 		serviceAccount: ServiceAccountAuthenticationFragment;
@@ -148,19 +146,15 @@
 
 					<div class="right">
 						{#if binding.lastUsedAt}
-							<Tooltip content="Last used - {format(binding.lastUsedAt, 'PPPP', { locale: enGB })}">
-								<Detail>
-									Last used <Time time={binding.lastUsedAt} distance={true} />
-								</Detail>
-							</Tooltip>
+							<Detail>
+								Last used <Time time={binding.lastUsedAt} distance={true} />
+							</Detail>
 						{:else}
 							<Detail>Never used</Detail>
 						{/if}
-						<Tooltip content="Created - {format(binding.createdAt, 'PPPP', { locale: enGB })}">
-							<Detail>
-								Created <Time time={binding.createdAt} distance={true} />
-							</Detail>
-						</Tooltip>
+						<Detail>
+							Created <Time time={binding.createdAt} distance={true} />
+						</Detail>
 						{#if canManage}
 							<Button
 								size="xsmall"
@@ -197,25 +191,19 @@
 
 					<div class="right">
 						{#if token.lastUsedAt}
-							<Tooltip content="Last used - {format(token.lastUsedAt, 'PPPP', { locale: enGB })}">
-								<Detail>
-									Last used <Time time={token.lastUsedAt} distance={true} />
-								</Detail>
-							</Tooltip>
+							<Detail>
+								Last used <Time time={token.lastUsedAt} distance={true} />
+							</Detail>
 						{:else}
 							<Detail>Never used</Detail>
 						{/if}
-						<Tooltip content="Created - {format(token.createdAt, 'PPPP', { locale: enGB })}">
-							<Detail>
-								Created <Time time={token.createdAt} distance={true} />
-							</Detail>
-						</Tooltip>
+						<Detail>
+							Created <Time time={token.createdAt} distance={true} />
+						</Detail>
 						{#if token.expiresAt}
-							<Tooltip content="Expires - {format(token.expiresAt, 'PPPP', { locale: enGB })}">
-								<Detail>
-									Expires <Time time={token.expiresAt} distance={true} />
-								</Detail>
-							</Tooltip>
+							<Detail>
+								Expires <Time time={token.expiresAt} distance={true} />
+							</Detail>
 						{/if}
 						{#if canManage}
 							<Button

--- a/src/lib/domain/service-accounts/ServiceAccountDetail.svelte
+++ b/src/lib/domain/service-accounts/ServiceAccountDetail.svelte
@@ -8,10 +8,8 @@
 	import Confirm from '$lib/ui/Confirm.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyLong, Button, Heading, Tooltip } from '@nais/ds-svelte-community';
+	import { BodyLong, Button, Heading } from '@nais/ds-svelte-community';
 	import { TrashIcon } from '@nais/ds-svelte-community/icons';
-	import { format } from 'date-fns';
-	import { enGB } from 'date-fns/locale';
 	import ServiceAccountAuthentications from './ServiceAccountAuthentications.svelte';
 	import ServiceAccountRoles from './ServiceAccountRoles.svelte';
 
@@ -86,22 +84,16 @@
 		<dl class="settings-list">
 			<dt>Created</dt>
 			<dd>
-				<Tooltip content={format(serviceAccount.createdAt, 'PPPP', { locale: enGB })}>
-					<Time time={serviceAccount.createdAt} distance={true} />
-				</Tooltip>
+				<Time time={serviceAccount.createdAt} distance={true} />
 			</dd>
 			<dt>Last updated</dt>
 			<dd>
-				<Tooltip content={format(serviceAccount.updatedAt, 'PPPP', { locale: enGB })}>
-					<Time time={serviceAccount.updatedAt} distance={true} />
-				</Tooltip>
+				<Time time={serviceAccount.updatedAt} distance={true} />
 			</dd>
 			<dt>Last used</dt>
 			<dd>
 				{#if serviceAccount.lastUsedAt}
-					<Tooltip content={format(serviceAccount.lastUsedAt, 'PPPP', { locale: enGB })}>
-						<Time time={serviceAccount.lastUsedAt} distance={true} />
-					</Tooltip>
+					<Time time={serviceAccount.lastUsedAt} distance={true} />
 				{:else}
 					Never
 				{/if}

--- a/src/lib/ui/Time.svelte
+++ b/src/lib/ui/Time.svelte
@@ -18,20 +18,22 @@
 
 	let tick = $state(0);
 
-	let fullTimestamp = $derived(format(time, 'dd. MMMM yyyy HH:mm:ss', { locale: enGB }));
+	const normalizedTime = $derived(time instanceof Date ? time : new Date(time as string));
+
+	let fullTimestamp = $derived(format(normalizedTime, 'dd. MMMM yyyy HH:mm:ss', { locale: enGB }));
 
 	function isRecent(): boolean {
-		return differenceInDays(new Date(), time) < DISTANCE_THRESHOLD_DAYS;
+		return differenceInDays(new Date(), normalizedTime) < DISTANCE_THRESHOLD_DAYS;
 	}
 
 	function distanceText(): string {
 		if (isRecent()) {
-			return formatDistanceStrict(time, Date.now(), { addSuffix: true });
+			return formatDistanceStrict(normalizedTime, Date.now(), { addSuffix: true });
 		}
-		if (isSameYear(time, new Date())) {
-			return format(time, 'd MMM, HH:mm', { locale: enGB });
+		if (isSameYear(normalizedTime, new Date())) {
+			return format(normalizedTime, 'd MMM, HH:mm', { locale: enGB });
 		}
-		return format(time, 'd MMM yyyy, HH:mm', { locale: enGB });
+		return format(normalizedTime, 'd MMM yyyy, HH:mm', { locale: enGB });
 	}
 
 	let text = $derived.by(() => {
@@ -39,13 +41,13 @@
 		if (distance) {
 			return distanceText();
 		}
-		return format(time, dateFormat, { locale: enGB });
+		return format(normalizedTime, dateFormat, { locale: enGB });
 	});
 
 	let tooltipContent = $derived.by(() => {
 		void tick;
 		if (distance && !isRecent()) {
-			const relative = formatDistanceStrict(time, Date.now(), { addSuffix: true });
+			const relative = formatDistanceStrict(normalizedTime, Date.now(), { addSuffix: true });
 			return `${fullTimestamp} (${relative})`;
 		}
 		return fullTimestamp;
@@ -61,6 +63,8 @@
 	});
 
 	$effect(() => {
+		void tick;
+
 		if (!distance) {
 			if (interval) {
 				clearInterval(interval);
@@ -86,10 +90,9 @@
 		}, desiredDelay);
 	});
 
-	const datetime = $derived.by(() => {
-		const d = time instanceof Date ? time : new Date(time as string);
-		return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
-	});
+	const datetime = $derived(
+		Number.isNaN(normalizedTime.getTime()) ? undefined : normalizedTime.toISOString()
+	);
 </script>
 
 <Tooltip content={tooltipContent}>

--- a/src/lib/ui/Time.svelte
+++ b/src/lib/ui/Time.svelte
@@ -71,7 +71,7 @@
 	$effect(() => {
 		void tick;
 
-		if (!distance) {
+		if (!distance || !isValidDate) {
 			if (interval) {
 				clearInterval(interval);
 				interval = undefined;
@@ -99,8 +99,14 @@
 	const datetime = $derived(isValidDate ? normalizedTime.toISOString() : undefined);
 </script>
 
-<Tooltip content={tooltipContent}>
+{#if tooltipContent}
+	<Tooltip content={tooltipContent}>
+		<time {datetime}>
+			{text}
+		</time>
+	</Tooltip>
+{:else}
 	<time {datetime}>
 		{text}
 	</time>
-</Tooltip>
+{/if}

--- a/src/lib/ui/Time.svelte
+++ b/src/lib/ui/Time.svelte
@@ -19,10 +19,14 @@
 	let tick = $state(0);
 
 	const normalizedTime = $derived(time instanceof Date ? time : new Date(time as string));
+	const isValidDate = $derived(!Number.isNaN(normalizedTime.getTime()));
 
-	let fullTimestamp = $derived(format(normalizedTime, 'dd. MMMM yyyy HH:mm:ss', { locale: enGB }));
+	let fullTimestamp = $derived(
+		isValidDate ? format(normalizedTime, 'dd. MMMM yyyy HH:mm:ss', { locale: enGB }) : ''
+	);
 
 	function isRecent(): boolean {
+		if (!isValidDate) return false;
 		return differenceInDays(new Date(), normalizedTime) < DISTANCE_THRESHOLD_DAYS;
 	}
 
@@ -38,6 +42,7 @@
 
 	let text = $derived.by(() => {
 		void tick;
+		if (!isValidDate) return '';
 		if (distance) {
 			return distanceText();
 		}
@@ -46,6 +51,7 @@
 
 	let tooltipContent = $derived.by(() => {
 		void tick;
+		if (!isValidDate) return '';
 		if (distance && !isRecent()) {
 			const relative = formatDistanceStrict(normalizedTime, Date.now(), { addSuffix: true });
 			return `${fullTimestamp} (${relative})`;
@@ -90,9 +96,7 @@
 		}, desiredDelay);
 	});
 
-	const datetime = $derived(
-		Number.isNaN(normalizedTime.getTime()) ? undefined : normalizedTime.toISOString()
-	);
+	const datetime = $derived(isValidDate ? normalizedTime.toISOString() : undefined);
 </script>
 
 <Tooltip content={tooltipContent}>

--- a/src/lib/ui/Time.svelte
+++ b/src/lib/ui/Time.svelte
@@ -51,7 +51,8 @@
 		return fullTimestamp;
 	});
 
-	let interval: ReturnType<typeof setTimeout> | undefined = $state();
+	let interval: ReturnType<typeof setInterval> | undefined = $state();
+	let intervalDelay: number | undefined = $state();
 
 	onDestroy(() => {
 		if (interval) {
@@ -64,18 +65,25 @@
 			if (interval) {
 				clearInterval(interval);
 				interval = undefined;
+				intervalDelay = undefined;
 			}
 			return;
 		}
 
-		if (!interval) {
-			interval = setInterval(
-				() => {
-					tick++;
-				},
-				isRecent() ? 1000 : 60_000
-			);
+		const desiredDelay = isRecent() ? 1000 : 60_000;
+
+		if (interval && intervalDelay === desiredDelay) {
+			return;
 		}
+
+		if (interval) {
+			clearInterval(interval);
+		}
+
+		intervalDelay = desiredDelay;
+		interval = setInterval(() => {
+			tick++;
+		}, desiredDelay);
 	});
 
 	const datetime = $derived.by(() => {

--- a/src/lib/ui/Time.svelte
+++ b/src/lib/ui/Time.svelte
@@ -1,63 +1,56 @@
 <script lang="ts">
-	import {
-		differenceInDays,
-		differenceInHours,
-		differenceInMinutes,
-		differenceInMonths,
-		differenceInSeconds,
-		differenceInYears,
-		format,
-		formatDistanceStrict
-	} from 'date-fns';
+	import { Tooltip } from '@nais/ds-svelte-community';
+	import { differenceInDays, format, formatDistanceStrict, isSameYear } from 'date-fns';
 	import { enGB } from 'date-fns/locale';
 	import { onDestroy } from 'svelte';
+
+	const DISTANCE_THRESHOLD_DAYS = 7;
 
 	const {
 		time,
 		dateFormat = 'PPPP',
-		distance = false,
-		short = false
+		distance = false
 	}: {
 		time: Date;
 		dateFormat?: string;
-	} & ({ distance?: false; short?: never } | { distance: true; short?: boolean }) = $props();
+		distance?: boolean;
+	} = $props();
 
-	let title = $derived(format(time, 'dd. MMMM yyyy HH:mm:ss', { locale: enGB }));
+	let tick = $state(0);
+
+	let fullTimestamp = $derived(format(time, 'dd. MMMM yyyy HH:mm:ss', { locale: enGB }));
+
+	function isRecent(): boolean {
+		return differenceInDays(new Date(), time) < DISTANCE_THRESHOLD_DAYS;
+	}
 
 	function distanceText(): string {
-		return formatDistanceStrict(time, Date.now(), { addSuffix: true });
+		if (isRecent()) {
+			return formatDistanceStrict(time, Date.now(), { addSuffix: true });
+		}
+		if (isSameYear(time, new Date())) {
+			return format(time, 'd MMM, HH:mm', { locale: enGB });
+		}
+		return format(time, 'd MMM yyyy, HH:mm', { locale: enGB });
 	}
 
-	function distanceShortText(): string {
-		const now = new Date();
-
-		const seconds = differenceInSeconds(now, time);
-		if (seconds < 60) return `${Math.ceil(seconds)}s`;
-
-		const minutes = differenceInMinutes(now, time);
-		if (minutes < 60) return `${Math.ceil(minutes)}m`;
-
-		const hours = differenceInHours(now, time);
-		if (hours < 24) return `${Math.ceil(hours)}h`;
-
-		const days = differenceInDays(now, time);
-		if (days < 30) return `${Math.ceil(days)}d`;
-
-		const months = differenceInMonths(now, time);
-		if (months < 12) return `${Math.ceil(months)}mo`;
-
-		const years = differenceInYears(now, time);
-		return `${Math.ceil(years)}y`;
-	}
-
-	function getDisplayText(): string {
+	let text = $derived.by(() => {
+		void tick;
 		if (distance) {
-			return short ? distanceShortText() : distanceText();
+			return distanceText();
 		}
 		return format(time, dateFormat, { locale: enGB });
-	}
+	});
 
-	let text: string = $state(getDisplayText());
+	let tooltipContent = $derived.by(() => {
+		void tick;
+		if (distance && !isRecent()) {
+			const relative = formatDistanceStrict(time, Date.now(), { addSuffix: true });
+			return `${fullTimestamp} (${relative})`;
+		}
+		return fullTimestamp;
+	});
+
 	let interval: ReturnType<typeof setTimeout> | undefined = $state();
 
 	onDestroy(() => {
@@ -67,8 +60,6 @@
 	});
 
 	$effect(() => {
-		text = getDisplayText();
-
 		if (!distance) {
 			if (interval) {
 				clearInterval(interval);
@@ -78,19 +69,23 @@
 		}
 
 		if (!interval) {
-			interval = setInterval(() => {
-				text = getDisplayText();
-			}, 1000);
+			interval = setInterval(
+				() => {
+					tick++;
+				},
+				isRecent() ? 1000 : 60_000
+			);
 		}
 	});
 
 	const datetime = $derived.by(() => {
-		// Houdini (pre-new-compiler) may pass Date scalars as strings. Normalize to Date first.
 		const d = time instanceof Date ? time : new Date(time as string);
 		return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
 	});
 </script>
 
-<time {datetime} {title}>
-	{text}
-</time>
+<Tooltip content={tooltipContent}>
+	<time {datetime}>
+		{text}
+	</time>
+</Tooltip>

--- a/src/lib/ui/Time.svelte
+++ b/src/lib/ui/Time.svelte
@@ -11,14 +11,14 @@
 		dateFormat = 'PPPP',
 		distance = false
 	}: {
-		time: Date;
+		time: Date | string;
 		dateFormat?: string;
 		distance?: boolean;
 	} = $props();
 
 	let tick = $state(0);
 
-	const normalizedTime = $derived(time instanceof Date ? time : new Date(time as string));
+	const normalizedTime = $derived(time instanceof Date ? time : new Date(time));
 	const isValidDate = $derived(!Number.isNaN(normalizedTime.getTime()));
 
 	let fullTimestamp = $derived(

--- a/src/lib/ui/Time.svelte
+++ b/src/lib/ui/Time.svelte
@@ -27,7 +27,7 @@
 
 	function isRecent(): boolean {
 		if (!isValidDate) return false;
-		return differenceInDays(new Date(), normalizedTime) < DISTANCE_THRESHOLD_DAYS;
+		return Math.abs(differenceInDays(new Date(), normalizedTime)) < DISTANCE_THRESHOLD_DAYS;
 	}
 
 	function distanceText(): string {

--- a/src/routes/team/[team]/[env]/bigquery/[bigquery]/+page.svelte
+++ b/src/routes/team/[team]/[env]/bigquery/[bigquery]/+page.svelte
@@ -40,11 +40,11 @@
 
 				<dl class="settings-list">
 					<dt>Created</dt>
-					<dd><Time time={bq.status.creationTime} /></dd>
+					<dd><Time time={bq.status.creationTime} distance /></dd>
 
 					<dt>Last modified</dt>
 					<dd>
-						<Time time={bq.status.lastModifiedTime || bq.status.creationTime} />
+						<Time time={bq.status.lastModifiedTime || bq.status.creationTime} distance />
 					</dd>
 
 					<dt>Cascading delete</dt>

--- a/src/routes/team/[team]/[env]/bigquery/[bigquery]/+page.svelte
+++ b/src/routes/team/[team]/[env]/bigquery/[bigquery]/+page.svelte
@@ -40,7 +40,7 @@
 
 				<dl class="settings-list">
 					<dt>Created</dt>
-					<dd><Time time={bq.status.creationTime} distance /></dd>
+					<dd><Time time={bq.status.creationTime} dateFormat="d MMM yyyy, HH:mm" /></dd>
 
 					<dt>Last modified</dt>
 					<dd>

--- a/src/routes/team/[team]/unleash/+page.svelte
+++ b/src/routes/team/[team]/unleash/+page.svelte
@@ -685,7 +685,7 @@
 										{extractVersion(channel.currentVersion)}
 										{#if channel.lastUpdated}
 											<br /><span class="channel-date"
-												><Time time={new Date(channel.lastUpdated)} /></span
+												><Time time={new Date(channel.lastUpdated)} distance /></span
 											>
 										{/if}
 									</Td>


### PR DESCRIPTION
## Summary

Addresses user feedback requesting actual timestamps instead of only "X days ago" in Deployments and Activity Log views.

Adopts a GitHub-style hybrid display for the `Time` component:
- **< 7 days**: relative time ("2 hours ago", "3 days ago")
- **≥ 7 days, same year**: actual date with time ("15 Jun, 14:30")
- **Different year**: date with year and time ("15 Jun 2025, 14:30")

Also replaces the native `title` attribute (invisible on mobile, not keyboard-accessible) with the design system `Tooltip` component.

## Changes

### `Time.svelte`
- Hybrid display logic with 7-day threshold
- `Tooltip` from `@nais/ds-svelte-community` replaces native `title`
- Tooltip shows full timestamp; for non-recent dates also includes relative time in parentheses
- Refactored to use tick-based `$derived` pattern (Svelte 5 best practice)
- Removed unused `short` prop and `distanceShortText` function
- Interval optimization: 1s tick for recent, 60s for non-recent

### Remove redundant Tooltip wrappers
- `AppListItem`, `JobListItem`, `ServiceAccountListItem`, `ServiceAccountDetail`, `ServiceAccountAuthentications` — removed outer `Tooltip` wrappers that caused double tooltips

### Normalize date formatting
- BigQuery and Unleash pages: switched to `distance` mode for "last modified" contexts
- `DeploymentWithTeamListItem` and `PostgresGrantAccessActivityLogEntryText`: switched from ambiguous `dd/MM/yyyy HH:mm` to unambiguous `d MMM yyyy, HH:mm`

## User feedback

> I visning av application under f.eks "Deployments" eller "Activity Log" så står det: "X days ago". Jeg synes dette er ganske et upraktisk format og hadde mye heller foretrukket timestamp. Nå må jeg trekke X antall dager fra dagens dato, og trykke på alle lenkene for den dagen for å finne en spesifikk hendelse.