### PR TITLE
feat(network): replace dead nginx metrics with HAProxy PromQL

### DIFF
--- a/src/lib/chart/LegendWrapper.svelte
+++ b/src/lib/chart/LegendWrapper.svelte
@@ -13,10 +13,19 @@
 	let {
 		children,
 		height,
-		ref = $bindable()
-	}: { children: Snippet; height: `${number}px`; ref?: HTMLDivElement | null } = $props();
+		ref = $bindable(),
+		onContextReady
+	}: {
+		children: Snippet;
+		height: `${number}px`;
+		ref?: HTMLDivElement | null;
+		onContextReady?: (ctx: ReturnType<typeof createLegendContext>) => void;
+	} = $props();
 
 	const ctx = createLegendContext();
+	$effect.pre(() => {
+		onContextReady?.(ctx);
+	});
 </script>
 
 {#snippet legendSnippet({ context }: { context: LegendSnippetProps })}
@@ -34,7 +43,17 @@
 						class:deselected={ctx.selection &&
 							!ctx.selection.isEmpty() &&
 							!ctx.selection.isSelected(item.key)}
-						onclick={() => ctx.selection?.toggle(item.key)}
+						onclick={() => {
+							ctx.selection?.toggle(item.key);
+							ctx.hiddenKeys.clear();
+							if (ctx.selection && !ctx.selection.isEmpty()) {
+								for (const legendItem of ctx.items) {
+									if (!ctx.selection.isSelected(legendItem.key)) {
+										ctx.hiddenKeys.add(legendItem.key);
+									}
+								}
+							}
+						}}
 					>
 						<span class="legend-swatch" style="background-color: {item.color};"></span>
 						<span class="legend-label">{item.label}</span>

--- a/src/lib/chart/LegendWrapper.svelte
+++ b/src/lib/chart/LegendWrapper.svelte
@@ -23,8 +23,12 @@
 	} = $props();
 
 	const ctx = createLegendContext();
+	let contextReported = false;
 	$effect.pre(() => {
-		onContextReady?.(ctx);
+		if (!contextReported && onContextReady) {
+			contextReported = true;
+			onContextReady(ctx);
+		}
 	});
 </script>
 

--- a/src/lib/chart/LegendWrapperData.svelte
+++ b/src/lib/chart/LegendWrapperData.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" module>
 	import { getContext, setContext } from 'svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 
 	export type LegendSnippetProps =
 		| {
@@ -28,7 +29,10 @@
 		hasLegend = $state(false);
 		items: LegendItem[] = $state([]);
 		selection: SelectionApi | null = $state(null);
+		hiddenKeys: SvelteSet<string> = new SvelteSet();
 	}
+
+	export type LegendContext = Context;
 
 	function getLegendContext() {
 		return getContext<Context>(contextKey);

--- a/src/lib/chart/PrometheusChart.svelte
+++ b/src/lib/chart/PrometheusChart.svelte
@@ -1,3 +1,11 @@
+<script lang="ts" module>
+	export type PrometheusChartSeries = {
+		key: string;
+		data: { timestamp: Date; value: number }[];
+		color: string;
+	};
+</script>
+
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import { graphql } from '$houdini';
@@ -73,6 +81,7 @@
 	let allowLoading = $state(false);
 	let firstTimeLoad = $state(false);
 	let showQueryModal = $state(false);
+	let legendCtx = $state<{ hiddenKeys: Set<string> } | undefined>(undefined);
 
 	// Intersection observer callback
 	const handleIntersection = (isVisible: boolean) => {
@@ -113,6 +122,12 @@
 		return [];
 	});
 
+	// Determine which series are visible based on legend toggle state
+	const visibleSeries = $derived.by(() => {
+		if (!legendCtx || legendCtx.hiddenKeys.size === 0) return series;
+		return series.filter((s) => !legendCtx!.hiddenKeys.has(s.key));
+	});
+
 	// Compute chart data from series
 	const chartData = $derived.by(() => {
 		// Always return chart data, even if empty
@@ -128,11 +143,12 @@
 			};
 		}
 
