### PR TITLE
Collapsible sidebar filters and responsive list pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,12 +249,62 @@ This project layers project-level design conventions on top of the `@nais/ds-sve
 
 Global utility classes defined in `src/styles/app.css` for common page patterns. **Use these instead of writing per-component layout CSS:**
 
-- `.layout-two-column` — two-column grid (`1fr 300px`) with `--spacing-layout` gap. Collapses to single column on mobile (`max-width: 767px`).
+- `.layout-two-column` — two-column grid (`1fr 300px`) with `--spacing-layout` gap. Collapses to single column at `≤1024px` (narrow desktop) and `≤767px` (mobile).
 - `.layout-sidebar` — grid with `--ax-space-24` gap, `align-content: start`. Use for the sidebar column inside `.layout-two-column`.
 - `.table-scroll` — horizontal scroll wrapper for wide tables. Wrap the `<Table>` with this instead of per-component overflow CSS.
 - `.detail-actions` — right-aligned flex row for action buttons above content (e.g., edit/delete buttons).
 - `.loading-centered` — centered flex container (300px height) for loading spinners.
 - `.settings-list` — grid-based `<dl>` for key-value pairs (`18ch` label column + `1fr` value column). Collapses to stacked layout on mobile. Bold `dt` with `--ax-text-neutral-subtle` color.
+- `.sidebar-toggle` — hidden by default, shown as `inline-flex` at `≤1024px`. Has `margin-left: auto` to stay right-aligned. Includes a chevron indicator via `::after`.
+
+### CollapsibleSidebar Pattern
+
+All list pages use `CollapsibleSidebar` (`$lib/ui/CollapsibleSidebar.svelte`) to handle filter visibility across breakpoints:
+
+- **Wide desktop (>1024px):** Filters display in the right sidebar column (`.desktop-only`).
+- **Narrow desktop / tablet (≤1024px):** Sidebar collapses. A "Filters" toggle button appears in the List header. Clicking it opens a right-side drawer overlay (uses `Modal`).
+- **Mobile (≤767px):** Same drawer behavior.
+
+#### Usage in list pages:
+
+```svelte
+<script lang="ts">
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
+	import { FunnelIcon } from '@nais/ds-svelte-community/icons';
+
+	let filtersOpen = $state(false);
+</script>
+
+<div class="layout-two-column">
+	<div>
+		<List title="Items" count={items.length}>
+			{#snippet actions()}
+				<!-- Other action buttons (Create, Add, etc.) go FIRST -->
+				<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+					Filters
+				</button>
+			{/snippet}
+			<!-- list items -->
+		</List>
+	</div>
+	<CollapsibleSidebar bind:open={filtersOpen}>
+		<SurfaceCard title="Filters">
+			<!-- filter components -->
+		</SurfaceCard>
+		{#snippet extras()}
+			<!-- Optional: TeamActivityCard or other sidebar content -->
+		{/snippet}
+	</CollapsibleSidebar>
+</div>
+```
+
+#### Rules:
+
+1. **Filters button is always last** in the `{#snippet actions()}` — keeps it consistently on the far right
+2. **`extras` snippet** is for content that shows in the sidebar on wide screens but below the list on narrow — never inside the drawer (e.g., TeamActivityCard)
+3. **Do not use `<div class="layout-sidebar">`** for filter sidebars on list pages — use `CollapsibleSidebar` instead
+4. **Container queries**: The `List` component's `.items` div has `container-type: inline-size`. Use `@container (max-width: 500px)` in list item components for reflow
 
 ### Surface System
 
@@ -357,8 +407,20 @@ The `layerchart.css` file has both a `:root` and a `.dark, .dark-theme` block wi
 
 ## Responsive UI / Mobile
 
+### Breakpoints
+
+| Breakpoint | Target                  | Behavior                                                             |
+| ---------- | ----------------------- | -------------------------------------------------------------------- |
+| `>1024px`  | Wide desktop            | Two-column layout, sidebar visible                                   |
+| `≤1024px`  | Narrow desktop / tablet | Single column, sidebar hidden, filter drawer via toggle button       |
+| `≤767px`   | Mobile                  | Single column, compact spacing, container query reflow on list items |
+
+### Guidelines
+
 - New pages and substantial page changes must work on narrow mobile widths, not just desktop layouts.
 - Use existing responsive patterns in the codebase before inventing route-specific mobile solutions.
+- List pages must use `CollapsibleSidebar` for their filter sidebar (see Design Guidelines above).
+- List item components should use `@container (max-width: 500px)` for reflow, not only `@media` queries — this responds to the actual list width, not viewport width.
 - For wide data tables, prefer a horizontal scroll wrapper around the desktop table before introducing a separate mobile card view.
 - Keep pagination outside horizontal scroll containers.
 - Avoid blanket `white-space: nowrap` and large fixed `min-width` rules across entire tables; let value-heavy columns wrap and keep only the columns that need it non-wrapping.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,12 @@ All list pages use `CollapsibleSidebar` (`$lib/ui/CollapsibleSidebar.svelte`) to
 		<List title="Items" count={items.length}>
 			{#snippet actions()}
 				<!-- Other action buttons (Create, Add, etc.) go FIRST -->
-				<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+				<button
+					type="button"
+					class="sidebar-toggle"
+					aria-expanded={filtersOpen}
+					onclick={() => (filtersOpen = !filtersOpen)}
+				>
 					<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 					Filters
 				</button>

--- a/src/lib/domain/list-items/AppListItem.svelte
+++ b/src/lib/domain/list-items/AppListItem.svelte
@@ -40,7 +40,7 @@
 	);
 </script>
 
-<ListItem interactive>
+<ListItem interactive href={appHref}>
 	<div class="app-row">
 		<div class="name-group">
 			{#if app.state === 'RUNNING'}
@@ -58,7 +58,7 @@
 					<span class="status-dot unknown"></span>
 				</Tooltip>
 			{/if}
-			<a href={appHref} class="app-name">{app.name}</a>
+			<span class="app-name">{app.name}</span>
 			<Tag size="xsmall" variant={envTagVariant(app.teamEnvironment.environment.name)}
 				>{app.teamEnvironment.environment.name}</Tag
 			>
@@ -158,10 +158,6 @@
 		flex: 0 1 auto;
 	}
 
-	.app-name:hover {
-		text-decoration: underline;
-	}
-
 	.issues-cell {
 		display: flex;
 		align-items: center;
@@ -182,6 +178,28 @@
 		display: inline-flex;
 		align-items: center;
 		gap: var(--ax-space-4);
+	}
+
+	@container (max-width: 500px) {
+		.app-row {
+			grid-template-columns: 1fr;
+			gap: var(--ax-space-8);
+		}
+
+		.name-group {
+			flex-wrap: wrap;
+		}
+
+		.app-name {
+			flex: 1 1 0;
+			width: auto;
+			min-width: 0;
+		}
+
+		.issues-cell,
+		.meta-cell {
+			justify-content: flex-start;
+		}
 	}
 
 	@media (max-width: 767px) {

--- a/src/lib/domain/list-items/JobListItem.svelte
+++ b/src/lib/domain/list-items/JobListItem.svelte
@@ -46,7 +46,7 @@
 	const lastRun = $derived(job.runs.edges.length ? job.runs.edges[0].node : null);
 </script>
 
-<ListItem interactive>
+<ListItem interactive href={jobHref}>
 	<div class="job-row">
 		<div class="name-group">
 			{#if job.state === JobState.RUNNING}
@@ -68,7 +68,7 @@
 					<span class="status-dot unknown"></span>
 				</Tooltip>
 			{/if}
-			<a href={jobHref} class="job-name">{job.name}</a>
+			<span class="job-name">{job.name}</span>
 			<Tag size="xsmall" variant={envTagVariant(job.teamEnvironment.environment.name)}
 				>{job.teamEnvironment.environment.name}</Tag
 			>
@@ -187,10 +187,6 @@
 		flex: 0 1 auto;
 	}
 
-	.job-name:hover {
-		text-decoration: underline;
-	}
-
 	.issues-cell {
 		display: flex;
 		align-items: center;
@@ -216,6 +212,28 @@
 	.run-status :global(svg) {
 		width: 16px;
 		height: 16px;
+	}
+
+	@container (max-width: 500px) {
+		.job-row {
+			grid-template-columns: 1fr;
+			gap: var(--ax-space-8);
+		}
+
+		.name-group {
+			flex-wrap: wrap;
+		}
+
+		.job-name {
+			flex: 1 1 0;
+			width: auto;
+			min-width: 0;
+		}
+
+		.issues-cell,
+		.meta-cell {
+			justify-content: flex-start;
+		}
 	}
 
 	@media (max-width: 767px) {

--- a/src/lib/domain/vulnerability/VulnerabilitySummaryMetrics.svelte
+++ b/src/lib/domain/vulnerability/VulnerabilitySummaryMetrics.svelte
@@ -30,7 +30,7 @@
 
 <div class="wrapper">
 	<div class="metrics">
-		<span class="metric critical">
+		<div class="metric critical">
 			<div class="metric-icon critical">
 				<VirusIcon />
 			</div>
@@ -38,9 +38,9 @@
 				<span class="metric-value">{numberFormatter(vulnerabilitySummary.critical)}</span>
 				<span class="metric-label">Critical</span>
 			</div>
-		</span>
+		</div>
 
-		<span class="metric high">
+		<div class="metric high">
 			<div class="metric-icon high">
 				<VirusIcon />
 			</div>
@@ -48,9 +48,9 @@
 				<span class="metric-value">{numberFormatter(vulnerabilitySummary.high)}</span>
 				<span class="metric-label">High</span>
 			</div>
-		</span>
+		</div>
 
-		<span class="metric medium">
+		<div class="metric medium">
 			<div class="metric-icon medium">
 				<VirusIcon />
 			</div>
@@ -58,9 +58,9 @@
 				<span class="metric-value">{numberFormatter(vulnerabilitySummary.medium)}</span>
 				<span class="metric-label">Medium</span>
 			</div>
-		</span>
+		</div>
 
-		<span class="metric low">
+		<div class="metric low">
 			<div class="metric-icon low">
 				<VirusIcon />
 			</div>
@@ -68,9 +68,9 @@
 				<span class="metric-value">{numberFormatter(vulnerabilitySummary.low)}</span>
 				<span class="metric-label">Low</span>
 			</div>
-		</span>
+		</div>
 
-		<span class="metric unassigned">
+		<div class="metric unassigned">
 			<div class="metric-icon unassigned">
 				<VirusIcon />
 			</div>
@@ -78,9 +78,9 @@
 				<span class="metric-value">{numberFormatter(vulnerabilitySummary.unassigned)}</span>
 				<span class="metric-label">Unassigned</span>
 			</div>
-		</span>
+		</div>
 
-		<span
+		<div
 			class="metric risk-score"
 			class:danger={vulnerabilitySummary.riskScore > 100}
 			class:success={vulnerabilitySummary.riskScore <= 100}
@@ -107,7 +107,7 @@
 				</span>
 				<span class="metric-label">Risk score</span>
 			</div>
-		</span>
+		</div>
 	</div>
 
 	<div class="footer">
@@ -134,13 +134,16 @@
 	}
 
 	.metric {
+		position: relative;
 		display: flex;
 		align-items: center;
 		gap: var(--ax-space-12);
 		padding: var(--ax-space-12);
 		border-radius: var(--ax-radius-8);
+		color: inherit;
 		background: color-mix(in srgb, var(--ax-bg-default) 82%, transparent);
 		box-shadow: 0 0 0 1px var(--ax-border-neutral-subtleA);
+		min-width: 0;
 	}
 
 	.metric-icon {
@@ -191,6 +194,12 @@
 		line-height: 1.2;
 	}
 
+	.metric-label {
+		font-size: var(--ax-font-size-small);
+		color: var(--ax-text-neutral-subtle);
+		white-space: nowrap;
+	}
+
 	.metric.critical .metric-value {
 		color: var(--ax-text-danger);
 	}
@@ -208,11 +217,6 @@
 	}
 
 	.metric.unassigned .metric-value {
-		color: var(--ax-text-neutral-subtle);
-	}
-
-	.metric-label {
-		font-size: var(--ax-font-size-small);
 		color: var(--ax-text-neutral-subtle);
 	}
 
@@ -242,9 +246,15 @@
 		color: var(--ax-text-neutral-subtle);
 	}
 
-	@media (max-width: 767px) {
+	@media (max-width: 767px), (max-height: 500px) {
 		.metrics {
 			grid-template-columns: 1fr 1fr;
+		}
+	}
+
+	@media (max-width: 480px) {
+		.metrics {
+			grid-template-columns: 1fr;
 		}
 	}
 </style>

--- a/src/lib/ui/CollapsibleSidebar.svelte
+++ b/src/lib/ui/CollapsibleSidebar.svelte
@@ -16,6 +16,9 @@
 
 	$effect(() => {
 		const mql = window.matchMedia('(min-width: 1025px)');
+		if (mql.matches) {
+			open = false;
+		}
 		const handler = (e: MediaQueryListEvent) => {
 			if (e.matches) {
 				open = false;

--- a/src/lib/ui/CollapsibleSidebar.svelte
+++ b/src/lib/ui/CollapsibleSidebar.svelte
@@ -14,13 +14,9 @@
 		label?: string;
 	} = $props();
 
-	let isDesktop = $state(false);
-
 	$effect(() => {
 		const mql = window.matchMedia('(min-width: 1025px)');
-		isDesktop = mql.matches;
 		const handler = (e: MediaQueryListEvent) => {
-			isDesktop = e.matches;
 			if (e.matches) {
 				open = false;
 			}
@@ -30,11 +26,12 @@
 	});
 </script>
 
-{#if isDesktop}
-	<div class="layout-sidebar desktop-only">
-		{@render children()}
-	</div>
-{/if}
+<div class="layout-sidebar desktop-only">
+	{@render children()}
+	{#if extras}
+		{@render extras()}
+	{/if}
+</div>
 
 {#if extras}
 	<div class="sidebar-extras">
@@ -42,7 +39,7 @@
 	</div>
 {/if}
 
-{#if !isDesktop}
+{#if open}
 	<Modal bind:open header={{ heading: label, size: 'small' }} class="filter-drawer">
 		<div class="drawer-content">
 			{@render children()}
@@ -53,14 +50,21 @@
 <style>
 	.desktop-only {
 		display: grid;
+		gap: var(--ax-space-16);
+		align-content: start;
 	}
 
 	.sidebar-extras {
-		grid-column: 2;
+		display: none;
 	}
 
 	@media (max-width: 1024px) {
+		.desktop-only {
+			display: none;
+		}
+
 		.sidebar-extras {
+			display: block;
 			grid-column: 1;
 		}
 	}

--- a/src/lib/ui/CollapsibleSidebar.svelte
+++ b/src/lib/ui/CollapsibleSidebar.svelte
@@ -15,6 +15,7 @@
 	} = $props();
 
 	$effect(() => {
+		if (typeof window === 'undefined') return;
 		const mql = window.matchMedia('(min-width: 1025px)');
 		if (mql.matches) {
 			open = false;
@@ -56,6 +57,7 @@
 
 	.sidebar-extras {
 		grid-column: 2;
+		margin-top: calc(var(--ax-space-16) - var(--spacing-layout));
 	}
 
 	@media (max-width: 1024px) {
@@ -65,6 +67,7 @@
 
 		.sidebar-extras {
 			grid-column: 1;
+			margin-top: 0;
 		}
 	}
 
@@ -140,12 +143,6 @@
 
 	@media (min-width: 1025px) {
 		:global(dialog.filter-drawer.aksel-modal) {
-			display: none;
-		}
-	}
-
-	@media (max-width: 1024px) {
-		.desktop-only {
 			display: none;
 		}
 	}

--- a/src/lib/ui/CollapsibleSidebar.svelte
+++ b/src/lib/ui/CollapsibleSidebar.svelte
@@ -13,6 +13,17 @@
 		open?: boolean;
 		label?: string;
 	} = $props();
+
+	$effect(() => {
+		const mql = window.matchMedia('(min-width: 1025px)');
+		const handler = (e: MediaQueryListEvent) => {
+			if (e.matches) {
+				open = false;
+			}
+		};
+		mql.addEventListener('change', handler);
+		return () => mql.removeEventListener('change', handler);
+	});
 </script>
 
 <div class="layout-sidebar desktop-only">

--- a/src/lib/ui/CollapsibleSidebar.svelte
+++ b/src/lib/ui/CollapsibleSidebar.svelte
@@ -14,9 +14,13 @@
 		label?: string;
 	} = $props();
 
+	let isDesktop = $state(false);
+
 	$effect(() => {
 		const mql = window.matchMedia('(min-width: 1025px)');
+		isDesktop = mql.matches;
 		const handler = (e: MediaQueryListEvent) => {
+			isDesktop = e.matches;
 			if (e.matches) {
 				open = false;
 			}
@@ -26,9 +30,11 @@
 	});
 </script>
 
-<div class="layout-sidebar desktop-only">
-	{@render children()}
-</div>
+{#if isDesktop}
+	<div class="layout-sidebar desktop-only">
+		{@render children()}
+	</div>
+{/if}
 
 {#if extras}
 	<div class="sidebar-extras">
@@ -36,11 +42,13 @@
 	</div>
 {/if}
 
-<Modal bind:open header={{ heading: label, size: 'small' }} class="filter-drawer">
-	<div class="drawer-content">
-		{@render children()}
-	</div>
-</Modal>
+{#if !isDesktop}
+	<Modal bind:open header={{ heading: label, size: 'small' }} class="filter-drawer">
+		<div class="drawer-content">
+			{@render children()}
+		</div>
+	</Modal>
+{/if}
 
 <style>
 	.desktop-only {

--- a/src/lib/ui/CollapsibleSidebar.svelte
+++ b/src/lib/ui/CollapsibleSidebar.svelte
@@ -31,9 +31,6 @@
 
 <div class="layout-sidebar desktop-only">
 	{@render children()}
-	{#if extras}
-		{@render extras()}
-	{/if}
 </div>
 
 {#if extras}
@@ -58,7 +55,7 @@
 	}
 
 	.sidebar-extras {
-		display: none;
+		grid-column: 2;
 	}
 
 	@media (max-width: 1024px) {
@@ -67,7 +64,6 @@
 		}
 
 		.sidebar-extras {
-			display: block;
 			grid-column: 1;
 		}
 	}

--- a/src/lib/ui/CollapsibleSidebar.svelte
+++ b/src/lib/ui/CollapsibleSidebar.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+	import { Modal } from '@nais/ds-svelte-community';
+	import type { Snippet } from 'svelte';
+
+	let {
+		children,
+		extras,
+		open = $bindable(false),
+		label = 'Filters'
+	}: {
+		children: Snippet;
+		extras?: Snippet;
+		open?: boolean;
+		label?: string;
+	} = $props();
+</script>
+
+<div class="layout-sidebar desktop-only">
+	{@render children()}
+</div>
+
+{#if extras}
+	<div class="sidebar-extras">
+		{@render extras()}
+	</div>
+{/if}
+
+<Modal bind:open header={{ heading: label, size: 'small' }} class="filter-drawer">
+	<div class="drawer-content">
+		{@render children()}
+	</div>
+</Modal>
+
+<style>
+	.desktop-only {
+		display: grid;
+	}
+
+	.sidebar-extras {
+		grid-column: 2;
+	}
+
+	@media (max-width: 1024px) {
+		.sidebar-extras {
+			grid-column: 1;
+		}
+	}
+
+	:global(dialog.filter-drawer.aksel-modal) {
+		inset: 0 0 0 auto;
+		margin: 0;
+		display: flex;
+		width: 320px;
+		max-width: calc(100vw - var(--ax-space-16));
+		max-height: 100dvh;
+		height: 100dvh;
+		flex-direction: column;
+		border: none;
+		border-radius: 0;
+		padding: 0;
+		background: var(--ax-bg-default);
+		box-shadow: -4px 0 24px rgb(15 23 42 / 0.16);
+		animation: filter-drawer-enter 160ms ease-out;
+	}
+
+	:global(dialog.filter-drawer::backdrop) {
+		background: rgb(15 23 42 / 0.38);
+		animation: filter-backdrop-enter 160ms ease-out;
+	}
+
+	:global(dialog.filter-drawer .aksel-modal__header) {
+		padding: var(--ax-space-16);
+		border-bottom: 1px solid var(--ax-border-neutral-subtleA);
+	}
+
+	:global(dialog.filter-drawer .aksel-modal__body) {
+		flex: 1;
+		min-height: 0;
+		padding: 0;
+		overflow-y: auto;
+	}
+
+	.drawer-content {
+		padding: var(--ax-space-16);
+		display: grid;
+		gap: var(--spacing-sidebar);
+		align-content: start;
+	}
+
+	@keyframes filter-drawer-enter {
+		from {
+			transform: translateX(24px);
+			opacity: 0;
+		}
+		to {
+			transform: translateX(0);
+			opacity: 1;
+		}
+	}
+
+	@keyframes filter-backdrop-enter {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		:global(dialog.filter-drawer.aksel-modal) {
+			animation: none;
+		}
+		:global(dialog.filter-drawer::backdrop) {
+			animation: none;
+		}
+	}
+
+	@media (min-width: 1025px) {
+		:global(dialog.filter-drawer.aksel-modal) {
+			display: none;
+		}
+	}
+
+	@media (max-width: 1024px) {
+		.desktop-only {
+			display: none;
+		}
+	}
+</style>

--- a/src/lib/ui/List.svelte
+++ b/src/lib/ui/List.svelte
@@ -87,7 +87,6 @@
 		justify-content: space-between;
 		align-items: center;
 		gap: var(--ax-space-16);
-		flex-wrap: wrap;
 	}
 
 	.header-left {
@@ -158,6 +157,7 @@
 	.items {
 		display: flex;
 		flex-direction: column;
+		container-type: inline-size;
 	}
 
 	.list.headerless .items {
@@ -172,9 +172,7 @@
 		}
 
 		.header-row {
-			flex-direction: column;
-			align-items: stretch;
-			gap: var(--ax-space-12);
+			flex-wrap: wrap;
 		}
 
 		.search-slot {

--- a/src/lib/ui/List.svelte
+++ b/src/lib/ui/List.svelte
@@ -93,7 +93,7 @@
 		display: flex;
 		align-items: center;
 		gap: var(--ax-space-8);
-		flex-shrink: 0;
+		min-width: 0;
 	}
 
 	.title {

--- a/src/lib/ui/ListItem.svelte
+++ b/src/lib/ui/ListItem.svelte
@@ -42,6 +42,13 @@
 		max-width: 100%;
 	}
 
+	@container (max-width: 500px) {
+		.list-item {
+			grid-auto-flow: row;
+			padding: var(--ax-space-12) var(--ax-space-16);
+		}
+	}
+
 	@media (max-width: 767px), (max-height: 500px) {
 		.list-item {
 			grid-auto-flow: row;

--- a/src/routes/team/[team]/activity-log/+page.svelte
+++ b/src/routes/team/[team]/activity-log/+page.svelte
@@ -3,15 +3,18 @@
 	import { type ActivityLogActivityType$options } from '$houdini';
 	import ActivityLogFacets from '$lib/domain/activity/ActivityLogFacets.svelte';
 	import ActivityLogItem from '$lib/domain/list-items/ActivityLogListItem.svelte';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import List from '$lib/ui/List.svelte';
 	import ListFilters from '$lib/ui/ListFilters.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
+	import { FunnelIcon } from '@nais/ds-svelte-community/icons';
 	import { tick } from 'svelte';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
+	let filtersOpen = $state(false);
 	let { ActivityLog } = $derived(data);
 
 	let selectedActivityTypes: ActivityLogActivityType$options[] = $derived(
@@ -94,6 +97,12 @@
 		<div class="layout-two-column">
 			<div bind:this={wrapperEl}>
 				<List title="Activity Log" count={ae.pageInfo.totalCount}>
+					{#snippet actions()}
+						<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+							<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+							Filters
+						</button>
+					{/snippet}
 					{#each ae.edges || [] as { node: item } (item.id)}
 						<ActivityLogItem {item} mode="full" />
 					{/each}
@@ -126,7 +135,7 @@
 			</div>
 
 			{#if ae.facets}
-				<div class="layout-sidebar">
+				<CollapsibleSidebar bind:open={filtersOpen}>
 					<SurfaceCard title="Filters">
 						<ListFilters>
 							<ActivityLogFacets
@@ -142,7 +151,7 @@
 							/>
 						</ListFilters>
 					</SurfaceCard>
-				</div>
+				</CollapsibleSidebar>
 			{/if}
 		</div>
 	{/if}

--- a/src/routes/team/[team]/activity-log/+page.svelte
+++ b/src/routes/team/[team]/activity-log/+page.svelte
@@ -98,7 +98,12 @@
 			<div bind:this={wrapperEl}>
 				<List title="Activity Log" count={ae.pageInfo.totalCount}>
 					{#snippet actions()}
-						<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<button
+							type="button"
+							class="sidebar-toggle"
+							aria-expanded={filtersOpen}
+							onclick={() => (filtersOpen = !filtersOpen)}
+						>
 							<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 							Filters
 						</button>

--- a/src/routes/team/[team]/activity-log/+page.svelte
+++ b/src/routes/team/[team]/activity-log/+page.svelte
@@ -98,15 +98,17 @@
 			<div bind:this={wrapperEl}>
 				<List title="Activity Log" count={ae.pageInfo.totalCount}>
 					{#snippet actions()}
-						<button
-							type="button"
-							class="sidebar-toggle"
-							aria-expanded={filtersOpen}
-							onclick={() => (filtersOpen = !filtersOpen)}
-						>
-							<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
-							Filters
-						</button>
+						{#if ae.facets}
+							<button
+								type="button"
+								class="sidebar-toggle"
+								aria-expanded={filtersOpen}
+								onclick={() => (filtersOpen = !filtersOpen)}
+							>
+								<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+								Filters
+							</button>
+						{/if}
 					{/snippet}
 					{#each ae.edges || [] as { node: item } (item.id)}
 						<ActivityLogItem {item} mode="full" />

--- a/src/routes/team/[team]/alerts/+page.svelte
+++ b/src/routes/team/[team]/alerts/+page.svelte
@@ -146,7 +146,12 @@
 	<div>
 		<List title="Alerts" count={alerts?.pageInfo.totalCount ?? 0}>
 			{#snippet actions()}
-				<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+				<button
+					type="button"
+					class="sidebar-toggle"
+					aria-expanded={filtersOpen}
+					onclick={() => (filtersOpen = !filtersOpen)}
+				>
 					<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 					Filters
 				</button>

--- a/src/routes/team/[team]/alerts/+page.svelte
+++ b/src/routes/team/[team]/alerts/+page.svelte
@@ -6,6 +6,7 @@
 	import CodeBlockPromQl from '$lib/domain/monitoring/CodeBlockPromQL.svelte';
 	import { formatSeconds } from '$lib/domain/vulnerability/dateUtils';
 	import { envTagVariant } from '$lib/envTagVariant';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import List from '$lib/ui/List.svelte';
 	import ListFilters from '$lib/ui/ListFilters.svelte';
@@ -14,12 +15,14 @@
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { CopyButton, Heading, Tag } from '@nais/ds-svelte-community';
-	import { ChevronRightIcon, ClockDashedIcon } from '@nais/ds-svelte-community/icons';
+	import { ChevronRightIcon, ClockDashedIcon, FunnelIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 	import PrometheusAlarmDetail from './PrometheusAlarmDetail.svelte';
 
 	let { data }: PageProps = $props();
 	let { Alerts, AlertsMetadata } = $derived(data);
+
+	let filtersOpen = $state(false);
 
 	let alerts = $derived($Alerts.data?.team.alerts);
 	let filter = $state($Alerts.variables?.filter?.name ?? '');
@@ -142,6 +145,12 @@
 <div class="layout-two-column">
 	<div>
 		<List title="Alerts" count={alerts?.pageInfo.totalCount ?? 0}>
+			{#snippet actions()}
+				<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+					Filters
+				</button>
+			{/snippet}
 			{#if alerts && alerts.edges.length > 0}
 				{#each alerts.edges as { node: alert } (alert.id)}
 					<details class="item">
@@ -232,7 +241,7 @@
 			}}
 		/>
 	</div>
-	<div class="layout-sidebar">
+	<CollapsibleSidebar bind:open={filtersOpen}>
 		<SurfaceCard title="Filters">
 			<ListFilters
 				{filter}
@@ -259,7 +268,7 @@
 				/>
 			</ListFilters>
 		</SurfaceCard>
-	</div>
+	</CollapsibleSidebar>
 </div>
 
 <style>

--- a/src/routes/team/[team]/applications/+page.svelte
+++ b/src/routes/team/[team]/applications/+page.svelte
@@ -135,7 +135,12 @@
 
 			<List title="Apps" count={apps?.pageInfo.totalCount ?? 0}>
 				{#snippet actions()}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/applications/+page.svelte
+++ b/src/routes/team/[team]/applications/+page.svelte
@@ -8,16 +8,20 @@
 	} from '$houdini';
 	import AppListItem from '$lib/domain/list-items/AppListItem.svelte';
 	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { BodyLong } from '@nais/ds-svelte-community';
+	import { FunnelIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
 	let { Applications, ApplicationsListMetadata } = $derived(data);
+
+	let filtersOpen = $state(false);
 
 	let filter = $state($Applications.variables?.filter?.name ?? '');
 
@@ -130,6 +134,12 @@
 			{@const apps = $Applications.data?.team.applications}
 
 			<List title="Apps" count={apps?.pageInfo.totalCount ?? 0}>
+				{#snippet actions()}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
+				{/snippet}
 				{#each apps?.edges ?? [] as { node: app } (app.id)}
 					<AppListItem {app} />
 				{/each}
@@ -149,7 +159,7 @@
 			<BodyLong><strong>No applications found.</strong></BodyLong>
 		{/if}
 	</div>
-	<div class="layout-sidebar">
+	<CollapsibleSidebar bind:open={filtersOpen}>
 		<SurfaceCard title="Filters">
 			<WorkloadListFilters
 				{filter}
@@ -176,7 +186,7 @@
 				onLabelsChange={handleLabelsChange}
 			/>
 		</SurfaceCard>
-	</div>
+	</CollapsibleSidebar>
 </div>
 
 <style>

--- a/src/routes/team/[team]/bigquery/+page.svelte
+++ b/src/routes/team/[team]/bigquery/+page.svelte
@@ -6,6 +6,7 @@
 	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
 	import BigQueryIcon from '$lib/icons/BigQueryIcon.svelte';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -14,6 +15,7 @@
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Tag } from '@nais/ds-svelte-community';
+	import { FunnelIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
 	type BigQueryOrderFieldOptions =
@@ -21,6 +23,7 @@
 	type OrderDirectionOptions = (typeof OrderDirection)[keyof typeof OrderDirection];
 
 	let { data }: PageProps = $props();
+	let filtersOpen = $state(false);
 	let { BigQuery } = $derived(data);
 
 	const sortFields: { value: BigQueryOrderFieldOptions; label: string }[] = [
@@ -73,6 +76,12 @@
 	<div class="layout-two-column">
 		<div>
 			<List title="BigQuery" count={$BigQuery.data.team.bigQueryDatasets.pageInfo.totalCount}>
+				{#snippet actions()}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
+				{/snippet}
 				{#each $BigQuery.data.team.bigQueryDatasets.edges as { node: instance } (instance.id)}
 					<ListItem interactive>
 						<div class="name-group">
@@ -126,7 +135,7 @@
 				}}
 			/>
 		</div>
-		<div class="layout-sidebar">
+		<CollapsibleSidebar bind:open={filtersOpen}>
 			<SurfaceCard title="Filters">
 				<WorkloadListFilters
 					{sortFields}
@@ -141,7 +150,7 @@
 					onLabelsChange={handleLabelsChange}
 				/>
 			</SurfaceCard>
-		</div>
+		</CollapsibleSidebar>
 	</div>
 
 	<style>

--- a/src/routes/team/[team]/bigquery/+page.svelte
+++ b/src/routes/team/[team]/bigquery/+page.svelte
@@ -83,14 +83,14 @@
 					</button>
 				{/snippet}
 				{#each $BigQuery.data.team.bigQueryDatasets.edges as { node: instance } (instance.id)}
-					<ListItem interactive>
+					<ListItem
+						interactive
+						href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
+							.name}/bigquery/{instance.name}"
+					>
 						<div class="name-group">
 							<BigQueryIcon style="font-size: 1.25rem; flex-shrink: 0" />
-							<a
-								href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
-									.name}/bigquery/{instance.name}"
-								class="item-name">{instance.name}</a
-							>
+							<span class="item-name">{instance.name}</span>
 							<Tag size="xsmall" variant={envTagVariant(instance.teamEnvironment.environment.name)}
 								>{instance.teamEnvironment.environment.name}</Tag
 							>

--- a/src/routes/team/[team]/bigquery/+page.svelte
+++ b/src/routes/team/[team]/bigquery/+page.svelte
@@ -77,7 +77,12 @@
 		<div>
 			<List title="BigQuery" count={$BigQuery.data.team.bigQueryDatasets.pageInfo.totalCount}>
 				{#snippet actions()}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/bigquery/+page.svelte
+++ b/src/routes/team/[team]/bigquery/+page.svelte
@@ -88,14 +88,14 @@
 					</button>
 				{/snippet}
 				{#each $BigQuery.data.team.bigQueryDatasets.edges as { node: instance } (instance.id)}
-					<ListItem
-						interactive
-						href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
-							.name}/bigquery/{instance.name}"
-					>
+					<ListItem interactive>
 						<div class="name-group">
 							<BigQueryIcon style="font-size: 1.25rem; flex-shrink: 0" />
-							<span class="item-name">{instance.name}</span>
+							<a
+								class="item-name"
+								href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
+									.name}/bigquery/{instance.name}">{instance.name}</a
+							>
 							<Tag size="xsmall" variant={envTagVariant(instance.teamEnvironment.environment.name)}
 								>{instance.teamEnvironment.environment.name}</Tag
 							>

--- a/src/routes/team/[team]/buckets/+page.svelte
+++ b/src/routes/team/[team]/buckets/+page.svelte
@@ -75,7 +75,12 @@
 		<div>
 			<List title="Buckets" count={$Buckets.data.team.buckets.pageInfo.totalCount}>
 				{#snippet actions()}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/buckets/+page.svelte
+++ b/src/routes/team/[team]/buckets/+page.svelte
@@ -5,6 +5,7 @@
 	import WorkloadLink from '$lib/domain/workload/WorkloadLink.svelte';
 	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -13,13 +14,14 @@
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Tag } from '@nais/ds-svelte-community';
-	import { BucketIcon } from '@nais/ds-svelte-community/icons';
+	import { BucketIcon, FunnelIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
 	type BucketOrderFieldOptions = (typeof BucketOrderField)[keyof typeof BucketOrderField];
 	type OrderDirectionOptions = (typeof OrderDirection)[keyof typeof OrderDirection];
 
 	let { data }: PageProps = $props();
+	let filtersOpen = $state(false);
 	let { Buckets } = $derived(data);
 
 	const sortFields: { value: BucketOrderFieldOptions; label: string }[] = [
@@ -72,6 +74,12 @@
 	<div class="layout-two-column">
 		<div>
 			<List title="Buckets" count={$Buckets.data.team.buckets.pageInfo.totalCount}>
+				{#snippet actions()}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
+				{/snippet}
 				{#each $Buckets.data.team.buckets.edges as { node: instance } (instance.id)}
 					<ListItem interactive>
 						<div class="name-group">
@@ -122,7 +130,7 @@
 				}}
 			/>
 		</div>
-		<div class="layout-sidebar">
+		<CollapsibleSidebar bind:open={filtersOpen}>
 			<SurfaceCard title="Filters">
 				<WorkloadListFilters
 					{sortFields}
@@ -137,7 +145,7 @@
 					onLabelsChange={handleLabelsChange}
 				/>
 			</SurfaceCard>
-		</div>
+		</CollapsibleSidebar>
 	</div>
 {/if}
 

--- a/src/routes/team/[team]/buckets/+page.svelte
+++ b/src/routes/team/[team]/buckets/+page.svelte
@@ -81,14 +81,14 @@
 					</button>
 				{/snippet}
 				{#each $Buckets.data.team.buckets.edges as { node: instance } (instance.id)}
-					<ListItem interactive>
+					<ListItem
+						interactive
+						href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
+							.name}/bucket/{instance.name}"
+					>
 						<div class="name-group">
 							<BucketIcon style="font-size: 1.25rem; flex-shrink: 0" />
-							<a
-								href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
-									.name}/bucket/{instance.name}"
-								class="item-name">{instance.name}</a
-							>
+							<span class="item-name">{instance.name}</span>
 							<Tag size="xsmall" variant={envTagVariant(instance.teamEnvironment.environment.name)}
 								>{instance.teamEnvironment.environment.name}</Tag
 							>

--- a/src/routes/team/[team]/buckets/+page.svelte
+++ b/src/routes/team/[team]/buckets/+page.svelte
@@ -86,14 +86,14 @@
 					</button>
 				{/snippet}
 				{#each $Buckets.data.team.buckets.edges as { node: instance } (instance.id)}
-					<ListItem
-						interactive
-						href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
-							.name}/bucket/{instance.name}"
-					>
+					<ListItem interactive>
 						<div class="name-group">
 							<BucketIcon style="font-size: 1.25rem; flex-shrink: 0" />
-							<span class="item-name">{instance.name}</span>
+							<a
+								class="item-name"
+								href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
+									.name}/bucket/{instance.name}">{instance.name}</a
+							>
 							<Tag size="xsmall" variant={envTagVariant(instance.teamEnvironment.environment.name)}
 								>{instance.teamEnvironment.environment.name}</Tag
 							>

--- a/src/routes/team/[team]/cloudsql/+page.svelte
+++ b/src/routes/team/[team]/cloudsql/+page.svelte
@@ -95,11 +95,7 @@
 					</button>
 				{/snippet}
 				{#each si.edges as { node: instance } (instance.id)}
-					<ListItem
-						interactive
-						href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
-							.name}/cloudsql/{instance.name}"
-					>
+					<ListItem interactive>
 						<div class="name-group">
 							<TooltipAlignHack
 								content={{
@@ -126,7 +122,11 @@
 									}[instance.state] ?? '--ax-bg-info-strong'}); font-size: 0.7rem"
 								/>
 							</TooltipAlignHack>
-							<span class="item-name">{instance.name}</span>
+							<a
+								class="item-name"
+								href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
+									.name}/cloudsql/{instance.name}">{instance.name}</a
+							>
 							<Tag size="xsmall" variant={envTagVariant(instance.teamEnvironment.environment.name)}
 								>{instance.teamEnvironment.environment.name}</Tag
 							>

--- a/src/routes/team/[team]/cloudsql/+page.svelte
+++ b/src/routes/team/[team]/cloudsql/+page.svelte
@@ -5,6 +5,7 @@
 	import IssueSeverityTags from '$lib/domain/issues/IssueSeverityTags.svelte';
 	import WorkloadLink from '$lib/domain/workload/WorkloadLink.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -16,13 +17,15 @@
 	import { countIssuesBySeverity } from '$lib/utils/issueCounts';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Loader, Tag } from '@nais/ds-svelte-community';
-	import { CircleFillIcon } from '@nais/ds-svelte-community/icons';
+	import { CircleFillIcon, FunnelIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
 	type SqlOrderFieldOptions = (typeof SqlInstanceOrderField)[keyof typeof SqlInstanceOrderField];
 	type OrderDirectionOptions = (typeof OrderDirection)[keyof typeof OrderDirection];
 
 	let { data }: PageProps = $props();
+
+	let filtersOpen = $state(false);
 
 	let { SqlInstances } = $derived(data);
 
@@ -80,6 +83,12 @@
 	<div class="layout-two-column">
 		<div>
 			<List title="Cloud SQL" count={si.pageInfo.totalCount}>
+				{#snippet actions()}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
+				{/snippet}
 				{#each si.edges as { node: instance } (instance.id)}
 					<ListItem interactive>
 						<div class="name-group">
@@ -162,7 +171,7 @@
 				}}
 			/>
 		</div>
-		<div class="layout-sidebar">
+		<CollapsibleSidebar bind:open={filtersOpen}>
 			<SurfaceCard title="Filters">
 				<ListFilters
 					{sortFields}
@@ -171,7 +180,7 @@
 					onSort={(field) => setSort(field as SqlOrderFieldOptions)}
 				/>
 			</SurfaceCard>
-		</div>
+		</CollapsibleSidebar>
 	</div>
 {/if}
 

--- a/src/routes/team/[team]/cloudsql/+page.svelte
+++ b/src/routes/team/[team]/cloudsql/+page.svelte
@@ -84,7 +84,12 @@
 		<div>
 			<List title="Cloud SQL" count={si.pageInfo.totalCount}>
 				{#snippet actions()}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/cloudsql/+page.svelte
+++ b/src/routes/team/[team]/cloudsql/+page.svelte
@@ -90,7 +90,11 @@
 					</button>
 				{/snippet}
 				{#each si.edges as { node: instance } (instance.id)}
-					<ListItem interactive>
+					<ListItem
+						interactive
+						href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
+							.name}/cloudsql/{instance.name}"
+					>
 						<div class="name-group">
 							<TooltipAlignHack
 								content={{
@@ -117,11 +121,7 @@
 									}[instance.state] ?? '--ax-bg-info-strong'}); font-size: 0.7rem"
 								/>
 							</TooltipAlignHack>
-							<a
-								href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
-									.name}/cloudsql/{instance.name}"
-								class="item-name">{instance.name}</a
-							>
+							<span class="item-name">{instance.name}</span>
 							<Tag size="xsmall" variant={envTagVariant(instance.teamEnvironment.environment.name)}
 								>{instance.teamEnvironment.environment.name}</Tag
 							>

--- a/src/routes/team/[team]/configs/+page.svelte
+++ b/src/routes/team/[team]/configs/+page.svelte
@@ -347,16 +347,16 @@
 		flex: 0 1 auto;
 	}
 
-	@container (max-width: 500px) {
+	@media (max-width: 767px), (max-height: 500px) {
 		.right {
-			align-items: flex-start;
+			align-items: flex-end;
 			margin-top: var(--ax-space-6);
 		}
 	}
 
-	@media (max-width: 767px), (max-height: 500px) {
+	@container (max-width: 500px) {
 		.right {
-			align-items: flex-end;
+			align-items: flex-start;
 			margin-top: var(--ax-space-6);
 		}
 	}

--- a/src/routes/team/[team]/configs/+page.svelte
+++ b/src/routes/team/[team]/configs/+page.svelte
@@ -5,6 +5,7 @@
 	import TeamActivityCard from '$lib/domain/activity/TeamActivityCard.svelte';
 	import LabelFacets from '$lib/domain/labels/LabelFacets.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -16,7 +17,7 @@
 	import { getConfigPermissions } from '$lib/utils/configPermissions';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Button, Detail, Tag } from '@nais/ds-svelte-community';
-	import { FileTextIcon, PlusIcon } from '@nais/ds-svelte-community/icons';
+	import { FileTextIcon, FunnelIcon, PlusIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 	import CreateConfig, { type EnvironmentType } from './CreateConfig.svelte';
 
@@ -125,6 +126,7 @@
 	}
 
 	let createConfigOpen = $state(false);
+	let filtersOpen = $state(false);
 
 	const environments = $derived.by(() => {
 		return (
@@ -167,16 +169,19 @@
 							Create Config
 						</Button>
 					{/if}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
 				{/snippet}
 				{#each configs.edges as { node: config } (config.id)}
-					<ListItem interactive>
+					<ListItem
+						interactive
+						href="/team/{teamSlug}/{config.teamEnvironment.environment.name}/config/{config.name}"
+					>
 						<div class="name-group">
 							<FileTextIcon style="font-size: 1.25rem; flex-shrink: 0" />
-							<a
-								href="/team/{teamSlug}/{config.teamEnvironment.environment
-									.name}/config/{config.name}"
-								class="item-name">{config.name}</a
-							>
+							<span class="item-name">{config.name}</span>
 							<Tag size="xsmall" variant={envTagVariant(config.teamEnvironment.environment.name)}
 								>{config.teamEnvironment.environment.name}</Tag
 							>
@@ -225,7 +230,20 @@
 				}}
 			/>
 		</div>
-		<div class="layout-sidebar" style="gap: var(--ax-space-16)">
+		<CollapsibleSidebar bind:open={filtersOpen}>
+			{#snippet extras()}
+				<TeamActivityCard
+					{teamSlug}
+					viewAllHref="/team/{teamSlug}/activity-log"
+					filter={{
+						activityTypes: [
+							ActivityLogActivityType.CONFIG_CREATED,
+							ActivityLogActivityType.CONFIG_UPDATED,
+							ActivityLogActivityType.CONFIG_DELETED
+						]
+					}}
+				/>
+			{/snippet}
 			<SurfaceCard title="Filters">
 				<ListFilters
 					{filter}
@@ -288,18 +306,7 @@
 					{/if}
 				</ListFilters>
 			</SurfaceCard>
-			<TeamActivityCard
-				{teamSlug}
-				viewAllHref="/team/{teamSlug}/activity-log"
-				filter={{
-					activityTypes: [
-						ActivityLogActivityType.CONFIG_CREATED,
-						ActivityLogActivityType.CONFIG_UPDATED,
-						ActivityLogActivityType.CONFIG_DELETED
-					]
-				}}
-			/>
-		</div>
+		</CollapsibleSidebar>
 	</div>
 	{#if createConfigOpen}
 		<CreateConfig team={teamSlug} bind:open={createConfigOpen} {environments} />
@@ -334,8 +341,12 @@
 		min-width: 0;
 		flex: 0 1 auto;
 	}
-	.item-name:hover {
-		text-decoration: underline;
+
+	@container (max-width: 500px) {
+		.right {
+			align-items: flex-start;
+			margin-top: var(--ax-space-6);
+		}
 	}
 
 	@media (max-width: 767px), (max-height: 500px) {

--- a/src/routes/team/[team]/configs/+page.svelte
+++ b/src/routes/team/[team]/configs/+page.svelte
@@ -169,7 +169,12 @@
 							Create Config
 						</Button>
 					{/if}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/issues/+page.svelte
+++ b/src/routes/team/[team]/issues/+page.svelte
@@ -120,7 +120,12 @@
 	<div>
 		<List title="Issues" count={issues?.pageInfo.totalCount ?? 0}>
 			{#snippet actions()}
-				<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+				<button
+					type="button"
+					class="sidebar-toggle"
+					aria-expanded={filtersOpen}
+					onclick={() => (filtersOpen = !filtersOpen)}
+				>
 					<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 					Filters
 				</button>

--- a/src/routes/team/[team]/issues/+page.svelte
+++ b/src/routes/team/[team]/issues/+page.svelte
@@ -3,6 +3,7 @@
 	import { IssueOrderField, IssueType, OrderDirection } from '$houdini';
 	import IssuesFacets from '$lib/domain/issues/IssuesFacets.svelte';
 	import IssueListItem from '$lib/domain/list-items/IssueListItem.svelte';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
 	import ListFilters from '$lib/ui/ListFilters.svelte';
@@ -10,10 +11,13 @@
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
+	import { FunnelIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
 	let { TeamIssues, TeamIssuesMetadata } = $derived(data);
+
+	let filtersOpen = $state(false);
 	let issues = $derived($TeamIssues.data?.team.issues);
 
 	let after: string = $derived($TeamIssues.variables?.after ?? '');
@@ -115,6 +119,12 @@
 <div class="layout-two-column">
 	<div>
 		<List title="Issues" count={issues?.pageInfo.totalCount ?? 0}>
+			{#snippet actions()}
+				<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+					Filters
+				</button>
+			{/snippet}
 			{#each issues?.edges ?? [] as { node: issue } (issue.id)}
 				<IssueListItem item={issue} />
 			{:else}
@@ -140,7 +150,7 @@
 			/>
 		{/if}
 	</div>
-	<div class="layout-sidebar">
+	<CollapsibleSidebar bind:open={filtersOpen}>
 		<SurfaceCard title="Filters">
 			<ListFilters
 				{sortFields}
@@ -161,7 +171,7 @@
 				/>
 			</ListFilters>
 		</SurfaceCard>
-	</div>
+	</CollapsibleSidebar>
 </div>
 
 <style>

--- a/src/routes/team/[team]/jobs/+page.svelte
+++ b/src/routes/team/[team]/jobs/+page.svelte
@@ -8,16 +8,20 @@
 	} from '$houdini';
 	import JobListItem from '$lib/domain/list-items/JobListItem.svelte';
 	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { BodyLong } from '@nais/ds-svelte-community';
+	import { FunnelIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
 	let { Jobs, JobsListMetadata } = $derived(data);
+
+	let filtersOpen = $state(false);
 
 	let filter = $state($Jobs.variables?.filter?.name ?? '');
 
@@ -131,6 +135,12 @@
 			{@const jobs = $Jobs.data?.team.jobs}
 
 			<List title="Jobs" count={jobs?.pageInfo.totalCount ?? 0}>
+				{#snippet actions()}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
+				{/snippet}
 				{#each jobs?.edges ?? [] as { node: job } (job.id)}
 					<JobListItem {job} />
 				{/each}
@@ -150,7 +160,7 @@
 			<BodyLong><strong>No jobs found.</strong></BodyLong>
 		{/if}
 	</div>
-	<div class="layout-sidebar">
+	<CollapsibleSidebar bind:open={filtersOpen}>
 		<SurfaceCard title="Filters">
 			<WorkloadListFilters
 				{filter}
@@ -177,7 +187,7 @@
 				onLabelsChange={handleLabelsChange}
 			/>
 		</SurfaceCard>
-	</div>
+	</CollapsibleSidebar>
 </div>
 
 <style>

--- a/src/routes/team/[team]/jobs/+page.svelte
+++ b/src/routes/team/[team]/jobs/+page.svelte
@@ -136,7 +136,12 @@
 
 			<List title="Jobs" count={jobs?.pageInfo.totalCount ?? 0}>
 				{#snippet actions()}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/kafka/+page.svelte
+++ b/src/routes/team/[team]/kafka/+page.svelte
@@ -92,7 +92,12 @@
 		<div>
 			<List title="Kafka" count={$KafkaTopics.data.team.kafkaTopics.pageInfo.totalCount}>
 				{#snippet actions()}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/kafka/+page.svelte
+++ b/src/routes/team/[team]/kafka/+page.svelte
@@ -5,6 +5,7 @@
 	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
 	import KafkaIcon from '$lib/icons/KafkaIcon.svelte';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -13,6 +14,7 @@
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Tag } from '@nais/ds-svelte-community';
+	import { FunnelIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
 	type KafkaTopicOrderFieldOptions =
@@ -20,6 +22,7 @@
 	type OrderDirectionOptions = (typeof OrderDirection)[keyof typeof OrderDirection];
 
 	let { data }: PageProps = $props();
+	let filtersOpen = $state(false);
 	let { KafkaTopics } = $derived(data);
 
 	const sortFields: { value: KafkaTopicOrderFieldOptions; label: string }[] = [
@@ -88,6 +91,12 @@
 	<div class="layout-two-column">
 		<div>
 			<List title="Kafka" count={$KafkaTopics.data.team.kafkaTopics.pageInfo.totalCount}>
+				{#snippet actions()}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
+				{/snippet}
 				{#each $KafkaTopics.data.team.kafkaTopics.edges as { node: instance } (instance.id)}
 					<ListItem interactive>
 						<div class="name-group">
@@ -133,7 +142,7 @@
 				}}
 			/>
 		</div>
-		<div class="layout-sidebar">
+		<CollapsibleSidebar bind:open={filtersOpen}>
 			<SurfaceCard title="Filters">
 				<WorkloadListFilters
 					{sortFields}
@@ -167,7 +176,7 @@
 					{/if}
 				</WorkloadListFilters>
 			</SurfaceCard>
-		</div>
+		</CollapsibleSidebar>
 	</div>
 
 	<style>

--- a/src/routes/team/[team]/kafka/+page.svelte
+++ b/src/routes/team/[team]/kafka/+page.svelte
@@ -98,14 +98,14 @@
 					</button>
 				{/snippet}
 				{#each $KafkaTopics.data.team.kafkaTopics.edges as { node: instance } (instance.id)}
-					<ListItem interactive>
+					<ListItem
+						interactive
+						href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
+							.name}/kafka/{instance.name}"
+					>
 						<div class="name-group">
 							<KafkaIcon style="font-size: 1.25rem; flex-shrink: 0" />
-							<a
-								href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
-									.name}/kafka/{instance.name}"
-								class="item-name">{instance.name}</a
-							>
+							<span class="item-name">{instance.name}</span>
 							<Tag size="xsmall" variant={envTagVariant(instance.teamEnvironment.environment.name)}
 								>{instance.teamEnvironment.environment.name}</Tag
 							>

--- a/src/routes/team/[team]/members/+page.svelte
+++ b/src/routes/team/[team]/members/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import { ActivityLogActivityType, graphql, OrderDirection, TeamMemberOrderField } from '$houdini';
 	import TeamActivityCard from '$lib/domain/activity/TeamActivityCard.svelte';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import Confirm from '$lib/ui/Confirm.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -11,12 +12,13 @@
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { BodyShort, Button, Heading } from '@nais/ds-svelte-community';
-	import { PencilIcon, PlusIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
+	import { FunnelIcon, PencilIcon, PlusIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 	import AddMember from './AddMember.svelte';
 	import EditMember from './EditMember.svelte';
 
 	let { data }: PageProps = $props();
+	let filtersOpen = $state(false);
 	let { Members, UserInfo, viewerIsOwner } = $derived(data);
 	let team = $derived($Members.data?.team);
 
@@ -111,6 +113,10 @@
 							icon={PlusIcon}>Add member</Button
 						>
 					{/if}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
 				{/snippet}
 				{#if $Members.data?.team.members.edges}
 					{#each $Members.data?.team.members.edges as edge (edge.node.user.id + edge.node.role)}
@@ -184,7 +190,7 @@
 				}}
 			/>
 		</div>
-		<div class="layout-sidebar" style="gap: var(--ax-space-16)">
+		<CollapsibleSidebar bind:open={filtersOpen}>
 			<SurfaceCard title="Filters">
 				<ListFilters
 					{sortFields}
@@ -193,18 +199,20 @@
 					onSort={(field) => setSort(field as TeamMemberOrderFieldOptions)}
 				/>
 			</SurfaceCard>
-			<TeamActivityCard
-				teamSlug={team.slug}
-				viewAllHref="/team/{team.slug}/activity-log"
-				filter={{
-					activityTypes: [
-						ActivityLogActivityType.TEAM_MEMBER_REMOVED,
-						ActivityLogActivityType.TEAM_MEMBER_ADDED,
-						ActivityLogActivityType.TEAM_MEMBER_SET_ROLE
-					]
-				}}
-			/>
-		</div>
+			{#snippet extras()}
+				<TeamActivityCard
+					teamSlug={team.slug}
+					viewAllHref="/team/{team.slug}/activity-log"
+					filter={{
+						activityTypes: [
+							ActivityLogActivityType.TEAM_MEMBER_REMOVED,
+							ActivityLogActivityType.TEAM_MEMBER_ADDED,
+							ActivityLogActivityType.TEAM_MEMBER_SET_ROLE
+						]
+					}}
+				/>
+			{/snippet}
+		</CollapsibleSidebar>
 	</div>
 	{#if team}
 		<AddMember bind:open={addMemberOpen} team={team.slug} oncreated={refetch} />

--- a/src/routes/team/[team]/members/+page.svelte
+++ b/src/routes/team/[team]/members/+page.svelte
@@ -113,7 +113,12 @@
 							icon={PlusIcon}>Add member</Button
 						>
 					{/if}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/opensearch/+page.svelte
+++ b/src/routes/team/[team]/opensearch/+page.svelte
@@ -5,6 +5,7 @@
 	import IssueSeverityTags from '$lib/domain/issues/IssueSeverityTags.svelte';
 	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -18,7 +19,7 @@
 	import { countIssuesBySeverity } from '$lib/utils/issueCounts';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Button, Tag } from '@nais/ds-svelte-community';
-	import { CircleFillIcon, PlusIcon } from '@nais/ds-svelte-community/icons';
+	import { CircleFillIcon, FunnelIcon, PlusIcon } from '@nais/ds-svelte-community/icons';
 	import CreatePage from '../opensearch/create/+page.svelte';
 	import type { PageProps } from './$types';
 
@@ -27,6 +28,7 @@
 	type OrderDirectionOptions = (typeof OrderDirection)[keyof typeof OrderDirection];
 
 	let { data }: PageProps = $props();
+	let filtersOpen = $state(false);
 	let { OpenSearch, viewerIsMember } = $derived(data);
 
 	const sortFields: { value: OpenSearchOrderFieldOptions; label: string }[] = [
@@ -122,6 +124,10 @@
 							{create.buttonText}
 						</Button>
 					{/if}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
 				{/snippet}
 				{#each $OpenSearch.data.team.openSearches.edges as { node: instance } (instance.id)}
 					<ListItem interactive>
@@ -207,7 +213,7 @@
 				}}
 			/>
 		</div>
-		<div class="layout-sidebar">
+		<CollapsibleSidebar bind:open={filtersOpen}>
 			<SurfaceCard title="Filters">
 				<WorkloadListFilters
 					{sortFields}
@@ -243,7 +249,7 @@
 					{/if}
 				</WorkloadListFilters>
 			</SurfaceCard>
-		</div>
+		</CollapsibleSidebar>
 	</div>
 
 	{#if create}

--- a/src/routes/team/[team]/opensearch/+page.svelte
+++ b/src/routes/team/[team]/opensearch/+page.svelte
@@ -124,7 +124,12 @@
 							{create.buttonText}
 						</Button>
 					{/if}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/opensearch/+page.svelte
+++ b/src/routes/team/[team]/opensearch/+page.svelte
@@ -130,7 +130,11 @@
 					</button>
 				{/snippet}
 				{#each $OpenSearch.data.team.openSearches.edges as { node: instance } (instance.id)}
-					<ListItem interactive>
+					<ListItem
+						interactive
+						href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
+							.name}/opensearch/{instance.name}"
+					>
 						<div class="name-group">
 							<TooltipAlignHack
 								content={{
@@ -159,11 +163,7 @@
 									/>
 								{/if}
 							</TooltipAlignHack>
-							<a
-								href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
-									.name}/opensearch/{instance.name}"
-								class="item-name">{instance.name}</a
-							>
+							<span class="item-name">{instance.name}</span>
 							<Tag size="xsmall" variant={envTagVariant(instance.teamEnvironment.environment.name)}
 								>{instance.teamEnvironment.environment.name}</Tag
 							>

--- a/src/routes/team/[team]/postgres/+page.svelte
+++ b/src/routes/team/[team]/postgres/+page.svelte
@@ -144,7 +144,11 @@
 					</button>
 				{/snippet}
 				{#each si.edges as { node: instance } (instance.id)}
-					<ListItem interactive>
+					<ListItem
+						interactive
+						href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
+							.name}/postgres/{instance.name}"
+					>
 						<div class="name-group">
 							<TooltipAlignHack
 								content={{
@@ -161,11 +165,7 @@
 									}[instance.state] ?? '--ax-bg-info-strong'}); font-size: 0.7rem"
 								/>
 							</TooltipAlignHack>
-							<a
-								href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
-									.name}/postgres/{instance.name}"
-								class="item-name">{instance.name}</a
-							>
+							<span class="item-name">{instance.name}</span>
 							<Tag size="xsmall" variant={envTagVariant(instance.teamEnvironment.environment.name)}
 								>{instance.teamEnvironment.environment.name}</Tag
 							>

--- a/src/routes/team/[team]/postgres/+page.svelte
+++ b/src/routes/team/[team]/postgres/+page.svelte
@@ -4,6 +4,7 @@
 	import { docURL } from '$lib/doc';
 	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -14,7 +15,7 @@
 	import { capitalizeFirstLetter } from '$lib/utils/formatters';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Alert, Loader, Tag } from '@nais/ds-svelte-community';
-	import { CircleFillIcon } from '@nais/ds-svelte-community/icons';
+	import { CircleFillIcon, FunnelIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
 	type PostgresOrderFieldOptions =
@@ -22,6 +23,8 @@
 	type OrderDirectionOptions = (typeof OrderDirection)[keyof typeof OrderDirection];
 
 	let { data }: PageProps = $props();
+
+	let filtersOpen = $state(false);
 
 	let { PostgresInstances } = $derived(data);
 
@@ -134,6 +137,12 @@
 			{@render cloudSqlRelocationAlert()}
 
 			<List title="Postgres" count={si.pageInfo.totalCount}>
+				{#snippet actions()}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
+				{/snippet}
 				{#each si.edges as { node: instance } (instance.id)}
 					<ListItem interactive>
 						<div class="name-group">
@@ -189,7 +198,7 @@
 				}}
 			/>
 		</div>
-		<div class="layout-sidebar">
+		<CollapsibleSidebar bind:open={filtersOpen}>
 			<SurfaceCard title="Filters">
 				<WorkloadListFilters
 					{sortFields}
@@ -248,7 +257,7 @@
 					{/if}
 				</WorkloadListFilters>
 			</SurfaceCard>
-		</div>
+		</CollapsibleSidebar>
 	</div>
 {/if}
 

--- a/src/routes/team/[team]/postgres/+page.svelte
+++ b/src/routes/team/[team]/postgres/+page.svelte
@@ -138,7 +138,12 @@
 
 			<List title="Postgres" count={si.pageInfo.totalCount}>
 				{#snippet actions()}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/repositories/+page.svelte
+++ b/src/routes/team/[team]/repositories/+page.svelte
@@ -3,6 +3,7 @@
 	import { ActivityLogActivityType, graphql, OrderDirection, RepositoryOrderField } from '$houdini';
 	import TeamActivityCard from '$lib/domain/activity/TeamActivityCard.svelte';
 	import GitHubIcon from '$lib/icons/GitHubIcon.svelte';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -12,11 +13,12 @@
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Alert, Button, Detail, Heading, Modal, TextField } from '@nais/ds-svelte-community';
-	import { PlusIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
+	import { FunnelIcon, PlusIcon, TrashIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
 
+	let filtersOpen = $state(false);
 	let { Repositories, teamSlug, viewerIsMember } = $derived(data);
 
 	type RepositoryOrderFieldOptions =
@@ -177,6 +179,10 @@
 								Add Repository
 							</Button>
 						{/if}
+						<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+							<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+							Filters
+						</button>
 					{/snippet}
 					{#each team.repositories.edges as { node: repo } (repo.id)}
 						<ListItem interactive>
@@ -218,7 +224,7 @@
 				/>
 			{/if}
 		</div>
-		<div class="layout-sidebar">
+		<CollapsibleSidebar bind:open={filtersOpen}>
 			<SurfaceCard title="Filters">
 				<ListFilters
 					{filter}
@@ -236,17 +242,19 @@
 					onSort={(field) => setSort(field as RepositoryOrderFieldOptions)}
 				/>
 			</SurfaceCard>
-			<TeamActivityCard
-				{teamSlug}
-				viewAllHref="/team/{teamSlug}/activity-log"
-				filter={{
-					activityTypes: [
-						ActivityLogActivityType.REPOSITORY_ADDED,
-						ActivityLogActivityType.REPOSITORY_REMOVED
-					]
-				}}
-			/>
-		</div>
+			{#snippet extras()}
+				<TeamActivityCard
+					{teamSlug}
+					viewAllHref="/team/{teamSlug}/activity-log"
+					filter={{
+						activityTypes: [
+							ActivityLogActivityType.REPOSITORY_ADDED,
+							ActivityLogActivityType.REPOSITORY_REMOVED
+						]
+					}}
+				/>
+			{/snippet}
+		</CollapsibleSidebar>
 	</div>
 
 	<Modal bind:open={addModalOpen} width="small" onclose={() => (addModalOpen = false)}>

--- a/src/routes/team/[team]/repositories/+page.svelte
+++ b/src/routes/team/[team]/repositories/+page.svelte
@@ -179,7 +179,12 @@
 								Add Repository
 							</Button>
 						{/if}
-						<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<button
+							type="button"
+							class="sidebar-toggle"
+							aria-expanded={filtersOpen}
+							onclick={() => (filtersOpen = !filtersOpen)}
+						>
 							<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 							Filters
 						</button>

--- a/src/routes/team/[team]/secrets/+page.svelte
+++ b/src/routes/team/[team]/secrets/+page.svelte
@@ -5,6 +5,7 @@
 	import TeamActivityCard from '$lib/domain/activity/TeamActivityCard.svelte';
 	import LabelFacets from '$lib/domain/labels/LabelFacets.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -16,7 +17,7 @@
 	import { changeParams } from '$lib/utils/searchparams';
 	import { getSecretPermissions } from '$lib/utils/secretPermissions';
 	import { Button, Detail, Tag } from '@nais/ds-svelte-community';
-	import { PadlockLockedIcon, PlusIcon } from '@nais/ds-svelte-community/icons';
+	import { FunnelIcon, PadlockLockedIcon, PlusIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 	import CreateSecret, { type EnvironmentType } from './CreateSecret.svelte';
 
@@ -125,6 +126,7 @@
 	}
 
 	let createSecretOpen = $state(false);
+	let filtersOpen = $state(false);
 
 	const environments = $derived.by(() => {
 		return (
@@ -167,16 +169,19 @@
 							Create Secret
 						</Button>
 					{/if}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
 				{/snippet}
 				{#each secrets.edges as { node: secret } (secret.id)}
-					<ListItem interactive>
+					<ListItem
+						interactive
+						href="/team/{teamSlug}/{secret.teamEnvironment.environment.name}/secret/{secret.name}"
+					>
 						<div class="name-group">
 							<PadlockLockedIcon style="font-size: 1.25rem; flex-shrink: 0" />
-							<a
-								href="/team/{teamSlug}/{secret.teamEnvironment.environment
-									.name}/secret/{secret.name}"
-								class="item-name">{secret.name}</a
-							>
+							<span class="item-name">{secret.name}</span>
 							<Tag size="xsmall" variant={envTagVariant(secret.teamEnvironment.environment.name)}
 								>{secret.teamEnvironment.environment.name}</Tag
 							>
@@ -225,7 +230,24 @@
 				}}
 			/>
 		</div>
-		<div class="layout-sidebar" style="gap: var(--ax-space-16)">
+		<CollapsibleSidebar bind:open={filtersOpen}>
+			{#snippet extras()}
+				<TeamActivityCard
+					{teamSlug}
+					viewAllHref="/team/{teamSlug}/activity-log"
+					filter={{
+						activityTypes: [
+							ActivityLogActivityType.SECRET_CREATED,
+							ActivityLogActivityType.SECRET_UPDATED,
+							ActivityLogActivityType.SECRET_VALUE_ADDED,
+							ActivityLogActivityType.SECRET_VALUE_UPDATED,
+							ActivityLogActivityType.SECRET_VALUE_REMOVED,
+							ActivityLogActivityType.SECRET_DELETED,
+							ActivityLogActivityType.SECRET_VALUES_VIEWED
+						]
+					}}
+				/>
+			{/snippet}
 			<SurfaceCard title="Filters">
 				<ListFilters
 					{filter}
@@ -288,22 +310,7 @@
 					{/if}
 				</ListFilters>
 			</SurfaceCard>
-			<TeamActivityCard
-				{teamSlug}
-				viewAllHref="/team/{teamSlug}/activity-log"
-				filter={{
-					activityTypes: [
-						ActivityLogActivityType.SECRET_CREATED,
-						ActivityLogActivityType.SECRET_UPDATED,
-						ActivityLogActivityType.SECRET_VALUE_ADDED,
-						ActivityLogActivityType.SECRET_VALUE_UPDATED,
-						ActivityLogActivityType.SECRET_VALUE_REMOVED,
-						ActivityLogActivityType.SECRET_DELETED,
-						ActivityLogActivityType.SECRET_VALUES_VIEWED
-					]
-				}}
-			/>
-		</div>
+		</CollapsibleSidebar>
 	</div>
 	{#if createSecretOpen}
 		<CreateSecret team={teamSlug} bind:open={createSecretOpen} {environments} />
@@ -316,6 +323,13 @@
 		flex-direction: column;
 		align-items: end;
 		gap: var(--ax-space-2);
+	}
+
+	@container (max-width: 500px) {
+		.right {
+			align-items: flex-start;
+			margin-top: var(--ax-space-6);
+		}
 	}
 
 	@media (max-width: 767px), (max-height: 500px) {
@@ -344,8 +358,5 @@
 		text-overflow: ellipsis;
 		min-width: 0;
 		flex: 0 1 auto;
-	}
-	.item-name:hover {
-		text-decoration: underline;
 	}
 </style>

--- a/src/routes/team/[team]/secrets/+page.svelte
+++ b/src/routes/team/[team]/secrets/+page.svelte
@@ -169,7 +169,12 @@
 							Create Secret
 						</Button>
 					{/if}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/secrets/+page.svelte
+++ b/src/routes/team/[team]/secrets/+page.svelte
@@ -330,16 +330,16 @@
 		gap: var(--ax-space-2);
 	}
 
-	@container (max-width: 500px) {
+	@media (max-width: 767px), (max-height: 500px) {
 		.right {
-			align-items: flex-start;
+			align-items: flex-end;
 			margin-top: var(--ax-space-6);
 		}
 	}
 
-	@media (max-width: 767px), (max-height: 500px) {
+	@container (max-width: 500px) {
 		.right {
-			align-items: flex-end;
+			align-items: flex-start;
 			margin-top: var(--ax-space-6);
 		}
 	}

--- a/src/routes/team/[team]/valkey/+page.svelte
+++ b/src/routes/team/[team]/valkey/+page.svelte
@@ -129,7 +129,11 @@
 					</button>
 				{/snippet}
 				{#each $Valkeys.data.team.valkeys.edges as { node: instance } (instance.id)}
-					<ListItem interactive>
+					<ListItem
+						interactive
+						href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
+							.name}/valkey/{instance.name}"
+					>
 						<div class="name-group">
 							<TooltipAlignHack
 								content={{
@@ -158,11 +162,7 @@
 									/>
 								{/if}
 							</TooltipAlignHack>
-							<a
-								href="/team/{instance.team.slug}/{instance.teamEnvironment.environment
-									.name}/valkey/{instance.name}"
-								class="item-name">{instance.name}</a
-							>
+							<span class="item-name">{instance.name}</span>
 							<Tag size="xsmall" variant={envTagVariant(instance.teamEnvironment.environment.name)}
 								>{instance.teamEnvironment.environment.name}</Tag
 							>

--- a/src/routes/team/[team]/valkey/+page.svelte
+++ b/src/routes/team/[team]/valkey/+page.svelte
@@ -5,6 +5,7 @@
 	import IssueSeverityTags from '$lib/domain/issues/IssueSeverityTags.svelte';
 	import WorkloadListFilters from '$lib/domain/workload/WorkloadListFilters.svelte';
 	import { envTagVariant } from '$lib/envTagVariant';
+	import CollapsibleSidebar from '$lib/ui/CollapsibleSidebar.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import List from '$lib/ui/List.svelte';
@@ -18,7 +19,7 @@
 	import { countIssuesBySeverity } from '$lib/utils/issueCounts';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { Button, Tag } from '@nais/ds-svelte-community';
-	import { CircleFillIcon, PlusIcon } from '@nais/ds-svelte-community/icons';
+	import { CircleFillIcon, FunnelIcon, PlusIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 	import CreatePage from './create/+page.svelte';
 
@@ -26,6 +27,7 @@
 	type OrderDirectionOptions = (typeof OrderDirection)[keyof typeof OrderDirection];
 
 	let { data }: PageProps = $props();
+	let filtersOpen = $state(false);
 	let { Valkeys, viewerIsMember } = $derived(data);
 
 	const sortFields: { value: ValkeyOrderFieldOptions; label: string }[] = [
@@ -121,6 +123,10 @@
 							{create.buttonText}
 						</Button>
 					{/if}
+					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
+						Filters
+					</button>
 				{/snippet}
 				{#each $Valkeys.data.team.valkeys.edges as { node: instance } (instance.id)}
 					<ListItem interactive>
@@ -207,7 +213,7 @@
 				}}
 			/>
 		</div>
-		<div class="layout-sidebar">
+		<CollapsibleSidebar bind:open={filtersOpen}>
 			<SurfaceCard title="Filters">
 				<WorkloadListFilters
 					{sortFields}
@@ -243,7 +249,7 @@
 					{/if}
 				</WorkloadListFilters>
 			</SurfaceCard>
-		</div>
+		</CollapsibleSidebar>
 	</div>
 
 	{#if create}

--- a/src/routes/team/[team]/valkey/+page.svelte
+++ b/src/routes/team/[team]/valkey/+page.svelte
@@ -123,7 +123,12 @@
 							{create.buttonText}
 						</Button>
 					{/if}
-					<button class="sidebar-toggle" onclick={() => (filtersOpen = !filtersOpen)}>
+					<button
+						type="button"
+						class="sidebar-toggle"
+						aria-expanded={filtersOpen}
+						onclick={() => (filtersOpen = !filtersOpen)}
+					>
 						<FunnelIcon aria-hidden="true" style="font-size: 1rem" />
 						Filters
 					</button>

--- a/src/routes/team/[team]/vulnerabilities/+page.svelte
+++ b/src/routes/team/[team]/vulnerabilities/+page.svelte
@@ -54,6 +54,7 @@
 <style>
 	.wrapper {
 		display: grid;
+		grid-template-columns: minmax(0, 1fr);
 		gap: var(--ax-space-32);
 		min-width: 0;
 	}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -153,6 +153,12 @@ html {
 	align-items: start;
 }
 
+@media (max-width: 1024px) and (min-width: 768px) {
+	.layout-two-column {
+		grid-template-columns: 1fr;
+	}
+}
+
 .filter-section {
 	display: flex;
 	flex-direction: column;
@@ -364,6 +370,47 @@ html {
 
 	.layout-sidebar {
 		order: -1;
+	}
+}
+
+.sidebar-toggle {
+	display: none;
+	align-items: center;
+	gap: var(--ax-space-6);
+	margin-left: auto;
+	padding: var(--ax-space-8) var(--ax-space-12);
+	border-radius: var(--ax-radius-8);
+	border: 1px solid var(--ax-border-neutral-subtleA);
+	background: var(--ax-bg-default);
+	color: var(--ax-text-neutral);
+	font-size: var(--ax-font-size-small);
+	font-weight: 500;
+	cursor: pointer;
+	transition: background-color 120ms ease;
+}
+
+.sidebar-toggle:hover {
+	background: var(--ax-neutral-200);
+}
+
+.sidebar-toggle::after {
+	content: '';
+	width: 0.4em;
+	height: 0.4em;
+	border-right: 2px solid currentColor;
+	border-bottom: 2px solid currentColor;
+	transform: rotate(45deg);
+	transition: transform 150ms ease;
+	flex-shrink: 0;
+}
+
+.sidebar-toggle[aria-expanded='true']::after {
+	transform: rotate(-135deg);
+}
+
+@media (max-width: 1024px) {
+	.sidebar-toggle {
+		display: inline-flex;
 	}
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -59,7 +59,7 @@
 	}
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 1025px) {
 	/* Desktop and beyond */
 	:root {
 		--spacing-layout: var(--ax-space-40);


### PR DESCRIPTION
## Summary

Add a collapsible filter sidebar pattern to all list pages. On wide desktop (>1024px) filters show in the right sidebar column. On narrower viewports (≤1024px) the sidebar collapses and a "Filters" toggle button appears in the list header, opening a right-side drawer overlay.

## Changes

### Core components
- **CollapsibleSidebar.svelte** — new component handling desktop sidebar + drawer overlay
- **List.svelte** — add container-type: inline-size for container queries; fix mobile header layout
- **ListItem.svelte** — support href prop for WCAG-compliant keyboard navigation; add @container reflow
- **app.css** — add .sidebar-toggle styles, update .layout-two-column breakpoint to collapse at 1024px

### List pages updated (16 pages)
All team list pages now use CollapsibleSidebar:
- applications, jobs, secrets, configs, alerts, issues
- cloudsql, postgres, buckets, kafka, bigquery
- valkey, opensearch, members, repositories, activity-log

### List item improvements
- AppListItem and JobListItem use ListItem interactive href for proper <a> semantics
- Container query reflow at @container (max-width: 500px)

### Vulnerability summary metrics
- Fix responsive layout with minmax(0, 1fr) on page wrapper
- Match Team Health pattern with min-width: 0 on metric cells
- Breakpoints: 3 cols (wide) → 2 cols (≤767px) → 1 col (≤480px)

### Documentation
- Updated AGENTS.md with CollapsibleSidebar usage pattern and responsive breakpoint system

## Breakpoints

| Width | Behavior |
|-------|----------|
| >1024px | Two-column layout, filters in sidebar |
| ≤1024px | Single column, filters in drawer overlay |
| ≤767px | Mobile compact spacing, container query reflow |