### PR TITLE
bump pnpm to 11.8.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION="24"
 FROM node:${NODE_VERSION}-alpine AS node-with-deps
-RUN corepack enable && corepack prepare pnpm@11.3.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.8.0 --activate
 WORKDIR /usr/app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml svelte.config.js .npmrc ./
@@ -15,7 +15,7 @@ RUN pnpm run build
 
 FROM node:${NODE_VERSION}-alpine
 RUN apk upgrade --no-cache
-RUN corepack enable && corepack prepare pnpm@11.3.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.8.0 --activate
 WORKDIR /usr/app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Align Dockerfile pnpm version with package.json (was 11.3.0). Rebuild with fresh node:24-alpine to resolve 93 vulnerabilities from VDR report (CVE-2026-34182, CVE-2026-25547, etc.).