### PR TITLE
fix: adapt image tag handling to digest field

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1996,7 +1996,10 @@ type ContainerImage implements ActivityLogger & Node {
   """SBOM pipeline status and processing information for this image."""
   sbom: ContainerImageSBOM!
 
-  """Tag of the container image."""
+  """
+  Tag of the container image. Empty when the image reference has no explicit tag,
+  for example when it is referenced by digest only.
+  """
   tag: String!
 
   """Get the vulnerabilities of the image."""

--- a/schema.graphql
+++ b/schema.graphql
@@ -539,6 +539,12 @@ type AlertConnection {
   """List of edges."""
   edges: [AlertEdge!]!
 
+  """
+  Facets for alerts. Provides distribution counts to help narrow down results.
+  Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+  """
+  facets: AlertFacets
+
   """List of nodes."""
   nodes: [Alert!]!
 
@@ -553,6 +559,17 @@ type AlertEdge {
 
   """The Alert."""
   node: Alert!
+}
+
+"""
+Facets for alerts, providing distribution counts across different dimensions.
+"""
+type AlertFacets {
+  """Distribution of alerts by environment."""
+  environments: [StringFacetItem!]!
+
+  """Distribution of alerts by state."""
+  states: [AlertStateFacetItem!]!
 }
 
 """Ordering options when fetching alerts."""
@@ -585,6 +602,15 @@ enum AlertState {
 
   """Only return alerts that are pending."""
   PENDING
+}
+
+"""A single facet item for alert states."""
+type AlertStateFacetItem {
+  """Number of matching alerts."""
+  count: Int!
+
+  """The alert state."""
+  state: AlertState!
 }
 
 input AllowTeamAccessToUnleashInput {
@@ -1952,6 +1978,9 @@ type ContainerImage implements ActivityLogger & Node {
     """
     last: Int
   ): ActivityLogEntryConnection!
+
+  """Digest of the container image, if present."""
+  digest: String
 
   """
   Whether the image has a software bill of materials (SBOM) attached to it.
@@ -3520,6 +3549,12 @@ type IssueConnection {
   """List of edges."""
   edges: [IssueEdge!]!
 
+  """
+  Facets for the issues. Provides distribution counts to help narrow down results.
+  Facet counts are computed over the full result set (ignoring pagination) but respect the current filter.
+  """
+  facets: IssueFacets
+
   """List of nodes."""
   nodes: [Issue!]!
 
@@ -3533,6 +3568,23 @@ type IssueEdge {
 
   """The Issue."""
   node: Issue!
+}
+
+"""
+Facets for issues, providing distribution counts across different dimensions.
+"""
+type IssueFacets {
+  """Distribution of issues by environment."""
+  environments: [StringFacetItem!]!
+
+  """Distribution of issues by issue type."""
+  issueTypes: [IssueTypeFacetItem!]!
+
+  """Distribution of issues by resource type."""
+  resourceTypes: [IssueResourceTypeFacetItem!]!
+
+  """Distribution of issues by severity."""
+  severities: [IssueSeverityFacetItem!]!
 }
 
 input IssueFilter {
@@ -3577,6 +3629,24 @@ enum IssueOrderField {
   SEVERITY
 }
 
+"""A single facet item for resource types."""
+type IssueResourceTypeFacetItem {
+  """Number of matching issues."""
+  count: Int!
+
+  """The resource type."""
+  resourceType: ResourceType!
+}
+
+"""A single facet item for issue severities."""
+type IssueSeverityFacetItem {
+  """Number of matching issues."""
+  count: Int!
+
+  """The severity."""
+  severity: Severity!
+}
+
 enum IssueType {
   """Raised when an application is stuck in a restart loop."""
   APPLICATION_RESTART_LOOP
@@ -3599,6 +3669,15 @@ enum IssueType {
   Raised when the platform reports a problem in a workload, such as an invalid spec, a failed synchronization or a deprecation.
   """
   WORKLOAD_PROBLEM
+}
+
+"""A single facet item for issue types."""
+type IssueTypeFacetItem {
+  """Number of matching issues."""
+  count: Int!
+
+  """The issue type."""
+  issueType: IssueType!
 }
 
 type Job implements ActivityLogger & Node & Workload {

--- a/src/lib/domain/vulnerability/WorkloadVulnerabilitiesPage.svelte
+++ b/src/lib/domain/vulnerability/WorkloadVulnerabilitiesPage.svelte
@@ -63,7 +63,11 @@
 			</SurfaceCard>
 		{/if}
 
-		<WorkloadImageCard imageName={workload?.image.name} tag={workload?.image.tag}>
+		<WorkloadImageCard
+			imageName={workload?.image.name}
+			tag={workload?.image.tag}
+			digest={workload?.image.digest}
+		>
 			{#if !hasVulnerabilityData && !isProcessing}
 				<BodyShort size="small" spacing>
 					<WarningIcon class="text-aligned-icon" /> No vulnerability data available. Learn how to generate

--- a/src/lib/domain/workload/WorkloadImageCard.svelte
+++ b/src/lib/domain/workload/WorkloadImageCard.svelte
@@ -62,7 +62,7 @@
 				<dd><code>{name}</code></dd>
 			</div>
 			<div>
-				<dt>Tag / digest</dt>
+				<dt>{digest ? 'Digest' : 'Tag'}</dt>
 				<dd><code class="tag">{tag || digest || '-'}</code></dd>
 			</div>
 		</dl>

--- a/src/lib/domain/workload/WorkloadImageCard.svelte
+++ b/src/lib/domain/workload/WorkloadImageCard.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
-	import { parseImage } from '$lib/utils/image';
+	import { formatImageRef, parseImage } from '$lib/utils/image';
 	import { CopyButton } from '@nais/ds-svelte-community';
 	import type { Snippet } from 'svelte';
 
 	interface Props {
 		imageName?: string;
 		tag?: string;
+		digest?: string | null;
 		title?: string;
 		bordered?: boolean;
 		level?: 'h2' | 'h3' | 'h4';
@@ -16,6 +17,7 @@
 	let {
 		imageName,
 		tag,
+		digest,
 		title = 'Image',
 		bordered = true,
 		level = 'h3',
@@ -23,11 +25,12 @@
 	}: Props = $props();
 
 	const { registry, repository, name } = $derived(parseImage(imageName));
+	const imageRef = $derived(imageName ? formatImageRef({ name: imageName, tag, digest }) : '');
 </script>
 
 <SurfaceCard {title} {level} {bordered}>
 	{#snippet headerAside()}
-		<CopyButton copyText={`${imageName ?? ''}:${tag ?? ''}`} size="xsmall" variant="action" />
+		<CopyButton copyText={imageRef} size="xsmall" variant="action" />
 	{/snippet}
 
 	{#if registry === '' || repository === '' || name === ''}
@@ -38,7 +41,7 @@
 			</div>
 			<div>
 				<dt>Tag</dt>
-				<dd><code class="tag">{tag}</code></dd>
+				<dd><code class="tag">{tag || digest || '-'}</code></dd>
 			</div>
 		</dl>
 	{:else}
@@ -57,7 +60,7 @@
 			</div>
 			<div>
 				<dt>Tag</dt>
-				<dd><code class="tag">{tag}</code></dd>
+				<dd><code class="tag">{tag || digest || '-'}</code></dd>
 			</div>
 		</dl>
 	{/if}

--- a/src/lib/domain/workload/WorkloadImageCard.svelte
+++ b/src/lib/domain/workload/WorkloadImageCard.svelte
@@ -24,7 +24,23 @@
 		children
 	}: Props = $props();
 
-	const { registry, repository, name } = $derived(parseImage(imageName));
+	const imageDetails = $derived.by(() => {
+		try {
+			const parsed = parseImage(imageName);
+
+			return {
+				registry: parsed.registry ?? '',
+				repository: parsed.repository ?? '',
+				name: parsed.name ?? ''
+			};
+		} catch {
+			return {
+				registry: '',
+				repository: '',
+				name: ''
+			};
+		}
+	});
 	const imageRef = $derived(imageName ? formatImageRef({ name: imageName, tag, digest }) : '');
 	const versionLabel = $derived(formatImageVersion({ tag, digest }));
 </script>
@@ -36,7 +52,7 @@
 		{/if}
 	{/snippet}
 
-	{#if registry === '' || repository === '' || name === ''}
+	{#if imageDetails.registry === '' || imageDetails.repository === '' || imageDetails.name === ''}
 		<dl class="kv">
 			<div>
 				<dt>Name</dt>
@@ -51,15 +67,15 @@
 		<dl class="kv">
 			<div>
 				<dt>Registry</dt>
-				<dd><code>{registry}</code></dd>
+				<dd><code>{imageDetails.registry}</code></dd>
 			</div>
 			<div>
 				<dt>Repository</dt>
-				<dd><code>{repository}</code></dd>
+				<dd><code>{imageDetails.repository}</code></dd>
 			</div>
 			<div>
 				<dt>Name</dt>
-				<dd><code>{name}</code></dd>
+				<dd><code>{imageDetails.name}</code></dd>
 			</div>
 			<div>
 				<dt>Version</dt>

--- a/src/lib/domain/workload/WorkloadImageCard.svelte
+++ b/src/lib/domain/workload/WorkloadImageCard.svelte
@@ -26,13 +26,12 @@
 
 	const { registry, repository, name } = $derived(parseImage(imageName));
 	const imageRef = $derived(imageName ? formatImageRef({ name: imageName, tag, digest }) : '');
-	const copyableImageRef = $derived(imageRef.trim());
 </script>
 
 <SurfaceCard {title} {level} {bordered}>
 	{#snippet headerAside()}
-		{#if copyableImageRef.length > 0}
-			<CopyButton copyText={copyableImageRef} size="xsmall" variant="action" />
+		{#if imageRef.length > 0}
+			<CopyButton copyText={imageRef} size="xsmall" variant="action" />
 		{/if}
 	{/snippet}
 

--- a/src/lib/domain/workload/WorkloadImageCard.svelte
+++ b/src/lib/domain/workload/WorkloadImageCard.svelte
@@ -43,7 +43,7 @@
 				<dd><code>{imageName}</code></dd>
 			</div>
 			<div>
-				<dt>Tag</dt>
+				<dt>Tag / digest</dt>
 				<dd><code class="tag">{tag || digest || '-'}</code></dd>
 			</div>
 		</dl>
@@ -62,7 +62,7 @@
 				<dd><code>{name}</code></dd>
 			</div>
 			<div>
-				<dt>Tag</dt>
+				<dt>Tag / digest</dt>
 				<dd><code class="tag">{tag || digest || '-'}</code></dd>
 			</div>
 		</dl>

--- a/src/lib/domain/workload/WorkloadImageCard.svelte
+++ b/src/lib/domain/workload/WorkloadImageCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
-	import { formatImageRef, parseImage } from '$lib/utils/image';
+	import { formatImageRef, formatImageVersion, parseImage } from '$lib/utils/image';
 	import { CopyButton } from '@nais/ds-svelte-community';
 	import type { Snippet } from 'svelte';
 
@@ -26,6 +26,7 @@
 
 	const { registry, repository, name } = $derived(parseImage(imageName));
 	const imageRef = $derived(imageName ? formatImageRef({ name: imageName, tag, digest }) : '');
+	const versionLabel = $derived(formatImageVersion({ tag, digest }));
 </script>
 
 <SurfaceCard {title} {level} {bordered}>
@@ -42,8 +43,8 @@
 				<dd><code>{imageName}</code></dd>
 			</div>
 			<div>
-				<dt>{digest ? 'Digest' : 'Tag'}</dt>
-				<dd><code class="tag">{tag || digest || '-'}</code></dd>
+				<dt>Version</dt>
+				<dd><code class="tag">{versionLabel}</code></dd>
 			</div>
 		</dl>
 	{:else}
@@ -61,8 +62,8 @@
 				<dd><code>{name}</code></dd>
 			</div>
 			<div>
-				<dt>{digest ? 'Digest' : 'Tag'}</dt>
-				<dd><code class="tag">{tag || digest || '-'}</code></dd>
+				<dt>Version</dt>
+				<dd><code class="tag">{versionLabel}</code></dd>
 			</div>
 		</dl>
 	{/if}

--- a/src/lib/domain/workload/WorkloadImageCard.svelte
+++ b/src/lib/domain/workload/WorkloadImageCard.svelte
@@ -43,7 +43,7 @@
 				<dd><code>{imageName}</code></dd>
 			</div>
 			<div>
-				<dt>Tag / digest</dt>
+				<dt>{digest ? 'Digest' : 'Tag'}</dt>
 				<dd><code class="tag">{tag || digest || '-'}</code></dd>
 			</div>
 		</dl>

--- a/src/lib/domain/workload/WorkloadImageCard.svelte
+++ b/src/lib/domain/workload/WorkloadImageCard.svelte
@@ -26,11 +26,14 @@
 
 	const { registry, repository, name } = $derived(parseImage(imageName));
 	const imageRef = $derived(imageName ? formatImageRef({ name: imageName, tag, digest }) : '');
+	const copyableImageRef = $derived(imageRef.trim());
 </script>
 
 <SurfaceCard {title} {level} {bordered}>
 	{#snippet headerAside()}
-		<CopyButton copyText={imageRef} size="xsmall" variant="action" />
+		{#if copyableImageRef.length > 0}
+			<CopyButton copyText={copyableImageRef} size="xsmall" variant="action" />
+		{/if}
 	{/snippet}
 
 	{#if registry === '' || repository === '' || name === ''}

--- a/src/lib/utils/image.test.ts
+++ b/src/lib/utils/image.test.ts
@@ -1,4 +1,106 @@
-import { getImageDisplayName } from './image';
+import { formatImageRef, getImageDisplayName, parseImage } from './image';
+
+describe('parseImage', () => {
+	test.each([
+		{
+			image: 'ghcr.io/navikt/my-app:latest',
+			expected: {
+				registry: 'ghcr.io',
+				repository: 'navikt',
+				name: 'my-app',
+				tag: 'latest',
+				digest: undefined
+			}
+		},
+		{
+			image: 'ghcr.io/navikt/my-app@sha256:cafebabe',
+			expected: {
+				registry: 'ghcr.io',
+				repository: 'navikt',
+				name: 'my-app',
+				tag: undefined,
+				digest: 'sha256:cafebabe'
+			}
+		},
+		{
+			image: 'ghcr.io/navikt/my-app:latest@sha256:deadbeef',
+			expected: {
+				registry: 'ghcr.io',
+				repository: 'navikt',
+				name: 'my-app',
+				tag: 'latest',
+				digest: 'sha256:deadbeef'
+			}
+		},
+		{
+			image: 'localhost:5000/navikt/my-app:latest@sha256:deadbeef',
+			expected: {
+				registry: 'localhost:5000',
+				repository: 'navikt',
+				name: 'my-app',
+				tag: 'latest',
+				digest: 'sha256:deadbeef'
+			}
+		}
+	])('parseImage($image)', ({ image, expected }) => {
+		expect(parseImage(image)).toEqual(expected);
+	});
+
+	test('returns empty object for missing image', () => {
+		expect(parseImage()).toEqual({});
+	});
+
+	test('returns empty object for whitespace-only image', () => {
+		expect(parseImage('   ')).toEqual({});
+	});
+
+	test.each([
+		['ghcr.io/navikt/my-app@deadbeef', 'Could not parse image digest'],
+		['ghcr.io/navikt/my-app@@sha256:deadbeef', 'Could not parse image reference'],
+		['ghcr.io/navikt/my-app:', 'Could not parse image tag'],
+		['ghcr.io/navikt/:latest', 'Could not parse image name'],
+		['ghcr.io/navikt/my app:latest', 'Could not parse image reference']
+	])('throws predictably for malformed image refs: %s', (image, message) => {
+		expect(() => parseImage(image)).toThrow(message);
+	});
+
+	test('trims surrounding whitespace before parsing', () => {
+		expect(parseImage('  ghcr.io/navikt/my-app:latest@sha256:deadbeef  ')).toEqual({
+			registry: 'ghcr.io',
+			repository: 'navikt',
+			name: 'my-app',
+			tag: 'latest',
+			digest: 'sha256:deadbeef'
+		});
+	});
+});
+
+describe('formatImageRef', () => {
+	test.each([
+		{
+			name: 'formats tag and digest',
+			image: { name: 'ghcr.io/navikt/my-app', tag: 'latest', digest: 'sha256:deadbeef' },
+			expected: 'ghcr.io/navikt/my-app:latest@sha256:deadbeef'
+		},
+		{
+			name: 'formats tag without digest',
+			image: { name: 'ghcr.io/navikt/my-app', tag: 'latest', digest: null },
+			expected: 'ghcr.io/navikt/my-app:latest'
+		},
+		{
+			name: 'formats digest-only image',
+			image: { name: 'ghcr.io/navikt/my-app', tag: '', digest: 'sha256:cafebabe' },
+			expected: 'ghcr.io/navikt/my-app@sha256:cafebabe'
+		},
+		{
+			name: 'formats image name without tag or digest',
+			image: { name: 'ghcr.io/navikt/my-app', tag: undefined, digest: undefined },
+			expected: 'ghcr.io/navikt/my-app'
+		}
+	])('formatImageRef: $name', ({ image, expected }) => {
+		expect(formatImageRef(image)).toBe(expected);
+	});
+});
 
 test.each([
 	[

--- a/src/lib/utils/image.test.ts
+++ b/src/lib/utils/image.test.ts
@@ -1,4 +1,10 @@
-import { formatImageRef, getImageDisplayName, parseImage } from './image';
+import {
+	formatImageRef,
+	formatImageVersion,
+	getImageDisplayName,
+	imageRefMatches,
+	parseImage
+} from './image';
 
 describe('parseImage', () => {
 	test.each([
@@ -99,6 +105,70 @@ describe('formatImageRef', () => {
 		}
 	])('formatImageRef: $name', ({ image, expected }) => {
 		expect(formatImageRef(image)).toBe(expected);
+	});
+});
+
+describe('formatImageVersion', () => {
+	test.each([
+		{
+			name: 'formats tag and digest together',
+			image: { tag: 'latest', digest: 'sha256:deadbeef' },
+			expected: 'latest@sha256:deadbeef'
+		},
+		{
+			name: 'formats digest-only version',
+			image: { tag: '', digest: 'sha256:cafebabe' },
+			expected: 'sha256:cafebabe'
+		},
+		{
+			name: 'formats tag-only version',
+			image: { tag: 'latest', digest: null },
+			expected: 'latest'
+		},
+		{
+			name: 'falls back to placeholder when version is missing',
+			image: { tag: undefined, digest: undefined },
+			expected: '-'
+		}
+	])('formatImageVersion: $name', ({ image, expected }) => {
+		expect(formatImageVersion(image)).toBe(expected);
+	});
+});
+
+describe('imageRefMatches', () => {
+	test.each([
+		{
+			name: 'matches tag-only history against current tag and digest',
+			imageRef: 'ghcr.io/navikt/my-app:latest',
+			image: { name: 'ghcr.io/navikt/my-app', tag: 'latest', digest: 'sha256:deadbeef' },
+			expected: true
+		},
+		{
+			name: 'matches full tag and digest refs exactly',
+			imageRef: 'ghcr.io/navikt/my-app:latest@sha256:deadbeef',
+			image: { name: 'ghcr.io/navikt/my-app', tag: 'latest', digest: 'sha256:deadbeef' },
+			expected: true
+		},
+		{
+			name: 'rejects different digests when the history ref includes one',
+			imageRef: 'ghcr.io/navikt/my-app:latest@sha256:cafebabe',
+			image: { name: 'ghcr.io/navikt/my-app', tag: 'latest', digest: 'sha256:deadbeef' },
+			expected: false
+		},
+		{
+			name: 'rejects different tags',
+			imageRef: 'ghcr.io/navikt/my-app:canary',
+			image: { name: 'ghcr.io/navikt/my-app', tag: 'latest', digest: 'sha256:deadbeef' },
+			expected: false
+		},
+		{
+			name: 'rejects different image names',
+			imageRef: 'ghcr.io/navikt/other-app:latest',
+			image: { name: 'ghcr.io/navikt/my-app', tag: 'latest', digest: 'sha256:deadbeef' },
+			expected: false
+		}
+	])('imageRefMatches: $name', ({ imageRef, image, expected }) => {
+		expect(imageRefMatches(imageRef, image)).toBe(expected);
 	});
 });
 

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -2,14 +2,39 @@ export const parseImage = (image?: string) => {
 	if (!image) {
 		return {};
 	}
-	const tag = image.split(':')[1];
-	const name = image.split(':')[0].split('/').pop();
-	const registry = image.split('/')[0];
-	const repository = image.split('/').slice(1, -1).join('/');
+
+	const withoutDigest = image.split('@')[0] ?? image;
+	const lastColonIndex = withoutDigest.lastIndexOf(':');
+	const lastSlashIndex = withoutDigest.lastIndexOf('/');
+	const hasTag = lastColonIndex > lastSlashIndex;
+	const imagePath = hasTag ? withoutDigest.slice(0, lastColonIndex) : withoutDigest;
+	const tag = hasTag ? withoutDigest.slice(lastColonIndex + 1) : undefined;
+	const digest = image.includes('@') ? image.split('@')[1] : undefined;
+	const name = imagePath.split('/').pop();
+	const registry = imagePath.split('/')[0] ?? '';
+	const repository = imagePath.split('/').slice(1, -1).join('/');
 	if (name === undefined) {
 		throw new Error('Could not parse image name');
 	}
-	return { registry, repository, name, tag };
+	return { registry, repository, name, tag, digest };
+};
+
+export const formatImageRef = (image: {
+	name: string;
+	tag?: string | null;
+	digest?: string | null;
+}) => {
+	let ref = image.name;
+
+	if (image.tag) {
+		ref += `:${image.tag}`;
+	}
+
+	if (image.digest) {
+		ref += `@${image.digest}`;
+	}
+
+	return ref;
 };
 
 export const getImageDisplayName = (name: string): string => {

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -3,19 +3,51 @@ export const parseImage = (image?: string) => {
 		return {};
 	}
 
-	const withoutDigest = image.split('@')[0] ?? image;
+	const normalizedImage = image.trim();
+
+	if (normalizedImage === '') {
+		return {};
+	}
+
+	if (/\s/.test(normalizedImage)) {
+		throw new Error('Could not parse image reference');
+	}
+
+	const digestParts = normalizedImage.split('@');
+
+	if (digestParts.length > 2) {
+		throw new Error('Could not parse image reference');
+	}
+
+	const withoutDigest = digestParts[0] ?? normalizedImage;
+	const digest = digestParts[1];
+
+	if (digest !== undefined) {
+		const [algorithm, value, ...rest] = digest.split(':');
+
+		if (!algorithm || !value || rest.length > 0) {
+			throw new Error('Could not parse image digest');
+		}
+	}
+
 	const lastColonIndex = withoutDigest.lastIndexOf(':');
 	const lastSlashIndex = withoutDigest.lastIndexOf('/');
 	const hasTag = lastColonIndex > lastSlashIndex;
 	const imagePath = hasTag ? withoutDigest.slice(0, lastColonIndex) : withoutDigest;
 	const tag = hasTag ? withoutDigest.slice(lastColonIndex + 1) : undefined;
-	const digest = image.includes('@') ? image.split('@')[1] : undefined;
+
+	if (hasTag && tag === '') {
+		throw new Error('Could not parse image tag');
+	}
+
 	const name = imagePath.split('/').pop();
 	const registry = imagePath.split('/')[0] ?? '';
 	const repository = imagePath.split('/').slice(1, -1).join('/');
-	if (name === undefined) {
+
+	if (name === undefined || name === '') {
 		throw new Error('Could not parse image name');
 	}
+
 	return { registry, repository, name, tag, digest };
 };
 

--- a/src/lib/utils/image.ts
+++ b/src/lib/utils/image.ts
@@ -69,6 +69,48 @@ export const formatImageRef = (image: {
 	return ref;
 };
 
+export const formatImageVersion = (image: { tag?: string | null; digest?: string | null }) => {
+	if (image.tag && image.digest) {
+		return `${image.tag}@${image.digest}`;
+	}
+
+	return image.tag || image.digest || '-';
+};
+
+export const imageRefMatches = (
+	imageRef: string,
+	image: {
+		name: string;
+		tag?: string | null;
+		digest?: string | null;
+	}
+) => {
+	if (imageRef === formatImageRef(image)) {
+		return true;
+	}
+
+	try {
+		const parsed = parseImage(imageRef);
+		const parsedName = [parsed.registry, parsed.repository, parsed.name].filter(Boolean).join('/');
+
+		if (parsedName !== image.name) {
+			return false;
+		}
+
+		if (parsed.digest && parsed.digest !== image.digest) {
+			return false;
+		}
+
+		if (parsed.tag && parsed.tag !== image.tag) {
+			return false;
+		}
+
+		return Boolean(parsed.tag || parsed.digest) || (!image.tag && !image.digest);
+	} catch {
+		return false;
+	}
+};
+
 export const getImageDisplayName = (name: string): string => {
 	return name.split('/').slice(2).join('/');
 };

--- a/src/routes/team/[team]/[env]/app/[app]/InstanceGroups.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/InstanceGroups.gql
@@ -8,6 +8,7 @@ query AppInstanceGroups($app: String!, $team: Slug!, $env: String!) {
 					image {
 						name
 						tag
+						digest
 					}
 					created
 					readyInstances

--- a/src/routes/team/[team]/[env]/app/[app]/InstanceGroups.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/InstanceGroups.svelte
@@ -63,7 +63,10 @@
 					>{group.readyInstances}/{group.desiredInstances} running</span
 				>
 				<span class="instance-group-meta">
-					{group.image.tag} &middot; Updated <Time time={group.created} distance />
+					{group.image.tag || group.image.digest || '-'} &middot; Updated <Time
+						time={group.created}
+						distance
+					/>
 				</span>
 			</div>
 			<div class="instance-group-tags">

--- a/src/routes/team/[team]/[env]/app/[app]/InstanceGroups.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/InstanceGroups.svelte
@@ -5,6 +5,7 @@
 	import RunningIndicator from '$lib/ui/RunningIndicator.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import Time from '$lib/ui/Time.svelte';
+	import { formatImageVersion } from '$lib/utils/image';
 	import { Tag } from '@nais/ds-svelte-community';
 	import { CloudSlashIcon } from '@nais/ds-svelte-community/icons';
 	import { slide } from 'svelte/transition';
@@ -63,10 +64,7 @@
 					>{group.readyInstances}/{group.desiredInstances} running</span
 				>
 				<span class="instance-group-meta">
-					{group.image.tag || group.image.digest || '-'} &middot; Updated <Time
-						time={group.created}
-						distance
-					/>
+					{formatImageVersion(group.image)} &middot; Updated <Time time={group.created} distance />
 				</span>
 			</div>
 			<div class="instance-group-tags">

--- a/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
@@ -4,7 +4,7 @@
 	import { page } from '$app/state';
 	import { isPossiblyInModal } from '$lib/ui/PageModal.svelte';
 	import Time from '$lib/ui/Time.svelte';
-	import { parseImage } from '$lib/utils/image';
+	import { formatImageRef, parseImage } from '$lib/utils/image';
 	import {
 		Alert,
 		BodyLong,
@@ -21,9 +21,7 @@
 	const { SetImageVersionData } = $derived(data);
 	const application = $derived($SetImageVersionData.data?.team?.environment?.application ?? null);
 
-	const currentImage = $derived(
-		application?.image ? `${application.image.name}:${application.image.tag}` : null
-	);
+	const currentImage = $derived(application?.image ? formatImageRef(application.image) : null);
 
 	const releases = $derived(
 		[...(application?.history ?? [])].sort(
@@ -39,7 +37,8 @@
 	let closeButtonEl: HTMLButtonElement | undefined = $state();
 
 	function tagFor(image: string): string {
-		return parseImage(image).tag ?? image;
+		const parsed = parseImage(image);
+		return parsed.tag ?? parsed.digest ?? image;
 	}
 
 	const close = async () => {

--- a/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
@@ -36,7 +36,7 @@
 	let success = $state(false);
 	let closeButtonEl: HTMLButtonElement | undefined = $state();
 
-	function tagFor(image: string): string {
+	function imageVersionLabelFor(image: string): string {
 		const parsed = parseImage(image);
 		return parsed.tag ?? parsed.digest ?? image;
 	}
@@ -52,8 +52,8 @@
 {#if success}
 	<div class="wrapper" role="status" aria-live="polite" aria-atomic="true">
 		<Alert variant="success" size="small">
-			Successfully set image version to <code>{tagFor(selected)}</code>. Restarting application to
-			apply the change.
+			Successfully set image version to <code>{imageVersionLabelFor(selected)}</code>. Restarting
+			application to apply the change.
 		</Alert>
 		<Button variant="tertiary" size="small" onclick={close} bind:ref={closeButtonEl}>Close</Button>
 	</div>
@@ -91,7 +91,7 @@
 					{@const isCurrent = release.image === currentImage}
 					<Radio value={release.image}>
 						<span class="release-label">
-							<code class="release-tag">{tagFor(release.image)}</code>
+							<code class="release-tag">{imageVersionLabelFor(release.image)}</code>
 							{#if isCurrent}<span class="release-current">(current)</span>{/if}
 							<span class="release-time">
 								deployed <Time time={release.deployedAt} distance />

--- a/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
@@ -4,7 +4,7 @@
 	import { page } from '$app/state';
 	import { isPossiblyInModal } from '$lib/ui/PageModal.svelte';
 	import Time from '$lib/ui/Time.svelte';
-	import { formatImageRef, parseImage } from '$lib/utils/image';
+	import { formatImageVersion, imageRefMatches, parseImage } from '$lib/utils/image';
 	import {
 		Alert,
 		BodyLong,
@@ -21,13 +21,25 @@
 	const { SetImageVersionData } = $derived(data);
 	const application = $derived($SetImageVersionData.data?.team?.environment?.application ?? null);
 
-	const currentImage = $derived(application?.image ? formatImageRef(application.image) : null);
-
 	const releases = $derived(
 		[...(application?.history ?? [])].sort(
 			(a, b) => b.deployedAt.getTime() - a.deployedAt.getTime()
 		)
 	);
+
+	const currentReleaseKey = $derived.by(() => {
+		if (!application?.image) {
+			return null;
+		}
+
+		const currentRelease = releases.find((release) =>
+			imageRefMatches(release.image, application.image)
+		);
+
+		return currentRelease
+			? `${currentRelease.image}|${currentRelease.deployedAt.toISOString()}`
+			: null;
+	});
 
 	const form = $derived(page.form);
 
@@ -39,7 +51,7 @@
 	function imageVersionLabelFor(image: string): string {
 		try {
 			const parsed = parseImage(image);
-			return parsed.tag ?? parsed.digest ?? image;
+			return formatImageVersion(parsed);
 		} catch {
 			return image;
 		}
@@ -92,7 +104,8 @@
 		{:else}
 			<RadioGroup legend="Releases" size="small" name="image" bind:value={selected}>
 				{#each releases as release (release.image + release.deployedAt.toISOString())}
-					{@const isCurrent = release.image === currentImage}
+					{@const releaseKey = `${release.image}|${release.deployedAt.toISOString()}`}
+					{@const isCurrent = releaseKey === currentReleaseKey}
 					<Radio value={release.image}>
 						<span class="release-label">
 							<code class="release-tag">{imageVersionLabelFor(release.image)}</code>

--- a/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/image/+page.svelte
@@ -37,8 +37,12 @@
 	let closeButtonEl: HTMLButtonElement | undefined = $state();
 
 	function imageVersionLabelFor(image: string): string {
-		const parsed = parseImage(image);
-		return parsed.tag ?? parsed.digest ?? image;
+		try {
+			const parsed = parseImage(image);
+			return parsed.tag ?? parsed.digest ?? image;
+		} catch {
+			return image;
+		}
 	}
 
 	const close = async () => {

--- a/src/routes/team/[team]/[env]/app/[app]/image/query.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/image/query.gql
@@ -5,6 +5,7 @@ query SetImageVersionData($team: Slug!, $env: String!, $app: String!) {
 				image {
 					name
 					tag
+					digest
 				}
 				history {
 					image

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/+page.svelte
@@ -8,6 +8,7 @@
 	import List from '$lib/ui/List.svelte';
 	import SurfaceCard from '$lib/ui/SurfaceCard.svelte';
 	import Time from '$lib/ui/Time.svelte';
+	import { formatImageRef } from '$lib/utils/image';
 	import {
 		Alert,
 		CopyButton,
@@ -386,12 +387,8 @@
 					<div class="image-line">
 						<Heading as="h3" size="xsmall">Image</Heading>
 						<div class="image-url">
-							<code>{group.image.name}:{group.image.tag}</code>
-							<CopyButton
-								copyText={`${group.image.name}:${group.image.tag}`}
-								size="xsmall"
-								variant="action"
-							/>
+							<code>{formatImageRef(group.image)}</code>
+							<CopyButton copyText={formatImageRef(group.image)} size="xsmall" variant="action" />
 						</div>
 					</div>
 				</section>

--- a/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/query.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/instancegroup/[instancegroup]/query.gql
@@ -56,6 +56,7 @@ query InstanceGroupDetail($app: String!, $team: Slug!, $env: String!) @cache(pol
 					image {
 						name
 						tag
+						digest
 					}
 					created
 					readyInstances

--- a/src/routes/team/[team]/[env]/app/[app]/vulnerabilities/query.gql
+++ b/src/routes/team/[team]/[env]/app/[app]/vulnerabilities/query.gql
@@ -22,6 +22,7 @@ query ApplicationImageDetails($team: Slug!, $env: String!, $app: String!)
 					id
 					name
 					tag
+					digest
 					sbom {
 						status
 						processingStartedAt

--- a/src/routes/team/[team]/[env]/job/[job]/vulnerabilities/query.gql
+++ b/src/routes/team/[team]/[env]/job/[job]/vulnerabilities/query.gql
@@ -20,6 +20,7 @@ query JobImageDetails($team: Slug!, $env: String!, $job: String!) @cache(policy:
 					id
 					name
 					tag
+					digest
 					sbom {
 						status
 						processingStartedAt

--- a/src/routes/team/[team]/vulnerabilities/[cve]/+page.svelte
+++ b/src/routes/team/[team]/vulnerabilities/[cve]/+page.svelte
@@ -7,6 +7,7 @@
 	import WorkloadLink from '$lib/domain/workload/WorkloadLink.svelte';
 	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
+	import { formatImageRef } from '$lib/utils/image';
 
 	import { suppressionStateLabels } from '$lib/utils/vulnerabilities';
 	import {
@@ -388,10 +389,7 @@
 												<div>
 													<Detail as="dt">Image</Detail>
 													<Detail as="dd"
-														><code
-															>{group.nodes[0].workload.image.name}:{group.nodes[0].workload.image
-																.tag}</code
-														></Detail
+														><code>{formatImageRef(group.nodes[0].workload.image)}</code></Detail
 													>
 												</div>
 											{/if}

--- a/src/routes/team/[team]/vulnerabilities/[cve]/+page.svelte
+++ b/src/routes/team/[team]/vulnerabilities/[cve]/+page.svelte
@@ -73,6 +73,7 @@
 								image {
 									name
 									tag
+									digest
 								}
 							}
 							vulnerability {

--- a/src/routes/vulnerabilities/[cve]/+page.svelte
+++ b/src/routes/vulnerabilities/[cve]/+page.svelte
@@ -6,6 +6,7 @@
 	import List from '$lib/ui/List.svelte';
 	import ListItem from '$lib/ui/ListItem.svelte';
 	import Pagination from '$lib/ui/Pagination.svelte';
+	import { formatImageRef } from '$lib/utils/image';
 	import { changeParams } from '$lib/utils/searchparams';
 	import { suppressionStateLabels } from '$lib/utils/vulnerabilities';
 	import {
@@ -151,7 +152,7 @@
 												<Detail as="dt">Image</Detail>
 												{#if workload.image}
 													<BodyShort as="dd">
-														<code>{workload.image.name}:{workload.image.tag}</code>
+														<code>{formatImageRef(workload.image)}</code>
 													</BodyShort>
 												{:else}
 													<BodyShort as="dd">-</BodyShort>

--- a/src/routes/vulnerabilities/[cve]/workloads.gql
+++ b/src/routes/vulnerabilities/[cve]/workloads.gql
@@ -27,6 +27,7 @@ query CVEWorkloads($identifier: String!, $first: Int, $last: Int, $after: Cursor
 					image {
 						name
 						tag
+						digest
 					}
 				}
 				vulnerability {


### PR DESCRIPTION
## Summary
- add support for `image.digest` in relevant GraphQL queries
- use `image.digest` instead of inferring digest from `image.tag`
- format full image refs as `name[:tag][@digest]`
- handle digest-only images in UI

## Verification
- `pnpm exec houdini generate`
- `pnpm exec prettier --check` on changed files