### PR TITLE
fix: handle WorkloadProblemIssue and UnleashReleaseChannelIssue in issue lists

### DIFF
--- a/src/lib/domain/issues/CriticalIssueRow.svelte
+++ b/src/lib/domain/issues/CriticalIssueRow.svelte
@@ -110,6 +110,18 @@
 							name
 						}
 					}
+					... on WorkloadProblemIssue {
+						workload {
+							__typename
+							name
+						}
+						problemType
+					}
+					... on UnleashReleaseChannelIssue {
+						unleash {
+							name
+						}
+					}
 				}
 			`)
 		)
@@ -154,6 +166,10 @@
 			const v = d.valkey as { name: string };
 			return { name: v.name, type: 'other', href: `/team/${team}/${env}/valkey/${v.name}` };
 		}
+		if ('unleash' in d && d.unleash) {
+			const u = d.unleash as { name: string };
+			return { name: u.name, type: 'other', href: `/team/${team}/${env}/unleash/${u.name}` };
+		}
 		return { name: 'Unknown', type: 'other', href: null };
 	}
 
@@ -172,7 +188,9 @@
 			OpenSearchIssue: 'OpenSearch issue',
 			SqlInstanceStateIssue: 'Database unhealthy',
 			SqlInstanceVersionIssue: 'Outdated database version',
-			ValkeyIssue: 'Valkey issue'
+			ValkeyIssue: 'Valkey issue',
+			WorkloadProblemIssue: 'Workload problem',
+			UnleashReleaseChannelIssue: 'Unleash release channel'
 		};
 		return map[typename] ?? typename;
 	}

--- a/src/lib/domain/issues/CriticalIssueRow.svelte
+++ b/src/lib/domain/issues/CriticalIssueRow.svelte
@@ -115,7 +115,6 @@
 							__typename
 							name
 						}
-						problemType
 					}
 					... on UnleashReleaseChannelIssue {
 						unleash {
@@ -168,7 +167,7 @@
 		}
 		if ('unleash' in d && d.unleash) {
 			const u = d.unleash as { name: string };
-			return { name: u.name, type: 'other', href: `/team/${team}/${env}/unleash/${u.name}` };
+			return { name: u.name, type: 'other', href: `/team/${team}/unleash` };
 		}
 		return { name: 'Unknown', type: 'other', href: null };
 	}

--- a/src/lib/domain/list-items/IssueListItem.svelte
+++ b/src/lib/domain/list-items/IssueListItem.svelte
@@ -133,7 +133,6 @@
 							__typename
 							name
 						}
-						problemType
 					}
 					... on UnleashReleaseChannelIssue {
 						unleash {
@@ -164,8 +163,7 @@
 		if ('valkey' in d && d.valkey) return ValkeyIcon;
 		if ('unleash' in d && d.unleash) return UnleashIcon;
 		if ('job' in d && d.job) return BriefcaseClockIcon;
-		if ('workload' in d && d.workload && d.workload.__typename === 'NaisJob')
-			return BriefcaseClockIcon;
+		if ('workload' in d && d.workload && d.workload.__typename === 'Job') return BriefcaseClockIcon;
 		return PackageIcon;
 	});
 

--- a/src/lib/domain/list-items/IssueListItem.svelte
+++ b/src/lib/domain/list-items/IssueListItem.svelte
@@ -2,6 +2,7 @@
 	import { fragment, graphql, type IssueFragment } from '$houdini';
 	import { envTagVariant } from '$lib/envTagVariant';
 	import OpenSearchIcon from '$lib/icons/OpenSearchIcon.svelte';
+	import UnleashIcon from '$lib/icons/UnleashIcon.svelte';
 	import ValkeyIcon from '$lib/icons/ValkeyIcon.svelte';
 	import CriticalIndicator from '$lib/ui/CriticalIndicator.svelte';
 	import { issueTypeLabel } from '$lib/utils/issueTypeLabel';
@@ -127,6 +128,18 @@
 							name
 						}
 					}
+					... on WorkloadProblemIssue {
+						workload {
+							__typename
+							name
+						}
+						problemType
+					}
+					... on UnleashReleaseChannelIssue {
+						unleash {
+							name
+						}
+					}
 				}
 			`)
 		)
@@ -139,6 +152,7 @@
 		if ('openSearch' in d && d.openSearch) return d.openSearch.name;
 		if ('sqlInstance' in d && d.sqlInstance) return d.sqlInstance.name;
 		if ('valkey' in d && d.valkey) return d.valkey.name;
+		if ('unleash' in d && d.unleash) return d.unleash.name;
 		if ('workload' in d && d.workload) return d.workload.name;
 		return 'Unknown';
 	});
@@ -148,6 +162,7 @@
 		if ('openSearch' in d && d.openSearch) return OpenSearchIcon;
 		if ('sqlInstance' in d && d.sqlInstance) return DatabaseIcon;
 		if ('valkey' in d && d.valkey) return ValkeyIcon;
+		if ('unleash' in d && d.unleash) return UnleashIcon;
 		if ('job' in d && d.job) return BriefcaseClockIcon;
 		if ('workload' in d && d.workload && d.workload.__typename === 'NaisJob')
 			return BriefcaseClockIcon;


### PR DESCRIPTION
This pull request adds support for two new issue types, `WorkloadProblemIssue` and `UnleashReleaseChannelIssue`, across the UI components that display and handle critical issues. The changes ensure that these new issue types are correctly queried, labeled, and rendered with appropriate icons and links.

**Support for new issue types:**

* Updated GraphQL fragments in both `CriticalIssueRow.svelte` and `IssueListItem.svelte` to include fields for `WorkloadProblemIssue` and `UnleashReleaseChannelIssue`, ensuring relevant data is fetched and available for rendering. [[1]](diffhunk://#diff-b43b4f379e29b1556f7f0b69d8c5c24386503ffd6832f33df5e589f7b14d30faR113-R124) [[2]](diffhunk://#diff-9f7e02f18f867abfc84d162d3cd884e8e8a46ed70b135d15ec52444f8853ae0aR131-R142)

* Added logic to extract and display names and links for `unleash` resources, similar to existing handling for other resource types, in `CriticalIssueRow.svelte` and `IssueListItem.svelte`. [[1]](diffhunk://#diff-b43b4f379e29b1556f7f0b69d8c5c24386503ffd6832f33df5e589f7b14d30faR169-R172) [[2]](diffhunk://#diff-9f7e02f18f867abfc84d162d3cd884e8e8a46ed70b135d15ec52444f8853ae0aR155)

* Updated the mapping of issue type labels to include user-friendly labels for the new issue types in `CriticalIssueRow.svelte`.

**UI improvements:**

* Added import and usage of the new `UnleashIcon` for issues related to Unleash, ensuring visual distinction in `IssueListItem.svelte`. [[1]](diffhunk://#diff-9f7e02f18f867abfc84d162d3cd884e8e8a46ed70b135d15ec52444f8853ae0aR5) [[2]](diffhunk://#diff-9f7e02f18f867abfc84d162d3cd884e8e8a46ed70b135d15ec52444f8853ae0aR165)