### PR TITLE
fix: CollapsibleSidebar layout and Time SSR hydration

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,6 @@
 pin = true
 [tools]
 node = "24.11.1"
-pnpm = "11.8.0"
+pnpm = "11.9.0"
 go = "1.26.3"
 "go:github.com/sethvargo/ratchet" = "0.11.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION="24"
 FROM node:${NODE_VERSION}-alpine AS node-with-deps
-RUN corepack enable && corepack prepare pnpm@11.8.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
 WORKDIR /usr/app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml svelte.config.js .npmrc ./
@@ -14,7 +14,7 @@ ENV VITE_GRAPHQL_ENDPOINT=http://nais-api/graphql
 RUN pnpm run build
 
 FROM node:${NODE_VERSION}-alpine AS prod-deps
-RUN corepack enable && corepack prepare pnpm@11.8.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
 WORKDIR /usr/app
 
 COPY --from=node-with-deps /usr/app/package.json /usr/app/pnpm-lock.yaml /usr/app/pnpm-workspace.yaml /usr/app/.npmrc ./

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "console-frontend",
 	"version": "0.0.1",
 	"private": true,
-	"packageManager": "pnpm@11.8.0",
+	"packageManager": "pnpm@11.9.0",
 	"scripts": {
 		"build": "vite build",
 		"check-outdated": "pnpm outdated",

--- a/schema.graphql
+++ b/schema.graphql
@@ -368,10 +368,22 @@ input ActivityLogFilter {
   environments: [String!]
 
   """
+  Only include entries created at or after this timestamp.
+  When combined with other fields in this input, entries must match this filter as well as the other selected filters.
+  """
+  from: Time
+
+  """
   Only include entries for resources whose type matches one of these values.
   When combined with other fields in this input, entries must match this filter as well as the other selected filters.
   """
   resourceTypes: [ActivityLogEntryResourceType!]
+
+  """
+  Only include entries created before this timestamp.
+  When combined with other fields in this input, entries must match this filter as well as the other selected filters.
+  """
+  to: Time
 }
 
 """A single facet item for resource types."""
@@ -5681,6 +5693,28 @@ type PrometheusAlert implements Alert & Node {
 
 """The query root for the Nais GraphQL API."""
 type Query {
+  """Activity log across all teams in the tenant."""
+  activityLog(
+    """Get items after this cursor."""
+    after: Cursor
+
+    """Get items before this cursor."""
+    before: Cursor
+
+    """Filter items."""
+    filter: ActivityLogFilter
+
+    """
+    Get the first n items in the connection. This can be used in combination with the after parameter.
+    """
+    first: Int
+
+    """
+    Get the last n items in the connection. This can be used in combination with the before parameter.
+    """
+    last: Int
+  ): ActivityLogEntryConnection!
+
   """Get the monthly cost summary for a tenant."""
   costMonthlySummary(
     """Start month of the period, inclusive."""
@@ -7547,11 +7581,6 @@ type ServiceAccountUpdatedActivityLogEntryDataUpdatedField {
 """
 A binding between a Nais service account and a Nais workload (application or job). When the workload presents its
 Workload Token to the API, the API will authenticate the request as the bound service account.
-
-The binding is identified at authentication time by the workload's environment, team and name, plus the Workload
-UID once it has been observed (trust on first use). If the UID changes (for instance because the workload has
-been recreated), the binding is considered broken and authentication will fail until the binding is removed and
-re-added.
 """
 type ServiceAccountWorkloadBinding implements Node {
   """When the binding was created."""
@@ -7564,8 +7593,7 @@ type ServiceAccountWorkloadBinding implements Node {
   id: ID!
 
   """
-  True if the binding is broken — either the workload no longer exists, or the Workload UID
-  does not match the value pinned to the binding.
+  True if the binding is broken, i.e. when the workload no longer exists.
   """
   isBroken: Boolean!
 

--- a/src/lib/ui/CollapsibleSidebar.svelte
+++ b/src/lib/ui/CollapsibleSidebar.svelte
@@ -30,15 +30,17 @@
 	});
 </script>
 
-<div class="layout-sidebar desktop-only">
-	{@render children()}
-</div>
-
-{#if extras}
-	<div class="sidebar-extras">
-		{@render extras()}
+<div class="sidebar-column">
+	<div class="layout-sidebar desktop-only">
+		{@render children()}
 	</div>
-{/if}
+
+	{#if extras}
+		<div class="sidebar-extras">
+			{@render extras()}
+		</div>
+	{/if}
+</div>
 
 {#if open}
 	<Modal bind:open header={{ heading: label, size: 'small' }} class="filter-drawer">
@@ -49,25 +51,22 @@
 {/if}
 
 <style>
+	.sidebar-column {
+		display: flex;
+		flex-direction: column;
+		gap: var(--ax-space-16);
+		align-self: start;
+	}
+
 	.desktop-only {
 		display: grid;
 		gap: var(--ax-space-16);
 		align-content: start;
 	}
 
-	.sidebar-extras {
-		grid-column: 2;
-		margin-top: calc(var(--ax-space-16) - var(--spacing-layout));
-	}
-
 	@media (max-width: 1024px) {
 		.desktop-only {
 			display: none;
-		}
-
-		.sidebar-extras {
-			grid-column: 1;
-			margin-top: 0;
 		}
 	}
 

--- a/src/lib/ui/Time.svelte
+++ b/src/lib/ui/Time.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { Tooltip } from '@nais/ds-svelte-community';
 	import { differenceInDays, format, formatDistanceStrict, isSameYear } from 'date-fns';
 	import { enGB } from 'date-fns/locale';
 	import { onDestroy } from 'svelte';
@@ -99,14 +98,6 @@
 	const datetime = $derived(isValidDate ? normalizedTime.toISOString() : undefined);
 </script>
 
-{#if tooltipContent}
-	<Tooltip content={tooltipContent}>
-		<time {datetime}>
-			{text}
-		</time>
-	</Tooltip>
-{:else}
-	<time {datetime}>
-		{text}
-	</time>
-{/if}
+<time {datetime} title={tooltipContent || undefined}>
+	{text}
+</time>


### PR DESCRIPTION
## What

Two layout/rendering fixes plus housekeeping.

### CollapsibleSidebar extras pushed below main content

`CollapsibleSidebar` rendered filters and extras as separate grid children inside `.layout-two-column`. The extras (e.g. activity log on `/team/[team]/members`) ended up in a new grid row that only started after the tall member list, pushing the activity card far below. 

Fixed by wrapping both in a single `.sidebar-column` flex container so they share one grid cell and stack naturally in the sidebar. On narrow screens the filters are still hidden while extras remain visible.

### Time component SSR hydration mismatch

`Time` wrapped its `<time>` element in `Tooltip` (which renders a `<div>`). When `Time` was placed inside `Detail` (which renders a `<p>`), this created invalid `<div>`-inside-`<p>` nesting, causing the browser to repair the DOM and trigger `hydration_mismatch` warnings.

Fixed by replacing `Tooltip` with a native `title` attribute on the `<time>` element.

### Housekeeping

- Bump pnpm 11.8.0 → 11.9.0
- Update schema.graphql