### PR TITLE
remove npm from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,21 @@ ENV VITE_GRAPHQL_ENDPOINT=http://nais-api/graphql
 
 RUN pnpm run build
 
-FROM node:${NODE_VERSION}-alpine
-RUN apk upgrade --no-cache
+FROM node:${NODE_VERSION}-alpine AS prod-deps
 RUN corepack enable && corepack prepare pnpm@11.8.0 --activate
 WORKDIR /usr/app
-
-ENV NODE_ENV=production
 
 COPY --from=node-with-deps /usr/app/package.json /usr/app/pnpm-lock.yaml /usr/app/pnpm-workspace.yaml /usr/app/.npmrc ./
 RUN pnpm install --frozen-lockfile --prod
 
+FROM node:${NODE_VERSION}-alpine
+RUN apk upgrade --no-cache && \
+	rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+WORKDIR /usr/app
+
+ENV NODE_ENV=production
+
+COPY --from=prod-deps /usr/app/node_modules ./node_modules
 COPY --from=node-with-deps /usr/app/build ./
 
 CMD ["node", "./index.js"]


### PR DESCRIPTION
npm is unused at runtime (we use pnpm). Removing it eliminates the last 2 vulnerabilities (GHSA-3ppc-4f35-3m26, GHSA-23c5-xmqv-rm74) in minimatch@9.0.5 bundled via npm's node-gyp.