-		// Calculate max value and min timestamp in one pass
+		// Calculate max value and min timestamp from VISIBLE series only
 		let maxValue = -Infinity;
 		let minTimestamp: Date | null = null;
 
-		for (const s of series) {
+		const seriesToMeasure = visibleSeries.length > 0 ? visibleSeries : series;
+		for (const s of seriesToMeasure) {
 			if (s.data.length > 0) {
 				// Check first timestamp for min
 				const firstTimestamp = s.data[0].timestamp;
@@ -292,7 +308,7 @@
 		<InformationIcon />
 	</button>
 
-	<LegendWrapper {height} bind:ref={htmlRef}>
+	<LegendWrapper {height} bind:ref={htmlRef} onContextReady={(ctx) => (legendCtx = ctx)}>
 		<LineChart
 			series={chartData.series}
 			x="timestamp"

--- a/src/lib/domain/resources/NetworkPolicy.svelte
+++ b/src/lib/domain/resources/NetworkPolicy.svelte
@@ -138,7 +138,7 @@
 	{/if}
 {/snippet}
 
-<div class="section-heading">
+<div class="heading-row">
 	<Heading as="h2" size="medium" spacing>Access policy</Heading>
 	<div class="actions">
 		<DocsLink path="/workloads/application/reference/application-spec/#accesspolicy" />
@@ -202,7 +202,7 @@
 </List>
 
 <style>
-	.section-heading {
+	.heading-row {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;

--- a/src/routes/team/[team]/[env]/app/[app]/network/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/network/+page.svelte
@@ -98,9 +98,9 @@
 				</div>
 				<div class="actions">
 					<ToggleGroup
-						bind:value={interval}
+						value={interval}
 						size="small"
-						onchange={() => changeParams({ interval }, { noScroll: true })}
+						onchange={(v) => changeParams({ interval: v }, { noScroll: true })}
 					>
 						{#each Object.values(PrometheusChartQueryInterval) as intervalOption (intervalOption)}
 							<ToggleGroupItem value={intervalOption}>{intervalOption}</ToggleGroupItem>

--- a/src/routes/team/[team]/[env]/app/[app]/network/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/network/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import LegendWrapper, { legendSnippet } from '$lib/chart/LegendWrapper.svelte';
+	import PrometheusChart from '$lib/chart/PrometheusChart.svelte';
+	import { PrometheusChartQueryInterval } from '$lib/chart/util';
 	import NetworkPolicy from '$lib/domain/resources/NetworkPolicy.svelte';
 	import WarningIcon from '$lib/icons/WarningIcon.svelte';
 	import DocsLink from '$lib/ui/DocsLink.svelte';
@@ -8,63 +9,30 @@
 	import TooltipAlignHack from '$lib/ui/TooltipAlignHack.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
 	import {
-		Accordion,
-		AccordionItem,
 		CopyButton,
 		Detail,
 		Heading,
-		Loader,
 		ToggleGroup,
 		ToggleGroupItem
 	} from '@nais/ds-svelte-community';
 	import { GlobeIcon, HouseIcon, PadlockLockedIcon } from '@nais/ds-svelte-community/icons';
-	import { LineChart } from 'layerchart';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
 	let { IngressMetrics } = $derived(data);
+	let { interval } = $derived(data);
 
-	const interval = $derived(page.url.searchParams.get('interval') ?? '7d');
+	const team = $derived(page.params.team!);
+	const app = $derived(page.params.app!);
+	const environmentName = $derived(page.params.env!);
 
-	let openIngresses: Record<string, boolean> = $state({});
-
-	// Keep previous data visible during refetch (Houdini nulls .data on new variables)
-	let lastData = $state<typeof $IngressMetrics.data>(null);
-	$effect(() => {
-		if ($IngressMetrics.data) {
-			lastData = $IngressMetrics.data;
-		}
-	});
-	let displayData = $derived($IngressMetrics.data ?? lastData);
-
-	interface Metric {
-		timestamp: Date;
-		value: number;
-	}
-
-	type Series = {
-		metrics: {
-			rps: Metric[];
-			eps: Metric[];
-		};
-	};
-
-	function options(input: Series) {
-		return {
-			series: [
-				{
-					key: 'req/s',
-					color: '#236B7D',
-					data: input.metrics.rps
-				},
-				{
-					key: 'err/s',
-					color: '#F25C5C',
-					data: input.metrics.eps
-				}
-			]
-		};
-	}
+	const trafficQuery = $derived(
+		`label_replace(sum(rate(haproxy_backend_http_requests_total{proxy=~"${team}_svc_${app}_.*"}[$__rate_interval])), "metric", "req/s", "", "")` +
+			` or ` +
+			`label_replace(sum(rate(haproxy_backend_http_responses_total{proxy=~"${team}_svc_${app}_.*", code="5xx"}[$__rate_interval])), "metric", "5xx/s", "", "")` +
+			` or ` +
+			`label_replace(sum(rate(haproxy_backend_http_responses_total{proxy=~"${team}_svc_${app}_.*", code="4xx"}[$__rate_interval])), "metric", "4xx/s", "", "")`
+	);
 
 	function ingressTypeLabel(type: string): string {
 		return type === 'UNKNOWN' ? 'Unknown' : `${type.at(0)}${type.slice(1).toLowerCase()}`;
@@ -76,109 +44,89 @@
 <Heading as="h2" class="aksel-sr-only">Network</Heading>
 
 <div class="wrapper">
-	{#if displayData}
-		{@const app = displayData.team.environment.application}
-		{@const ingresses = app.ingresses}
+	{#if $IngressMetrics.data}
+		{@const appData = $IngressMetrics.data.team.environment.application}
+		{@const ingresses = appData.ingresses}
 
-		<div class="section-heading">
-			<div class="heading-wrapper">
-				<Heading as="h2" size="medium" spacing>Ingresses</Heading>
+		<section>
+			<div class="heading-row">
+				<div class="heading-wrapper">
+					<Heading as="h2" size="medium" spacing>Ingresses</Heading>
+				</div>
+				<div class="actions">
+					<DocsLink path="/workloads/application/reference/ingress/" />
+				</div>
 			</div>
-			<div class="actions">
-				<DocsLink path="/workloads/application/reference/ingress/" />
-			</div>
-		</div>
 
-		{#if ingresses.length > 0}
-			<Accordion size="small" indent={false}>
-				{#each ingresses as ingress (ingress.url)}
-					<AccordionItem
-						open={openIngresses[ingress.url] ?? false}
-						onOpenChange={(isOpen) => {
-							openIngresses[ingress.url] = isOpen;
-						}}
-					>
-						{#snippet heading()}
-							<span class="ingress-heading">
-								<span class="ingress-icon">
-									<TooltipAlignHack content="{ingressTypeLabel(ingress.type)} ingress">
-										{#if ingress.type === 'EXTERNAL'}
-											<GlobeIcon />
-										{:else if ingress.type === 'INTERNAL'}
-											<HouseIcon />
-										{:else if ingress.type === 'AUTHENTICATED'}
-											<PadlockLockedIcon />
-										{:else}
-											<WarningIcon />
-										{/if}
-									</TooltipAlignHack>
-								</span>
-								<span class="ingress-url">{ingress.url}</span>
-								<span class="ingress-metrics">
-									<span>{ingress.metrics.requestsPerSecond.toFixed(2)} req/s</span>
-									<span>{ingress.metrics.errorsPerSecond.toFixed(2)} err/s</span>
-								</span>
+			{#if ingresses.length > 0}
+				<ul class="ingress-list">
+					{#each ingresses as ingress (ingress.url)}
+						<li class="ingress-item">
+							<span class="ingress-icon">
+								<TooltipAlignHack content="{ingressTypeLabel(ingress.type)} ingress">
+									{#if ingress.type === 'EXTERNAL'}
+										<GlobeIcon />
+									{:else if ingress.type === 'INTERNAL'}
+										<HouseIcon />
+									{:else if ingress.type === 'AUTHENTICATED'}
+										<PadlockLockedIcon />
+									{:else}
+										<WarningIcon />
+									{/if}
+								</TooltipAlignHack>
 							</span>
-						{/snippet}
-						<div class="chart-content">
-							<div class="ingress-copy">
-								<code class="ingress-url-text">{ingress.url}</code><CopyButton
-									copyText={ingress.url}
-									size="xsmall"
-									variant="action"
-								/>
-							</div>
-							<div class="chart-controls">
-								<ToggleGroup
-									value={interval}
-									size="small"
-									onchange={(interval) => changeParams({ interval }, { noScroll: true })}
-								>
-									{#each ['1h', '6h', '1d', '7d', '30d'] as interval (interval)}
-										<ToggleGroupItem value={interval}>{interval}</ToggleGroupItem>
-									{/each}
-								</ToggleGroup>
-							</div>
-							{#if $IngressMetrics.fetching}
-								<div class="chart-loading">
-									<Loader size="xlarge" />
-								</div>
-							{:else}
-								<div class="chart-wrapper">
-									<LegendWrapper height="250px">
-										<LineChart
-											{...options(ingress)}
-											padding={{ left: 40 }}
-											brush={true}
-											x="timestamp"
-											y="value"
-											legend={legendSnippet}
-											props={{
-												spline: {
-													class: 'stroke-2'
-												},
-												tooltip: {
-													hideTotal: true
-												},
-												xAxis: {
-													format: 'day'
-												}
-											}}
-										/>
-									</LegendWrapper>
-								</div>
-							{/if}
-						</div>
-					</AccordionItem>
-				{/each}
-			</Accordion>
-		{:else}
-			<div class="empty-state">
-				<Detail>No ingresses configured.</Detail>
-			</div>
-		{/if}
+							<code class="ingress-url">{ingress.url}</code>
+							<CopyButton copyText={ingress.url} size="xsmall" variant="action" />
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<div class="empty-state">
+					<Detail>No ingresses configured.</Detail>
+				</div>
+			{/if}
+		</section>
 
-		<NetworkPolicy workload={app} />
+		<section>
+			<div class="heading-row">
+				<div class="heading-wrapper">
+					<Heading as="h2" size="medium" spacing>Traffic</Heading>
+				</div>
+				<div class="actions">
+					<ToggleGroup
+						bind:value={interval}
+						size="small"
+						onchange={() => changeParams({ interval }, { noScroll: true })}
+					>
+						{#each Object.values(PrometheusChartQueryInterval) as intervalOption (intervalOption)}
+							<ToggleGroupItem value={intervalOption}>{intervalOption}</ToggleGroupItem>
+						{/each}
+					</ToggleGroup>
+				</div>
+			</div>
+
+			<PrometheusChart
+				{environmentName}
+				title="Ingress traffic"
+				description="Request rate, server errors (5xx), and client errors (4xx)."
+				query={trafficQuery}
+				{interval}
+				labelFormatter={(labels) => {
+					const metric = labels.find((l) => l.name === 'metric')?.value;
+					if (metric === '4xx/s') return '4xx/s (client errors)';
+					if (metric === '5xx/s') return '5xx/s (server errors)';
+					return metric ?? 'unknown';
+				}}
+				formatYValue={(value) => `${value.toFixed(2)}/s`}
+				colorizer={(label) => {
+					if (label.startsWith('5xx')) return '#d62728';
+					if (label.startsWith('4xx')) return '#ff7f0e';
+					return '#1f77b4';
+				}}
+			/>
+		</section>
+
+		<NetworkPolicy workload={appData} />
 	{/if}
 </div>
 
@@ -186,74 +134,10 @@
 	.wrapper {
 		display: flex;
 		flex-direction: column;
-		gap: var(--ax-space-24);
+		gap: var(--ax-space-32);
 	}
 
-	.ingress-heading {
-		display: flex;
-		align-items: center;
-		gap: var(--ax-space-4);
-		color: var(--ax-text-neutral);
-		width: 100%;
-		font-size: 1rem;
-	}
-
-	:global(.aksel-accordion__header > .aksel-heading) {
-		flex: 1;
-		font-size: 1rem;
-	}
-
-	.ingress-icon {
-		display: flex;
-		align-items: center;
-	}
-
-	.ingress-metrics {
-		margin-left: auto;
-		display: flex;
-		gap: var(--ax-space-8);
-		color: var(--ax-text-neutral-subtle);
-	}
-
-	.ingress-copy {
-		word-break: break-all;
-	}
-
-	.ingress-copy :global(button) {
-		vertical-align: middle;
-	}
-
-	.ingress-url-text {
-		font-family: monospace;
-		font-size: var(--ax-font-size-small);
-		color: var(--ax-text-neutral);
-	}
-
-	.chart-loading {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		min-height: 250px;
-	}
-
-	.chart-content {
-		display: flex;
-		flex-direction: column;
-		gap: var(--ax-space-8);
-	}
-
-	.chart-controls {
-		display: flex;
-		justify-content: flex-end;
-	}
-
-	.chart-wrapper {
-		width: 100%;
-		min-width: 0;
-		padding-block: var(--ax-space-4) var(--ax-space-16);
-	}
-
-	.section-heading {
+	.heading-row {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -274,10 +158,31 @@
 		flex-shrink: 0;
 	}
 
-	@media (max-width: 767px), (max-height: 500px) {
-		.ingress-metrics {
-			display: none;
-		}
+	.ingress-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--ax-space-4);
+	}
+
+	.ingress-item {
+		display: flex;
+		align-items: center;
+		gap: var(--ax-space-4);
+	}
+
+	.ingress-icon {
+		display: flex;
+		align-items: center;
+	}
+
+	.ingress-url {
+		font-family: monospace;
+		font-size: var(--ax-font-size-small);
+		color: var(--ax-text-neutral);
+		word-break: break-all;
 	}
 
 	.empty-state {

--- a/src/routes/team/[team]/[env]/app/[app]/network/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/network/+page.svelte
@@ -22,8 +22,12 @@
 	let { IngressMetrics } = $derived(data);
 	let { interval } = $derived(data);
 
-	const team = $derived(page.params.team!);
-	const app = $derived(page.params.app!);
+	function sanitizeLabel(value: string): string {
+		return value.replace(/[^a-zA-Z0-9_-]/g, '');
+	}
+
+	const team = $derived(sanitizeLabel(page.params.team!));
+	const app = $derived(sanitizeLabel(page.params.app!));
 	const environmentName = $derived(page.params.env!);
 
 	const trafficQuery = $derived(

--- a/src/routes/team/[team]/[env]/app/[app]/network/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/network/+page.svelte
@@ -23,7 +23,8 @@
 	let { interval } = $derived(data);
 
 	function sanitizeLabel(value: string): string {
-		return value.replace(/[^a-zA-Z0-9_-]/g, '');
+		const sanitized = value.replace(/[^a-zA-Z0-9_-]/g, '');
+		return sanitized || 'invalid';
 	}
 
 	const team = $derived(sanitizeLabel(page.params.team!));
@@ -31,11 +32,11 @@
 	const environmentName = $derived(page.params.env!);
 
 	const trafficQuery = $derived(
-		`label_replace(sum(rate(haproxy_backend_http_requests_total{proxy=~"${team}_svc_${app}_.*"}[$__rate_interval])), "metric", "req/s", "", "")` +
+		`label_replace(sum(rate(haproxy_backend_http_requests_total{proxy=~"${team}_svc_${app}_.*"}[$__rate_interval])), "metric", "req/s", "__name__", ".*")` +
 			` or ` +
-			`label_replace(sum(rate(haproxy_backend_http_responses_total{proxy=~"${team}_svc_${app}_.*", code="5xx"}[$__rate_interval])), "metric", "5xx/s", "", "")` +
+			`label_replace(sum(rate(haproxy_backend_http_responses_total{proxy=~"${team}_svc_${app}_.*", code="5xx"}[$__rate_interval])), "metric", "5xx/s", "__name__", ".*")` +
 			` or ` +
-			`label_replace(sum(rate(haproxy_backend_http_responses_total{proxy=~"${team}_svc_${app}_.*", code="4xx"}[$__rate_interval])), "metric", "4xx/s", "", "")`
+			`label_replace(sum(rate(haproxy_backend_http_responses_total{proxy=~"${team}_svc_${app}_.*", code="4xx"}[$__rate_interval])), "metric", "4xx/s", "__name__", ".*")`
 	);
 
 	function ingressTypeLabel(type: string): string {

--- a/src/routes/team/[team]/[env]/app/[app]/network/+page.ts
+++ b/src/routes/team/[team]/[env]/app/[app]/network/+page.ts
@@ -1,26 +1,13 @@
 import { load_IngressMetrics } from '$houdini';
+import { PrometheusChartQueryInterval } from '$lib/chart/util';
 import { addPageMeta } from '$lib/utils/pageMeta';
-
-function getStart(interval: string | null) {
-	switch (interval) {
-		case '1h':
-			return new Date(Date.now() - 1000 * 60 * 60);
-		case '6h':
-			return new Date(Date.now() - 6 * 1000 * 60 * 60);
-		case '1d':
-			return new Date(Date.now() - 24 * 1000 * 60 * 60);
-		case '30d':
-			return new Date(Date.now() - 30 * 24 * 1000 * 60 * 60);
-		default:
-			return new Date(Date.now() - 7 * 24 * 1000 * 60 * 60);
-	}
-}
 
 export const ssr = false;
 export async function load(event) {
-	const interval = event.url.searchParams.get('interval');
-	const end = new Date(Date.now());
-	const start = getStart(interval);
+	let interval = (event.url.searchParams.get('interval') || '7d') as PrometheusChartQueryInterval;
+	if (!Object.values(PrometheusChartQueryInterval).includes(interval)) {
+		interval = '7d';
+	}
 
 	return {
 		interval,
@@ -32,9 +19,7 @@ export async function load(event) {
 			variables: {
 				app: event.params.app,
 				env: event.params.env,
-				team: event.params.team,
-				start,
-				end
+				team: event.params.team
 			}
 		}))
 	};

--- a/src/routes/team/[team]/[env]/app/[app]/network/query.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/network/query.gql
@@ -1,4 +1,4 @@
-query IngressMetrics($team: Slug!, $app: String!, $env: String!, $start: Time!, $end: Time!) {
+query IngressMetrics($team: Slug!, $app: String!, $env: String!) {
 	team(slug: $team) {
 		environment(name: $env) {
 			application(name: $app) {
@@ -6,18 +6,6 @@ query IngressMetrics($team: Slug!, $app: String!, $env: String!, $start: Time!, 
 				ingresses {
 					url
 					type
-					metrics {
-						requestsPerSecond
-						errorsPerSecond
-						rps: series(input: { end: $end, start: $start, type: REQUESTS_PER_SECOND }) {
-							timestamp
-							value
-						}
-						eps: series(input: { end: $end, start: $start, type: ERRORS_PER_SECOND }) {
-							timestamp
-							value
-						}
-					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Replace the dead nginx-based ingress metrics on the network page with live HAProxy metrics fetched directly via PrometheusChart.

## Changes

### Network page rewrite
- Remove the per-ingress accordion layout with separate request/error/latency charts
- Replace with a single combined PrometheusChart showing:
  - **req/s** (total request rate, blue)
  - **5xx/s** (server error rate, red)
  - **4xx/s** (client error rate, orange)
- Simplify `query.gql` — remove metrics block and `$start`/`$end` variables
- Simplify `+page.ts` — use `PrometheusChartQueryInterval` instead of manual date math
- Show ingress URLs as a simple list below the chart

### PrometheusChart legend Y-axis rescaling
- Add `hiddenKeys` tracking to `LegendWrapperData` context (using `SvelteSet`)
- PrometheusChart derives visible series from legend state and recalculates Y-axis domain
- Sync `hiddenKeys` from LayerChart's selection API after each toggle to keep them in lockstep

### Misc
- Rename `.section-heading` → `.heading-row` in NetworkPolicy to avoid conflict with global CSS that adds chevron icons to `<details>` summary elements