### PR TITLE
Reintroduce clickable ingresses with ExternalLink component

### DIFF
--- a/src/routes/team/[team]/[env]/app/[app]/network/+page.svelte
+++ b/src/routes/team/[team]/[env]/app/[app]/network/+page.svelte
@@ -5,16 +5,11 @@
 	import NetworkPolicy from '$lib/domain/resources/NetworkPolicy.svelte';
 	import WarningIcon from '$lib/icons/WarningIcon.svelte';
 	import DocsLink from '$lib/ui/DocsLink.svelte';
+	import ExternalLink from '$lib/ui/ExternalLink.svelte';
 	import GraphErrors from '$lib/ui/GraphErrors.svelte';
 	import TooltipAlignHack from '$lib/ui/TooltipAlignHack.svelte';
 	import { changeParams } from '$lib/utils/searchparams';
-	import {
-		CopyButton,
-		Detail,
-		Heading,
-		ToggleGroup,
-		ToggleGroupItem
-	} from '@nais/ds-svelte-community';
+	import { Detail, Heading, ToggleGroup, ToggleGroupItem } from '@nais/ds-svelte-community';
 	import { GlobeIcon, HouseIcon, PadlockLockedIcon } from '@nais/ds-svelte-community/icons';
 	import type { PageProps } from './$types';
 
@@ -80,8 +75,9 @@
 									{/if}
 								</TooltipAlignHack>
 							</span>
-							<code class="ingress-url">{ingress.url}</code>
-							<CopyButton copyText={ingress.url} size="xsmall" variant="action" />
+							<ExternalLink href={ingress.url}>
+								{ingress.url}
+							</ExternalLink>
 						</li>
 					{/each}
 				</ul>
@@ -181,13 +177,6 @@
 	.ingress-icon {
 		display: flex;
 		align-items: center;
-	}
-
-	.ingress-url {
-		font-family: monospace;
-		font-size: var(--ax-font-size-small);
-		color: var(--ax-text-neutral);
-		word-break: break-all;
 	}
 
 	.empty-state {


### PR DESCRIPTION
This pull request updates the display of ingress URLs in the app network page to improve usability and accessibility. The main change replaces the plain text display and copy button with a clickable external link, and removes related unused code and styles.

**UI improvements:**

* Replaced the plain text display of ingress URLs and the `CopyButton` with an `ExternalLink` component, making URLs clickable and opening them in a new tab. ([src/routes/team/[team]/[env]/app/[app]/network/+page.svelteL83-R80](diffhunk://#diff-97c842f26269ed732f56a2d2d77a22ecba804afe941cbc4d1914392a1258cbfbL83-R80))
* Removed the custom `.ingress-url` CSS styles since the URLs are no longer rendered as plain code blocks. ([src/routes/team/[team]/[env]/app/[app]/network/+page.svelteL186-L192](diffhunk://#diff-97c842f26269ed732f56a2d2d77a22ecba804afe941cbc4d1914392a1258cbfbL186-L192))

**Code cleanup:**

* Removed the unused `CopyButton` import from `@nais/ds-svelte-community` and added the `ExternalLink` import. ([src/routes/team/[team]/[env]/app/[app]/network/+page.svelteR8-R12](diffhunk://#diff-97c842f26269ed732f56a2d2d77a22ecba804afe941cbc4d1914392a1258cbfbR8-R12))