### PR TITLE
fix: tighten workload image card prop contract

### DIFF
--- a/src/lib/domain/vulnerability/WorkloadVulnerabilitiesPage.svelte
+++ b/src/lib/domain/vulnerability/WorkloadVulnerabilitiesPage.svelte
@@ -61,23 +61,23 @@
 			<SurfaceCard title="Summary" bordered level="h3">
 				<WorkloadVulnerabilitySummary {workload} />
 			</SurfaceCard>
-		{/if}
 
-		<WorkloadImageCard
-			imageName={workload?.image.name}
-			tag={workload?.image.tag}
-			digest={workload?.image.digest}
-		>
-			{#if !hasVulnerabilityData && !isProcessing}
-				<BodyShort size="small" spacing>
-					<WarningIcon class="text-aligned-icon" /> No vulnerability data available. Learn how to generate
-					SBOMs and attestations for your workloads in the
-					<ExternalLink href={docURL('/services/vulnerabilities/how-to/sbom/')}>
-						Nais documentation
-					</ExternalLink>.
-				</BodyShort>
-			{/if}
-		</WorkloadImageCard>
+			<WorkloadImageCard
+				imageName={workload.image.name}
+				tag={workload.image.tag}
+				digest={workload.image.digest}
+			>
+				{#if !hasVulnerabilityData && !isProcessing}
+					<BodyShort size="small" spacing>
+						<WarningIcon class="text-aligned-icon" /> No vulnerability data available. Learn how to generate
+						SBOMs and attestations for your workloads in the
+						<ExternalLink href={docURL('/services/vulnerabilities/how-to/sbom/')}>
+							Nais documentation
+						</ExternalLink>.
+					</BodyShort>
+				{/if}
+			</WorkloadImageCard>
+		{/if}
 	</div>
 
 	{#if hasVulnerabilityData && workload?.image.sbom.status === 'READY'}

--- a/src/lib/domain/workload/WorkloadImageCard.svelte
+++ b/src/lib/domain/workload/WorkloadImageCard.svelte
@@ -5,7 +5,7 @@
 	import type { Snippet } from 'svelte';
 
 	interface Props {
-		imageName?: string;
+		imageName: string;
 		tag?: string;
 		digest?: string | null;
 		title?: string;


### PR DESCRIPTION
## Summary

- make `WorkloadImageCard.imageName` required to match the GraphQL contract
- move the `WorkloadImageCard` render under the existing `workload` guard in `WorkloadVulnerabilitiesPage`
- keep the defensive parsing fallback in the card for malformed refs

## Verification

- `pnpm run check`
