### PR TITLE
fix: add missing optional chaining for AppLayout and JobLayout

### DIFF
--- a/src/routes/team/[team]/[env]/app/[app]/+layout.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/+layout.svelte
@@ -8,7 +8,7 @@
 	let { data, children }: LayoutProps = $props();
 	let { AppLayout, viewerIsMember } = $derived(data);
 
-	let app = $derived($AppLayout.data?.team?.environment?.application ?? null);
+	let app = $derived($AppLayout?.data?.team?.environment?.application ?? null);
 
 	let routeId = $derived(page.route.id ?? '');
 	let tabs = $derived([

--- a/src/routes/team/[team]/[env]/job/[job]/+layout.svelte
+++ b/src/routes/team/[team]/[env]/job/[job]/+layout.svelte
@@ -7,7 +7,7 @@
 
 	let { data, children }: LayoutProps = $props();
 	let { JobLayout, viewerIsMember } = $derived(data);
-	let job = $derived($JobLayout.data?.team?.environment?.job ?? null);
+	let job = $derived($JobLayout?.data?.team?.environment?.job ?? null);
 
 	let routeId = $derived(page.route.id ?? '');
 	let tabs = $derived([


### PR DESCRIPTION
This fixes navigation from an app or job to other linked resources (e.g. configs, secrets, etc)