### PR TITLE
fix: service account detail page polish

### DIFF
--- a/src/lib/domain/service-accounts/ServiceAccountAuthentications.svelte
+++ b/src/lib/domain/service-accounts/ServiceAccountAuthentications.svelte
@@ -94,7 +94,7 @@
 	<GraphErrors errors={removeErrors} dismissable />
 
 	{#if totalMethods > 0}
-		<List title="{totalMethods} authentication method{totalMethods !== 1 ? 's' : ''}" level="h4">
+		<List>
 			{#each $data.workloadBindings.edges as { node: binding } (binding.id)}
 				<ListItem>
 					<IconLabel

--- a/src/lib/domain/service-accounts/ServiceAccountAuthentications.svelte
+++ b/src/lib/domain/service-accounts/ServiceAccountAuthentications.svelte
@@ -89,119 +89,118 @@
 	const totalMethods = $derived($data.workloadBindings.edges.length + $data.tokens.edges.length);
 </script>
 
-<section aria-labelledby="auth-methods-heading">
-	<Heading size="small" as="h3" id="auth-methods-heading">Authentication methods</Heading>
+<section aria-label="Authentication methods">
 	<GraphErrors errors={removeErrors} dismissable />
 
-	{#if totalMethods > 0}
-		<List>
-			{#each $data.workloadBindings.edges as { node: binding } (binding.id)}
-				<ListItem>
-					<IconLabel
-						size="medium"
-						label={binding.workload?.name ?? binding.workloadName}
-						icon={LinkIcon}
-						tag={{
-							label: binding.workload?.teamEnvironment.environment.name ?? binding.environment,
-							variant: envTagVariant(
-								binding.workload?.teamEnvironment.environment.name ?? binding.environment
-							)
-						}}
-						description="Workload binding · {binding.workload?.__typename === 'Application'
-							? 'Application'
-							: binding.workload?.__typename === 'Job'
-								? 'Job'
-								: 'Workload'} · {binding.workload?.team?.slug ?? binding.teamSlug}{binding.isBroken
-							? ' · Broken'
-							: ''}"
-					/>
+	<List title="Authentication methods" count={totalMethods} level="h3" size="small">
+		{#each $data.workloadBindings.edges as { node: binding } (binding.id)}
+			<ListItem>
+				<IconLabel
+					size="medium"
+					label={binding.workload?.name ?? binding.workloadName}
+					icon={LinkIcon}
+					tag={{
+						label: binding.workload?.teamEnvironment.environment.name ?? binding.environment,
+						variant: envTagVariant(
+							binding.workload?.teamEnvironment.environment.name ?? binding.environment
+						)
+					}}
+					description="Workload binding · {binding.workload?.__typename === 'Application'
+						? 'Application'
+						: binding.workload?.__typename === 'Job'
+							? 'Job'
+							: 'Workload'} · {binding.workload?.team?.slug ?? binding.teamSlug}{binding.isBroken
+						? ' · Broken'
+						: ''}"
+				/>
 
-					<div class="right">
-						<div class="meta">
-							{#if binding.lastUsedAt}
-								<Detail>
-									Last used <Time time={binding.lastUsedAt} distance={true} />
-								</Detail>
-							{:else}
-								<Detail>Never used</Detail>
-							{/if}
+				<div class="right">
+					<div class="meta">
+						{#if binding.lastUsedAt}
 							<Detail>
-								Created <Time time={binding.createdAt} distance={true} />
+								Last used <Time time={binding.lastUsedAt} distance={true} />
 							</Detail>
-						</div>
-						{#if canManage}
-							<Button
-								size="xsmall"
-								variant="tertiary-neutral"
-								aria-label="Remove binding for {binding.workload?.name ?? binding.workloadName}"
-								onclick={() => {
-									bindingToRemove = {
-										id: binding.id,
-										workloadName: binding.workload?.name ?? binding.workloadName,
-										environment:
-											binding.workload?.teamEnvironment.environment.name ?? binding.environment
-									};
-									removeBindingOpen = true;
-								}}
-							>
-								{#snippet icon()}<TrashIcon
-										style="color:var(--ax-text-danger-decoration)"
-									/>{/snippet}
-							</Button>
+						{:else}
+							<Detail>Never used</Detail>
+						{/if}
+						<Detail>
+							Created <Time time={binding.createdAt} distance={true} />
+						</Detail>
+					</div>
+					{#if canManage}
+						<Button
+							size="xsmall"
+							variant="tertiary-neutral"
+							aria-label="Remove binding for {binding.workload?.name ?? binding.workloadName}"
+							onclick={() => {
+								bindingToRemove = {
+									id: binding.id,
+									workloadName: binding.workload?.name ?? binding.workloadName,
+									environment:
+										binding.workload?.teamEnvironment.environment.name ?? binding.environment
+								};
+								removeBindingOpen = true;
+							}}
+						>
+							{#snippet icon()}<TrashIcon
+									style="color:var(--ax-text-danger-decoration)"
+								/>{/snippet}
+						</Button>
+					{/if}
+				</div>
+			</ListItem>
+		{/each}
+
+		{#each $data.tokens.edges as { node: token } (token.id)}
+			<ListItem>
+				<IconLabel
+					size="medium"
+					label={token.name}
+					icon={TokenIcon}
+					description="API Token · {token.description}"
+				/>
+
+				<div class="right">
+					<div class="meta">
+						{#if token.lastUsedAt}
+							<Detail>
+								Last used <Time time={token.lastUsedAt} distance={true} />
+							</Detail>
+						{:else}
+							<Detail>Never used</Detail>
+						{/if}
+						<Detail>
+							Created <Time time={token.createdAt} distance={true} />
+						</Detail>
+						{#if token.expiresAt}
+							<Detail>
+								Expires <Time time={token.expiresAt} distance={true} />
+							</Detail>
 						{/if}
 					</div>
-				</ListItem>
-			{/each}
+					{#if canManage}
+						<Button
+							size="xsmall"
+							variant="tertiary-neutral"
+							aria-label="Delete token {token.name}"
+							onclick={() => {
+								tokenToDelete = { id: token.id, name: token.name };
+								deleteTokenOpen = true;
+							}}
+						>
+							{#snippet icon()}<TrashIcon
+									style="color:var(--ax-text-danger-decoration)"
+								/>{/snippet}
+						</Button>
+					{/if}
+				</div>
+			</ListItem>
+		{/each}
 
-			{#each $data.tokens.edges as { node: token } (token.id)}
-				<ListItem>
-					<IconLabel
-						size="medium"
-						label={token.name}
-						icon={TokenIcon}
-						description="API Token · {token.description}"
-					/>
-
-					<div class="right">
-						<div class="meta">
-							{#if token.lastUsedAt}
-								<Detail>
-									Last used <Time time={token.lastUsedAt} distance={true} />
-								</Detail>
-							{:else}
-								<Detail>Never used</Detail>
-							{/if}
-							<Detail>
-								Created <Time time={token.createdAt} distance={true} />
-							</Detail>
-							{#if token.expiresAt}
-								<Detail>
-									Expires <Time time={token.expiresAt} distance={true} />
-								</Detail>
-							{/if}
-						</div>
-						{#if canManage}
-							<Button
-								size="xsmall"
-								variant="tertiary-neutral"
-								aria-label="Delete token {token.name}"
-								onclick={() => {
-									tokenToDelete = { id: token.id, name: token.name };
-									deleteTokenOpen = true;
-								}}
-							>
-								{#snippet icon()}<TrashIcon
-										style="color:var(--ax-text-danger-decoration)"
-									/>{/snippet}
-							</Button>
-						{/if}
-					</div>
-				</ListItem>
-			{/each}
-		</List>
-	{:else}
-		<p>No authentication methods configured.</p>
-	{/if}
+		{#if totalMethods === 0}
+			<ListItem>No authentication methods configured.</ListItem>
+		{/if}
+	</List>
 </section>
 
 <Confirm

--- a/src/lib/domain/service-accounts/ServiceAccountDetail.svelte
+++ b/src/lib/domain/service-accounts/ServiceAccountDetail.svelte
@@ -16,7 +16,7 @@
 		ActionMenuItem
 	} from '@nais/ds-svelte-community/experimental';
 	import {
-		BranchingIcon,
+		LinkIcon,
 		MenuElipsisVerticalIcon,
 		PencilIcon,
 		ShieldLockIcon,
@@ -151,7 +151,7 @@
 						href="{basePath}/{serviceAccount.id}/binding/add"
 						onclick={pageModalClick}
 					>
-						<ActionMenuItem icon={BranchingIcon}>Add workload binding</ActionMenuItem>
+						<ActionMenuItem icon={LinkIcon}>Add workload binding</ActionMenuItem>
 					</a>
 					<ActionMenuDivider />
 					<button class="action-menu-button" onclick={() => (deleteServiceAccountOpen = true)}>
@@ -162,6 +162,7 @@
 				</ActionMenu>
 			{/if}
 		</div>
+
 		<dl class="settings-list">
 			<dt>Description</dt>
 			<dd>

--- a/src/lib/domain/service-accounts/ServiceAccountDetail.svelte
+++ b/src/lib/domain/service-accounts/ServiceAccountDetail.svelte
@@ -9,7 +9,7 @@
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import { pageModalClick } from '$lib/ui/PageModal.svelte';
 	import Time from '$lib/ui/Time.svelte';
-	import { BodyLong, Button, Heading, Modal, Textarea } from '@nais/ds-svelte-community';
+	import { Button, Heading, Modal, Textarea } from '@nais/ds-svelte-community';
 	import {
 		ActionMenu,
 		ActionMenuDivider,
@@ -162,25 +162,25 @@
 				</ActionMenu>
 			{/if}
 		</div>
-		<BodyLong>
-			{#if editingDescription}
-				<div class="edit-description">
-					<Textarea size="small" label="Description" hideLabel bind:value={newDescription} />
-					<div class="edit-actions">
-						<Button size="xsmall" onclick={saveDescription}>Save</Button>
-						<Button
-							size="xsmall"
-							variant="secondary-neutral"
-							onclick={() => (editingDescription = false)}>Cancel</Button
-						>
-					</div>
-				</div>
-			{:else}
-				{serviceAccount.description}
-			{/if}
-		</BodyLong>
-
 		<dl class="settings-list">
+			<dt>Description</dt>
+			<dd>
+				{#if editingDescription}
+					<div class="edit-description">
+						<Textarea size="small" label="Description" hideLabel bind:value={newDescription} />
+						<div class="edit-actions">
+							<Button size="xsmall" onclick={saveDescription}>Save</Button>
+							<Button
+								size="xsmall"
+								variant="secondary-neutral"
+								onclick={() => (editingDescription = false)}>Cancel</Button
+							>
+						</div>
+					</div>
+				{:else}
+					{serviceAccount.description}
+				{/if}
+			</dd>
 			<dt>Created</dt>
 			<dd>
 				<Time time={serviceAccount.createdAt} distance={true} />

--- a/src/lib/domain/service-accounts/ServiceAccountDetail.svelte
+++ b/src/lib/domain/service-accounts/ServiceAccountDetail.svelte
@@ -233,7 +233,6 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--ax-space-32);
-		max-width: 900px;
 	}
 
 	section {

--- a/src/lib/ui/List.svelte
+++ b/src/lib/ui/List.svelte
@@ -6,6 +6,7 @@
 		count,
 		headerless = false,
 		level = 'h2',
+		size = 'medium',
 		children,
 		menu,
 		search,
@@ -16,6 +17,7 @@
 		count?: number;
 		headerless?: boolean;
 		level?: 'h1' | 'h2' | 'h3' | 'h4';
+		size?: 'medium' | 'small';
 		children: Snippet;
 		menu?: Snippet;
 		search?: Snippet;
@@ -30,7 +32,9 @@
 			<div class="header-row">
 				<div class="header-left">
 					{#if title}
-						<svelte:element this={level} class="title">{title}</svelte:element>
+						<svelte:element this={level} class="title" class:small={size === 'small'}
+							>{title}</svelte:element
+						>
 					{/if}
 					{#if count !== undefined}
 						<span class="count-badge">{count}</span>
@@ -101,6 +105,13 @@
 		font-weight: 600;
 		margin: 0;
 		color: var(--ax-text-neutral);
+	}
+
+	.title.small {
+		font-size: var(--ax-font-size-heading-small);
+		line-height: var(--ax-font-line-height-heading-small);
+		letter-spacing: -0.001em;
+		font-weight: var(--ax-font-weight-bold);
 	}
 
 	.count-badge {

--- a/src/routes/team/[team]/settings/service_accounts/[serviceAccountID]/+layout.ts
+++ b/src/routes/team/[team]/settings/service_accounts/[serviceAccountID]/+layout.ts
@@ -6,7 +6,8 @@ export async function load(event) {
 			event,
 			variables: {
 				id: event.params.serviceAccountID
-			}
+			},
+			blocking: true
 		}))
 	};
 }

--- a/src/routes/team/[team]/settings/service_accounts/[serviceAccountID]/+page.svelte
+++ b/src/routes/team/[team]/settings/service_accounts/[serviceAccountID]/+page.svelte
@@ -4,7 +4,6 @@
 	import ServiceAccountDetail from '$lib/domain/service-accounts/ServiceAccountDetail.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import PageModal from '$lib/ui/PageModal.svelte';
-	import { ChevronLeftIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 	import AddBindingPage from './binding/add/+page.svelte';
 	import CreateTokenPage from './token/create/+page.svelte';
@@ -27,11 +26,6 @@
 	});
 </script>
 
-<a href="/team/{teamSlug}/settings/service_accounts" class="back-link">
-	<ChevronLeftIcon aria-hidden="true" />
-	Service Accounts
-</a>
-
 <GraphErrors errors={$query.errors} />
 {#if serviceAccount}
 	<ServiceAccountDetail
@@ -47,20 +41,3 @@
 {:else if page.state.modalHref?.includes('/token/create')}
 	<PageModal content={CreateTokenPage} header="Create API token" />
 {/if}
-
-<style>
-	.back-link {
-		display: inline-flex;
-		align-items: center;
-		gap: var(--ax-space-4);
-		font-size: var(--ax-font-size-small);
-		color: var(--ax-text-subtle);
-		text-decoration: none;
-		margin-bottom: var(--ax-space-16);
-	}
-
-	.back-link:hover {
-		color: var(--ax-text-neutral);
-		text-decoration: underline;
-	}
-</style>

--- a/src/routes/team/[team]/settings/service_accounts/[serviceAccountID]/+page.ts
+++ b/src/routes/team/[team]/settings/service_accounts/[serviceAccountID]/+page.ts
@@ -1,10 +1,16 @@
 import { addPageMeta } from '$lib/utils/pageMeta';
+import { get } from 'svelte/store';
+import type { PageLoad } from './$types';
 
-export async function load(event) {
+export async function load(event: Parameters<PageLoad>[0]) {
+	const { ServiceAccountDetail } = await event.parent();
+	const name = get(ServiceAccountDetail)?.data?.serviceAccount?.name ?? 'Service Account';
+
 	return {
 		...(await addPageMeta(event, {
-			title: 'Service Account',
+			title: name,
 			pageHeaderTitle: 'Team Settings',
+			docPath: '/operate/console/api/#service-accounts',
 			breadcrumbs: [
 				{
 					label: 'Team Settings',


### PR DESCRIPTION
## What

Follow-up polish for the service account detail page after #509.

## Changes

- **Remove redundant back-link** — the breadcrumb already provides navigation
- **Show description in details list** — moves description into the `<dl>` for consistent layout
- **Breadcrumb** — use actual service account name instead of generic "Service Account"
- **Docs link** — add `docPath` for the service account page
- **Remove duplicate title** — authentication methods section no longer repeats the heading
- **LinkIcon in action menu** — use `LinkIcon` for "Add workload binding" (matches the list items)